### PR TITLE
Add integration test project

### DIFF
--- a/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
+++ b/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services;
+using PhotoBank.Services.Api;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.IntegrationTests;
+
+[TestFixture]
+public class GetAllPhotosIntegrationTests
+{
+    private ServiceProvider _provider = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<PhotoBankDbContext>(options =>
+            options.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        RegisterServicesForApi.Configure(services);
+        services.AddAutoMapper(typeof(MappingProfile));
+        _provider = services.BuildServiceProvider();
+
+        using var scope = _provider.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<PhotoBankDbContext>();
+        context.Database.EnsureDeleted();
+        context.Database.EnsureCreated();
+        SeedData(context);
+    }
+
+    private static void SeedData(PhotoBankDbContext context)
+    {
+        var storage = new Storage { Name = "s", Folder = "f" };
+        var tag1 = new Tag { Name = "tag1" };
+        var tag2 = new Tag { Name = "tag2" };
+        context.AddRange(storage, tag1, tag2);
+        context.SaveChanges();
+
+        var photo1 = new Photo
+        {
+            Name = "p1",
+            StorageId = storage.Id,
+            IsBW = true,
+            Thumbnail = new byte[] {1},
+            RelativePath = "r1",
+            PhotoTags = new List<PhotoTag>{ new() { TagId = tag1.Id } }
+        };
+        var photo2 = new Photo
+        {
+            Name = "p2",
+            StorageId = storage.Id,
+            IsBW = false,
+            Thumbnail = new byte[] {1},
+            RelativePath = "r2",
+            PhotoTags = new List<PhotoTag>{ new() { TagId = tag2.Id } }
+        };
+        context.AddRange(photo1, photo2);
+        context.SaveChanges();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _provider.Dispose();
+    }
+
+    [Test]
+    public async Task GetAllPhotosAsync_NoFilter_ReturnsAll()
+    {
+        var service = _provider.GetRequiredService<IPhotoService>();
+        var result = await service.GetAllPhotosAsync(new FilterDto());
+        result.Count.Should().Be(2);
+        result.Photos.Should().HaveCount(2);
+    }
+
+    [Test]
+    public async Task GetAllPhotosAsync_FilterByIsBW_ReturnsOnlyBW()
+    {
+        var service = _provider.GetRequiredService<IPhotoService>();
+        var result = await service.GetAllPhotosAsync(new FilterDto { IsBW = true });
+        result.Count.Should().Be(1);
+        result.Photos!.Single().Name.Should().Be("p1");
+    }
+
+    [Test]
+    public async Task GetAllPhotosAsync_FilterByTag_ReturnsMatchingPhoto()
+    {
+        var service = _provider.GetRequiredService<IPhotoService>();
+        var result = await service.GetAllPhotosAsync(new FilterDto { Tags = new[] {1} });
+        result.Count.Should().Be(1);
+        result.Photos!.Single().Name.Should().Be("p1");
+    }
+}

--- a/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj
+++ b/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Platforms>AnyCPU;x64</Platforms>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="nunit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PhotoBank.DbContext\PhotoBank.DbContext.csproj" />
+    <ProjectReference Include="..\PhotoBank.Repositories\PhotoBank.Repositories.csproj" />
+    <ProjectReference Include="..\PhotoBank.Services\PhotoBank.Services.csproj" />
+  </ItemGroup>
+</Project>

--- a/PhotoBank.sln
+++ b/PhotoBank.sln
@@ -13,6 +13,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.Services", "Photo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.UnitTests", "PhotoBank.UnitTests\PhotoBank.UnitTests.csproj", "{8D6228B3-00A6-4D7F-97F8-80BA25278155}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.IntegrationTests", "PhotoBank.IntegrationTests\PhotoBank.IntegrationTests.csproj", "{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.ServerBlazorApp", "Photobank.ServerBlazorApp\PhotoBank.ServerBlazorApp.csproj", "{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.MAUI.Blazor", "PhotoBank.MAUI.Blazor\PhotoBank.MAUI.Blazor.csproj", "{43902204-0212-4585-A506-C909520D3AEA}"
@@ -69,9 +71,17 @@ Global
 		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Debug|x64.Build.0 = Debug|x64
 		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|x64.ActiveCfg = Release|x64
-		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|x64.Build.0 = Release|x64
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|x64.ActiveCfg = Release|x64
+                {8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|x64.Build.0 = Release|x64
+                {CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Debug|x64.ActiveCfg = Debug|x64
+                {CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Debug|x64.Build.0 = Debug|x64
+                {CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|x64.ActiveCfg = Release|x64
+                {CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|x64.Build.0 = Release|x64
+                {A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|x64.Build.0 = Debug|Any CPU


### PR DESCRIPTION
## Summary
- move integration tests into new `PhotoBank.IntegrationTests` project
- remove EF Core InMemory dependency from unit tests
- add integration project to the solution

## Testing
- `dotnet test PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj -c Release` *(fails: current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj -c Release` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6862971ab3288328b68cf7e185fcf69c