### PR TITLE
Add auth pages and profile editing

### DIFF
--- a/Photobank.Ts/packages/frontend/src/pages/auth/LoginPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/auth/LoginPage.tsx
@@ -1,0 +1,74 @@
+import {useNavigate} from 'react-router-dom';
+import {useForm} from 'react-hook-form';
+import {zodResolver} from '@hookform/resolvers/zod';
+import {z} from 'zod';
+import {login} from '@photobank/shared/api';
+
+import {Button} from '@/components/ui/button';
+import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
+import {Input} from '@/components/ui/input';
+
+const formSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+  });
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      await login(data);
+      navigate('/filter');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-sm mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <Form {...form}>
+        {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({field}) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input {...field} type="email" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({field}) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input {...field} type="password" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="w-full">Login</Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/Photobank.Ts/packages/frontend/src/pages/auth/LogoutPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/auth/LogoutPage.tsx
@@ -1,0 +1,13 @@
+import {useEffect} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {logout} from '@photobank/shared/api';
+
+export default function LogoutPage() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    logout();
+    navigate('/login');
+  }, [navigate]);
+
+  return <p className="p-4">Logging out...</p>;
+}

--- a/Photobank.Ts/packages/frontend/src/pages/profile/MyProfilePage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/profile/MyProfilePage.tsx
@@ -1,0 +1,94 @@
+import {useEffect, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {useForm} from 'react-hook-form';
+import {z} from 'zod';
+import {zodResolver} from '@hookform/resolvers/zod';
+import {getCurrentUser, updateUser, logout} from '@photobank/shared/api';
+
+import {Button} from '@/components/ui/button';
+import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
+import {Input} from '@/components/ui/input';
+import type {UserDto} from '@photobank/shared/types';
+
+const formSchema = z.object({
+  phoneNumber: z.string().optional(),
+  telegram: z.string().optional(),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+export default function MyProfilePage() {
+  const navigate = useNavigate();
+  const [user, setUser] = useState<UserDto | null>(null);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { phoneNumber: '', telegram: '' },
+  });
+
+  useEffect(() => {
+    getCurrentUser().then((u) => {
+      setUser(u);
+      form.reset({ phoneNumber: u.phoneNumber ?? '', telegram: u.telegram ?? '' });
+    }).catch((e) => {
+      console.error(e);
+    });
+  }, [form]);
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      await updateUser(data);
+      navigate('/filter');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold">My Profile</h1>
+      {user && (
+        <div className="space-y-2">
+          <div>
+            <span className="font-medium">Email:</span> {user.email}
+          </div>
+          <Form {...form}>
+            {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 mt-4">
+              <FormField
+                control={form.control}
+                name="phoneNumber"
+                render={({field}) => (
+                  <FormItem>
+                    <FormLabel>Phone number</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="telegram"
+                render={({field}) => (
+                  <FormItem>
+                    <FormLabel>Telegram</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" className="w-full">Save</Button>
+            </form>
+          </Form>
+        </div>
+      )}
+      <Button variant="secondary" className="w-full" onClick={() => { logout(); navigate('/login'); }}>
+        Logout
+      </Button>
+    </div>
+  );
+}

--- a/Photobank.Ts/packages/frontend/src/routes/AppRoutes.tsx
+++ b/Photobank.Ts/packages/frontend/src/routes/AppRoutes.tsx
@@ -3,10 +3,16 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import PhotoListPage from '@/pages/list/PhotoListPage.tsx';
 import FilterPage from '@/pages/filter/FilterPage.tsx';
 import PhotoDetailsPage from '@/pages/detail/PhotoDetailsPage.tsx';
+import LoginPage from '@/pages/auth/LoginPage.tsx';
+import LogoutPage from '@/pages/auth/LogoutPage.tsx';
+import MyProfilePage from '@/pages/profile/MyProfilePage.tsx';
 
 export const AppRoutes = () => (
   <Routes>
     <Route path="/" element={<Navigate to="/filter" />} />
+    <Route path="/login" element={<LoginPage />} />
+    <Route path="/logout" element={<LogoutPage />} />
+    <Route path="/profile" element={<MyProfilePage />} />
     <Route path="/filter" element={<FilterPage />} />
     <Route path="/photos" element={<PhotoListPage />} />
     <Route path="/photos/:id" element={<PhotoDetailsPage />} />


### PR DESCRIPTION
## Summary
- add login form
- add logout page
- create profile page to view and edit current user
- wire new pages into router

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6866b37a9fc48328b953d214f0a520e7