### PR TITLE
Add unit tests for shared package

### DIFF
--- a/Photobank.Ts/packages/shared/test/api.test.ts
+++ b/Photobank.Ts/packages/shared/test/api.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('api helpers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('searchPhotos posts filter', async () => {
+    const postMock = vi.fn().mockResolvedValue({ data: { count: 1 } });
+    vi.doMock('../src/api/client', () => ({ apiClient: { post: postMock } }));
+    const { searchPhotos } = await import('../src/api/photos');
+    const res = await searchPhotos({ thisDay: true } as any);
+    expect(postMock).toHaveBeenCalledWith('/photos/search', { thisDay: true });
+    expect(res).toEqual({ count: 1 });
+  });
+
+  it('getPhotoById requests by id', async () => {
+    const getMock = vi.fn().mockResolvedValue({ data: { id: 5 } });
+    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const { getPhotoById } = await import('../src/api/photos');
+    const res = await getPhotoById(5);
+    expect(getMock).toHaveBeenCalledWith('/photos/5');
+    expect(res).toEqual({ id: 5 });
+  });
+
+  it('getAllPersons fetches persons', async () => {
+    const getMock = vi.fn().mockResolvedValue({ data: [{ id: 1 }] });
+    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const { getAllPersons } = await import('../src/api/persons');
+    const res = await getAllPersons();
+    expect(getMock).toHaveBeenCalledWith('/persons');
+    expect(res).toEqual([{ id: 1 }]);
+  });
+
+  it('getAllPaths fetches paths', async () => {
+    const getMock = vi.fn().mockResolvedValue({ data: [{ storageId: 1 }] });
+    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const { getAllPaths } = await import('../src/api/paths');
+    const res = await getAllPaths();
+    expect(getMock).toHaveBeenCalledWith('/paths');
+    expect(res).toEqual([{ storageId: 1 }]);
+  });
+
+  it('getAllStorages fetches storages', async () => {
+    const getMock = vi.fn().mockResolvedValue({ data: [{ id: 2 }] });
+    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const { getAllStorages } = await import('../src/api/storages');
+    const res = await getAllStorages();
+    expect(getMock).toHaveBeenCalledWith('/storages');
+    expect(res).toEqual([{ id: 2 }]);
+  });
+
+  it('getAllTags fetches tags', async () => {
+    const getMock = vi.fn().mockResolvedValue({ data: [{ id: 3 }] });
+    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const { getAllTags } = await import('../src/api/tags');
+    const res = await getAllTags();
+    expect(getMock).toHaveBeenCalledWith('/tags');
+    expect(res).toEqual([{ id: 3 }]);
+  });
+});

--- a/Photobank.Ts/packages/shared/test/auth.test.ts
+++ b/Photobank.Ts/packages/shared/test/auth.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// helper to create a minimal localStorage mock
+const createStorage = (initial: Record<string, string> = {}) => {
+  const store: Record<string, string | undefined> = { ...initial };
+  return {
+    getItem: (k: string) => (k in store ? store[k]! : null),
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+  };
+};
+
+describe('auth utilities', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // ensure a clean global
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (global as any).window;
+    // @ts-ignore
+    delete (global as any).localStorage;
+  });
+
+  it('sets and gets token without browser', async () => {
+    const auth = await import('../src/api/auth');
+    auth.setAuthToken('abc');
+    expect(auth.getAuthToken()).toBe('abc');
+  });
+
+  it('persists token to localStorage in browser', async () => {
+    // @ts-ignore
+    const storage = createStorage();
+    // @ts-ignore
+    global.window = { localStorage: storage };
+    // @ts-ignore
+    global.localStorage = storage;
+    const auth = await import('../src/api/auth');
+    auth.setAuthToken('token');
+    expect(auth.getAuthToken()).toBe('token');
+    expect(global.window.localStorage.getItem('photobank_token')).toBe('token');
+  });
+
+  it('clears token and storage', async () => {
+    // @ts-ignore
+    const storage = createStorage();
+    // @ts-ignore
+    global.window = { localStorage: storage };
+    // @ts-ignore
+    global.localStorage = storage;
+    const auth = await import('../src/api/auth');
+    auth.setAuthToken('tok');
+    auth.clearAuthToken();
+    expect(auth.getAuthToken()).toBeNull();
+    expect(global.window.localStorage.getItem('photobank_token')).toBeNull();
+  });
+
+  it('loads token from storage on import', async () => {
+    // @ts-ignore
+    const storage = createStorage({ photobank_token: 'init' });
+    // @ts-ignore
+    global.window = { localStorage: storage };
+    // @ts-ignore
+    global.localStorage = storage;
+    const auth = await import('../src/api/auth');
+    expect(auth.getAuthToken()).toBe('init');
+  });
+
+  it('login posts credentials and saves token', async () => {
+    const postMock = vi.fn().mockResolvedValue({ data: { token: 'res' } });
+    vi.doMock('../src/api/client', () => ({ apiClient: { post: postMock } }));
+    const auth = await import('../src/api/auth');
+    const result = await auth.login({ email: 'e', password: 'p' });
+    expect(postMock).toHaveBeenCalledWith('/auth/login', { email: 'e', password: 'p' });
+    expect(result).toEqual({ token: 'res' });
+    expect(auth.getAuthToken()).toBe('res');
+  });
+});

--- a/Photobank.Ts/packages/shared/test/dictionaries.test.ts
+++ b/Photobank.Ts/packages/shared/test/dictionaries.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('dictionaries', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('getPersonName returns loaded name', async () => {
+    const getAllPersons = vi.fn().mockResolvedValue([{ id: 1, name: 'John' }]);
+    vi.doMock('../src/api', () => ({ getAllPersons }));
+    const dict = await import('../src/dictionaries');
+    await dict.loadDictionaries();
+    expect(dict.getPersonName(1)).toBe('John');
+  });
+
+  it('getPersonName falls back to id', async () => {
+    const dict = await import('../src/dictionaries');
+    expect(dict.getPersonName(99)).toBe('ID 99');
+  });
+
+  it('getTagName and getStorageName fall back', async () => {
+    const dict = await import('../src/dictionaries');
+    expect(dict.getTagName(5)).toBe('#5');
+    expect(dict.getStorageName(7)).toBe('ID 7');
+  });
+});


### PR DESCRIPTION
## Summary
- extend vitest coverage with new tests for auth utilities
- add tests for API helper functions
- add tests for dictionary helpers

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6864d3abfdb883289464fd15e00dd057