### PR TITLE
Add vitest tests for shared utilities

### DIFF
--- a/Photobank.Ts/packages/shared/package.json
+++ b/Photobank.Ts/packages/shared/package.json
@@ -7,11 +7,15 @@
   "types": "src/index.ts",
   "devDependencies": {
     "@types/node": "^24.0.7",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "axios": "^1.10.0",
     "date-fns": "^4.1.0",
     "dotenv": "^17.0.0"
+  },
+  "scripts": {
+    "test": "vitest run"
   }
 }

--- a/Photobank.Ts/packages/shared/test/formatPhotoMessage.test.ts
+++ b/Photobank.Ts/packages/shared/test/formatPhotoMessage.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { formatPhotoMessage } from '../src/utils/formatPhotoMessage';
+import type { PhotoDto } from '../src/types';
+
+vi.mock('../src/dictionaries', () => ({
+  getPersonName: (id: number) => `Person ${id}`,
+}));
+
+describe('formatPhotoMessage', () => {
+  const basePhoto: PhotoDto = {
+    id: 1,
+    name: 'Test',
+    scale: 1,
+    previewImage: '',
+    adultScore: 0,
+    racyScore: 0,
+    height: 100,
+    width: 100,
+  };
+
+  it('includes main fields in caption', () => {
+    const { caption, image } = formatPhotoMessage({
+      ...basePhoto,
+      takenDate: '2024-01-02T00:00:00Z',
+      captions: ['hello'],
+      tags: ['tag1', 'tag2'],
+      faces: [{ id: 1, personId: 2, faceBox: { top:0, left:0, width:1, height:1 }, friendlyFaceAttributes: '' }],
+    });
+    expect(caption).toContain('📸 <b>Test</b>');
+    expect(caption).toContain('📅');
+    expect(caption).toContain('📝 hello');
+    expect(caption).toContain('🏷️ tag1, tag2');
+    expect(caption).toContain('👤 Person 2');
+    expect(image).toBeUndefined();
+  });
+
+  it('decodes preview image when provided', () => {
+    const base64 = Buffer.from('img').toString('base64');
+    const { image } = formatPhotoMessage({ ...basePhoto, previewImage: base64 });
+    expect(image).toBeInstanceOf(Buffer);
+    expect(image?.toString()).toBe('img');
+  });
+});

--- a/Photobank.Ts/packages/shared/test/index.test.ts
+++ b/Photobank.Ts/packages/shared/test/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { formatDate, getGenderText } from '../src';
+
+// FormatDate tests
+
+describe('formatDate', () => {
+  it('returns formatted date for valid ISO string', () => {
+    const result = formatDate('2024-01-02T03:04:05Z');
+    expect(result).toBe('02.01.2024, 03:04');
+  });
+
+  it('returns fallback for undefined input', () => {
+    expect(formatDate()).toBe('не указана дата');
+  });
+
+  it('returns fallback for invalid input', () => {
+    expect(formatDate('not-a-date')).toBe('неверный формат даты');
+  });
+});
+
+describe('getGenderText', () => {
+  it('returns text for male', () => {
+    expect(getGenderText(true)).toBe('Муж');
+  });
+
+  it('returns text for female', () => {
+    expect(getGenderText(false)).toBe('Жен');
+  });
+
+  it('returns fallback for undefined', () => {
+    expect(getGenderText(undefined)).toBe('не указан пол');
+  });
+});

--- a/Photobank.Ts/packages/shared/vitest.config.ts
+++ b/Photobank.Ts/packages/shared/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@photobank/shared': path.resolve(__dirname, './src'),
+      '@photobank/shared/': path.resolve(__dirname, './src/')
+    }
+  },
+  test: {
+    environment: 'node'
+  }
+})

--- a/Photobank.Ts/pnpm-lock.yaml
+++ b/Photobank.Ts/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.0.7)(@vitest/ui@3.2.4)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.20.3)
 
   packages/telegram-bot:
     dependencies:


### PR DESCRIPTION
## Summary
- add vitest dev dependency and test script to @photobank/shared
- configure vitest aliases
- add tests for shared format helpers
- add tests for formatPhotoMessage utility

## Testing
- `pnpm --filter shared test`

------
https://chatgpt.com/codex/tasks/task_e_6864ce47abfc8328b3b4d167ed76014d