### PR TITLE
Add LRU cache for telegram bot

### DIFF
--- a/Photobank.Ts/packages/shared/package.json
+++ b/Photobank.Ts/packages/shared/package.json
@@ -14,7 +14,8 @@
     "axios": "^1.10.0",
     "date-fns": "^4.1.0",
     "dexie": "^4.0.11",
-    "dotenv": "^17.0.0"
+    "dotenv": "^17.0.0",
+    "lru-cache": "^10.4.3"
   },
   "scripts": {
     "test": "vitest run"

--- a/Photobank.Ts/packages/shared/src/cache/photosCache.ts
+++ b/Photobank.Ts/packages/shared/src/cache/photosCache.ts
@@ -1,4 +1,6 @@
 import Dexie, { type Table } from 'dexie';
+import { LRUCache } from 'lru-cache';
+import { isBrowser } from '../config';
 import type { PhotoItemDto, PhotoDto } from '../types';
 
 export interface CachedPhotoItem extends PhotoItemDto {
@@ -22,20 +24,45 @@ class PhotoCacheDb extends Dexie {
   }
 }
 
-const db = new PhotoCacheDb();
+let db: PhotoCacheDb | undefined;
+let photoItemCache: LRUCache<number, CachedPhotoItem> | undefined;
+let photoCache: LRUCache<number, CachedPhoto> | undefined;
+
+if (isBrowser) {
+  db = new PhotoCacheDb();
+} else {
+  photoItemCache = new LRUCache({ max: 1000 });
+  photoCache = new LRUCache({ max: 100 });
+}
 
 export async function cachePhotoItem(item: PhotoItemDto): Promise<void> {
-  await db.photoItems.put({ ...item, added: Date.now() });
+  const cached = { ...item, added: Date.now() };
+  if (isBrowser) {
+    await db!.photoItems.put(cached);
+  } else {
+    photoItemCache!.set(item.id, cached);
+  }
 }
 
 export async function getCachedPhotoItem(id: number): Promise<CachedPhotoItem | undefined> {
-  return db.photoItems.get(id);
+  if (isBrowser) {
+    return db!.photoItems.get(id);
+  }
+  return Promise.resolve(photoItemCache!.get(id));
 }
 
 export async function cachePhoto(photo: PhotoDto): Promise<void> {
-  await db.photos.put({ ...photo, added: Date.now() });
+  const cached = { ...photo, added: Date.now() };
+  if (isBrowser) {
+    await db!.photos.put(cached);
+  } else {
+    photoCache!.set(photo.id, cached);
+  }
 }
 
 export async function getCachedPhoto(id: number): Promise<CachedPhoto | undefined> {
-  return db.photos.get(id);
+  if (isBrowser) {
+    return db!.photos.get(id);
+  }
+  return Promise.resolve(photoCache!.get(id));
 }

--- a/Photobank.Ts/pnpm-lock.yaml
+++ b/Photobank.Ts/pnpm-lock.yaml
@@ -207,9 +207,15 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dexie:
+        specifier: ^4.0.11
+        version: 4.0.11
       dotenv:
         specifier: ^17.0.0
         version: 17.0.0
+      lru-cache:
+        specifier: ^10.4.3
+        version: 10.4.3
     devDependencies:
       '@types/node':
         specifier: ^24.0.7
@@ -1846,6 +1852,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dexie@4.0.11:
+    resolution: {integrity: sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -4941,6 +4950,8 @@ snapshots:
   detect-libc@2.0.4: {}
 
   detect-node-es@1.1.0: {}
+
+  dexie@4.0.11: {}
 
   doctrine@2.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- support both browser and Node caching
- set up memory LRU caches for PhotoDto and PhotoItemDto
- wire up `lru-cache` dependency

## Testing
- `pnpm install`
- `pnpm -r run test`

------
https://chatgpt.com/codex/tasks/task_e_6866df94db6083288f63a052159be11f