### PR TITLE
Add filter hashing utility

### DIFF
--- a/Photobank.Ts/packages/frontend/test/photoSlice.test.ts
+++ b/Photobank.Ts/packages/frontend/test/photoSlice.test.ts
@@ -12,7 +12,7 @@ describe('photoSlice', () => {
     let state = reducer(undefined, setFilter({ caption: 'foo' } as any));
     expect(state.filter).toEqual({ caption: 'foo' });
     state = reducer(state, resetFilter());
-    expect(state.filter).toEqual({});
+    expect(state.filter).toEqual({ top: 10 });
   });
 
   it('manages selected photos without duplicates', () => {
@@ -31,3 +31,4 @@ describe('photoSlice', () => {
     expect(state.lastResult).toBe(photos);
   });
 });
+

--- a/Photobank.Ts/packages/shared/src/index.ts
+++ b/Photobank.Ts/packages/shared/src/index.ts
@@ -13,3 +13,5 @@ export const getGenderText = (gender?: boolean) => {
   if (gender === undefined) return 'не указан пол';
   return gender ? 'Муж' : 'Жен';
 };
+
+export { getFilterHash } from './utils/getFilterHash';

--- a/Photobank.Ts/packages/shared/src/types/dto/FilterDto.ts
+++ b/Photobank.Ts/packages/shared/src/types/dto/FilterDto.ts
@@ -14,4 +14,10 @@ export interface FilterDto {
   orderBy?: string;
   skip?: number;
   top?: number;
+  /**
+   * Hash of the filter that can be used for caching.
+   * This property is not sent to the backend and is
+   * computed on the client side only.
+   */
+  hash?: string;
 }

--- a/Photobank.Ts/packages/shared/src/utils/getFilterHash.ts
+++ b/Photobank.Ts/packages/shared/src/utils/getFilterHash.ts
@@ -1,0 +1,34 @@
+import { createHash } from 'node:crypto';
+import type { FilterDto } from '../types';
+
+function sortObject<T extends Record<string, unknown>>(obj: T): Record<string, unknown> {
+  return Object.keys(obj)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = obj[key];
+      return acc;
+    }, {});
+}
+
+/**
+ * Creates a stable hash for a filter. When the filter has `thisDay` set to true,
+ * the hash will incorporate the current day of month and month to make the
+ * value change daily.
+ */
+export function getFilterHash(filter: FilterDto): string {
+  const clean: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(filter)) {
+    if (v !== undefined) clean[k] = v;
+  }
+
+  if (clean.thisDay) {
+    const now = new Date();
+    clean.day = now.getDate();
+    clean.month = now.getMonth() + 1;
+    delete clean.thisDay;
+  }
+
+  const json = JSON.stringify(sortObject(clean));
+  return createHash('md5').update(json).digest('hex');
+}
+

--- a/Photobank.Ts/packages/shared/test/getFilterHash.test.ts
+++ b/Photobank.Ts/packages/shared/test/getFilterHash.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getFilterHash } from '../src';
+import type { FilterDto } from '../src/types';
+
+describe('getFilterHash', () => {
+  it('returns stable hash for identical filters', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-05-05T12:00:00Z'));
+    const filter1: FilterDto = { caption: 'a', thisDay: true };
+    const filter2: FilterDto = { thisDay: true, caption: 'a' };
+    const hash1 = getFilterHash(filter1);
+    const hash2 = getFilterHash(filter2);
+    expect(hash1).toBe(hash2);
+    vi.useRealTimers();
+  });
+
+  it('changes when day changes for thisDay filter', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-05-05T12:00:00Z'));
+    const filter: FilterDto = { thisDay: true };
+    const hash1 = getFilterHash(filter);
+    vi.setSystemTime(new Date('2024-05-06T12:00:00Z'));
+    const hash2 = getFilterHash(filter);
+    vi.useRealTimers();
+    expect(hash1).not.toBe(hash2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend `FilterDto` with an optional `hash` field
- add `getFilterHash` helper to create deterministic filter hashes
- export the new helper
- update photo slice test to reflect default filter
- test filter hashing logic

## Testing
- `pnpm test` in `packages/shared`
- `pnpm test` in `packages/frontend`


------
https://chatgpt.com/codex/tasks/task_e_6866d4be8c1483289791b4a7668ecf05