### PR TITLE
Configure Swagger with JWT

### DIFF
--- a/PhotoBank.Api/Program.cs
+++ b/PhotoBank.Api/Program.cs
@@ -7,6 +7,7 @@ using PhotoBank.Services;
 using PhotoBank.Api.Middleware;
 using Serilog.Events;
 using Serilog;
+using Microsoft.OpenApi.Models;
 
 namespace PhotoBank.Api
 {
@@ -93,7 +94,33 @@ namespace PhotoBank.Api
             builder.Services.AddControllers();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
+            builder.Services.AddSwaggerGen(options =>
+            {
+                options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+                {
+                    Name = "Authorization",
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "bearer",
+                    BearerFormat = "JWT",
+                    In = ParameterLocation.Header,
+                    Description = "Enter JWT token"
+                });
+
+                options.AddSecurityRequirement(new OpenApiSecurityRequirement
+                {
+                    {
+                        new OpenApiSecurityScheme
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.SecurityScheme,
+                                Id = "Bearer"
+                            }
+                        },
+                        Array.Empty<string>()
+                    }
+                });
+            });
 
             RegisterServicesForApi.Configure(builder.Services);
             builder.Services.AddAutoMapper(typeof(MappingProfile));


### PR DESCRIPTION
## Summary
- enable JWT security for Swagger

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686572e8d720832899a1412a6fa65c9d