### PR TITLE
Add Identity auth to API

### DIFF
--- a/PhotoBank.Api/Controllers/PathsController.cs
+++ b/PhotoBank.Api/Controllers/PathsController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
 
@@ -6,6 +7,7 @@ namespace PhotoBank.Api.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
+[Authorize]
 public class PathsController(IPhotoService photoService) : ControllerBase
 {
     [HttpGet]

--- a/PhotoBank.Api/Controllers/PersonsController.cs
+++ b/PhotoBank.Api/Controllers/PersonsController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
 
@@ -6,6 +7,7 @@ namespace PhotoBank.Api.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
+[Authorize]
 public class PersonsController(IPhotoService photoService) : ControllerBase
 {
     [HttpGet]

--- a/PhotoBank.Api/Controllers/PhotosController.cs
+++ b/PhotoBank.Api/Controllers/PhotosController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
@@ -7,6 +8,7 @@ using System.Diagnostics.Metrics;
 namespace PhotoBank.Api.Controllers
 {
     [Route("api/[controller]")]
+    [Authorize]
     [ApiController]
     public class PhotosController(ILogger<PhotosController> logger, IPhotoService photoService)
         : ControllerBase

--- a/PhotoBank.Api/Controllers/StoragesController.cs
+++ b/PhotoBank.Api/Controllers/StoragesController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
 
@@ -6,6 +7,7 @@ namespace PhotoBank.Api.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
+[Authorize]
 public class StoragesController(IPhotoService photoService) : ControllerBase
 {
     [HttpGet]

--- a/PhotoBank.Api/Controllers/TagsController.cs
+++ b/PhotoBank.Api/Controllers/TagsController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
 
@@ -6,6 +7,7 @@ namespace PhotoBank.Api.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
+[Authorize]
 public class TagsController(IPhotoService photoService) : ControllerBase
 {
     [HttpGet]

--- a/PhotoBank.Api/PhotoBank.Api.csproj
+++ b/PhotoBank.Api/PhotoBank.Api.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PhotoBank.Api/Program.cs
+++ b/PhotoBank.Api/Program.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using Microsoft.AspNetCore.Identity;
 using PhotoBank.Services;
 using Serilog.Events;
 using Serilog;
@@ -47,7 +49,19 @@ namespace PhotoBank.Api
                 options.AddPolicy("AllowLocalFrontend", policy =>
                 {
                     policy
-                        .WithOrigins("http://192.168.1.45:5173") // IP фронта!
+            builder.Services.AddHttpContextAccessor();
+            builder.Services.AddDefaultIdentity<ApplicationUser>()
+                .AddRoles<IdentityRole>()
+                .AddEntityFrameworkStores<PhotoBankDbContext>();
+
+            builder.Services.AddAuthorizationBuilder()
+                .AddPolicy("AllowToSeeAdultContent", policy => {
+                    policy.RequireClaim("AllowAdultContent", "True");
+                })
+                .AddPolicy("AllowToSeeRacyContent", policy => {
+                    policy.RequireClaim("AllowRacyContent", "True");
+                });
+            app.UseAuthentication();
                         .AllowAnyMethod()
                         .AllowAnyHeader()
                         .AllowCredentials();


### PR DESCRIPTION
## Summary
- secure API endpoints with `[Authorize]`
- add Identity packages and configure default identity
- register authorization policies and `HttpContextAccessor`
- enable authentication middleware

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f8b412f8832882dd3838395e4cb4