### PR TITLE
Add basic auth API

### DIFF
--- a/PhotoBank.Api/Controllers/AuthController.cs
+++ b/PhotoBank.Api/Controllers/AuthController.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Api;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Api.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class AuthController(
+    UserManager<ApplicationUser> userManager,
+    SignInManager<ApplicationUser> signInManager,
+    ITokenService tokenService) : ControllerBase
+{
+    [HttpPost("login")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(LoginResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Login([FromBody] LoginRequestDto request)
+    {
+        var result = await signInManager.PasswordSignInAsync(request.Email, request.Password, false, false);
+        if (!result.Succeeded)
+            return BadRequest();
+
+        var user = await userManager.FindByEmailAsync(request.Email);
+        if (user == null)
+            return BadRequest();
+
+        var token = tokenService.CreateToken(user);
+        return Ok(new LoginResponseDto { Token = token });
+    }
+
+    [HttpPost("register")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Register([FromBody] RegisterRequestDto request)
+    {
+        var user = new ApplicationUser { UserName = request.Email, Email = request.Email };
+        var result = await userManager.CreateAsync(user, request.Password);
+        if (!result.Succeeded)
+            return BadRequest(result.Errors);
+
+        return Ok();
+    }
+
+    [HttpGet("user")]
+    [Authorize]
+    [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetUser()
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user == null)
+            return NotFound();
+
+        return Ok(new UserDto
+        {
+            Email = user.Email ?? string.Empty,
+            PhoneNumber = user.PhoneNumber,
+            Telegram = user.Telegram
+        });
+    }
+
+    [HttpPut("user")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> UpdateUser([FromBody] UpdateUserDto dto)
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user == null)
+            return NotFound();
+
+        user.PhoneNumber = dto.PhoneNumber;
+        user.Telegram = dto.Telegram;
+        var result = await userManager.UpdateAsync(user);
+        if (!result.Succeeded)
+            return BadRequest(result.Errors);
+
+        return Ok();
+    }
+}
+

--- a/PhotoBank.Api/PhotoBank.Api.csproj
+++ b/PhotoBank.Api/PhotoBank.Api.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PhotoBank.Api/Program.cs
+++ b/PhotoBank.Api/Program.cs
@@ -5,6 +5,9 @@ using PhotoBank.DbContext.Models;
 using Microsoft.AspNetCore.Identity;
 using PhotoBank.Services;
 using PhotoBank.Api.Middleware;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 using Serilog.Events;
 using Serilog;
 using Microsoft.OpenApi.Models;
@@ -78,6 +81,25 @@ namespace PhotoBank.Api
             builder.Services.AddDefaultIdentity<ApplicationUser>()
                 .AddRoles<IdentityRole>()
                 .AddEntityFrameworkStores<PhotoBankDbContext>();
+
+            var jwtSection = configuration.GetSection("Jwt");
+            builder.Services.AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+            }).AddJwtBearer(options =>
+            {
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidIssuer = jwtSection["Issuer"],
+                    ValidAudience = jwtSection["Audience"],
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSection["Key"]!))
+                };
+            });
 
             builder.Services.AddAuthorizationBuilder()
                 .AddPolicy("AllowToSeeAdultContent", policy => {

--- a/PhotoBank.Api/appsettings.Development.json
+++ b/PhotoBank.Api/appsettings.Development.json
@@ -5,4 +5,9 @@
       "Default": "Debug"
     }
   }
+  ,"Jwt": {
+    "Key": "SuperSecretKey1234567890",
+    "Issuer": "PhotoBank.Api",
+    "Audience": "PhotoBank.Api"
+  }
 }

--- a/PhotoBank.Api/appsettings.json
+++ b/PhotoBank.Api/appsettings.json
@@ -20,6 +20,11 @@
       }
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Key": "SuperSecretKey1234567890",
+    "Issuer": "PhotoBank.Api",
+    "Audience": "PhotoBank.Api"
+  }
 }
 

--- a/PhotoBank.Services/Api/TokenService.cs
+++ b/PhotoBank.Services/Api/TokenService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using PhotoBank.DbContext.Models;
+
+namespace PhotoBank.Services.Api;
+
+public interface ITokenService
+{
+    string CreateToken(ApplicationUser user);
+}
+
+public class TokenService(IConfiguration configuration) : ITokenService
+{
+    private readonly IConfiguration _configuration = configuration;
+
+    public string CreateToken(ApplicationUser user)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id),
+            new(JwtRegisteredClaimNames.Email, user.Email ?? string.Empty),
+            new(ClaimTypes.NameIdentifier, user.Id),
+            new(ClaimTypes.Name, user.UserName ?? string.Empty)
+        };
+
+        var token = new JwtSecurityToken(
+            issuer: _configuration["Jwt:Issuer"],
+            audience: _configuration["Jwt:Audience"],
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}
+

--- a/PhotoBank.Services/PhotoBank.Services.csproj
+++ b/PhotoBank.Services/PhotoBank.Services.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PhotoBank.Services/RegisterServicesForApi.cs
+++ b/PhotoBank.Services/RegisterServicesForApi.cs
@@ -10,6 +10,7 @@ namespace PhotoBank.Services
         {
             services.AddTransient(typeof(IRepository<>), typeof(Repository<>));
             services.AddTransient<IPhotoService, PhotoService>();
+            services.AddTransient<ITokenService, TokenService>();
         }
     }
 }

--- a/PhotoBank.ViewModel.Dto/LoginRequestDto.cs
+++ b/PhotoBank.ViewModel.Dto/LoginRequestDto.cs
@@ -1,0 +1,7 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class LoginRequestDto
+{
+    public required string Email { get; set; } = string.Empty;
+    public required string Password { get; set; } = string.Empty;
+}

--- a/PhotoBank.ViewModel.Dto/LoginResponseDto.cs
+++ b/PhotoBank.ViewModel.Dto/LoginResponseDto.cs
@@ -1,0 +1,6 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class LoginResponseDto
+{
+    public required string Token { get; set; } = string.Empty;
+}

--- a/PhotoBank.ViewModel.Dto/RegisterRequestDto.cs
+++ b/PhotoBank.ViewModel.Dto/RegisterRequestDto.cs
@@ -1,0 +1,7 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class RegisterRequestDto
+{
+    public required string Email { get; set; } = string.Empty;
+    public required string Password { get; set; } = string.Empty;
+}

--- a/PhotoBank.ViewModel.Dto/UpdateUserDto.cs
+++ b/PhotoBank.ViewModel.Dto/UpdateUserDto.cs
@@ -1,0 +1,7 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class UpdateUserDto
+{
+    public string? PhoneNumber { get; set; }
+    public string? Telegram { get; set; }
+}

--- a/PhotoBank.ViewModel.Dto/UserDto.cs
+++ b/PhotoBank.ViewModel.Dto/UserDto.cs
@@ -1,0 +1,8 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class UserDto
+{
+    public required string Email { get; set; } = string.Empty;
+    public string? PhoneNumber { get; set; }
+    public string? Telegram { get; set; }
+}


### PR DESCRIPTION
## Summary
- add authentication controller with login, register and user info APIs
- create token service for JWT generation
- register token service and configure JWT authentication
- add DTOs for auth requests and responses
- add JWT configuration settings

## Testing
- `pnpm -r test` *(fails: metaSlice.test.ts expected spy to be called)*
- `dotnet test` *(fails: project targeting .NET 9.0 unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_686577fe79388328bd551450d84410fc