### PR TITLE
Add filter button on list page and persist filter

### DIFF
--- a/Photobank.Ts/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -4,6 +4,8 @@ import type {z} from 'zod';
 
 import { useNavigate } from 'react-router-dom';
 import { useAppDispatch } from '@/app/hook.ts';
+import { useSelector } from 'react-redux';
+import type { RootState } from '@/app/store.ts';
 import { setFilter } from '@/features/photo/model/photoSlice.ts';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -17,21 +19,22 @@ type FormData = z.infer<typeof formSchema>;
 function FilterPage() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const savedFilter = useSelector((state: RootState) => state.photo.filter);
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      caption: undefined,
-      storages: [],
-      paths: [],
-      persons: [],
-      tags: [],
-      isBW: undefined,
-      isAdultContent: undefined,
-      isRacyContent: undefined,
-      thisDay: true,
-      dateFrom: undefined,
-      dateTo: undefined,
+      caption: savedFilter.caption,
+      storages: savedFilter.storages?.map(String) ?? [],
+      paths: savedFilter.paths?.map(String) ?? [],
+      persons: savedFilter.persons?.map(String) ?? [],
+      tags: savedFilter.tags?.map(String) ?? [],
+      isBW: savedFilter.isBW,
+      isAdultContent: savedFilter.isAdultContent,
+      isRacyContent: savedFilter.isRacyContent,
+      thisDay: savedFilter.thisDay ?? true,
+      dateFrom: savedFilter.takenDateFrom ? new Date(savedFilter.takenDateFrom) : undefined,
+      dateTo: savedFilter.takenDateTo ? new Date(savedFilter.takenDateTo) : undefined,
     },
   });
 

--- a/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -7,6 +7,7 @@ import { formatDate } from '@photobank/shared';
 import { useSearchPhotosMutation } from '@/entities/photo/api.ts';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import type { PhotoItemDto } from '@photobank/shared/types';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import type {RootState} from "@/app/store.ts";
@@ -38,9 +39,14 @@ const PhotoListPage = () => {
 
     return (
         <div className="w-full h-screen flex flex-col bg-background">
-            <div className="p-6 border-b">
-                <h1 className="text-3xl font-bold">Photo Gallery</h1>
-                <p className="text-muted-foreground mt-2">{photos.length} photos</p>
+            <div className="p-6 border-b flex items-center justify-between">
+                <div>
+                    <h1 className="text-3xl font-bold">Photo Gallery</h1>
+                    <p className="text-muted-foreground mt-2">{photos.length} photos</p>
+                </div>
+                <Button variant="outline" onClick={() => { navigate('/filter'); }}>
+                    Filter
+                </Button>
             </div>
 
             <ScrollArea className="flex-1">


### PR DESCRIPTION
## Summary
- add button on photo list page to open filter page
- load saved filter state as default values on filter page

## Testing
- `pnpm -r test`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bd3c6310832895c65fb73ec34902