### PR TITLE
Add endpoint for user claims and bot command

### DIFF
--- a/PhotoBank.Api/Controllers/AuthController.cs
+++ b/PhotoBank.Api/Controllers/AuthController.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Mvc;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace PhotoBank.Api.Controllers;
 
@@ -80,6 +82,20 @@ public class AuthController(
             return BadRequest(result.Errors);
 
         return Ok();
+    }
+
+    [HttpGet("claims")]
+    [Authorize]
+    [ProducesResponseType(typeof(IEnumerable<ClaimDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetUserClaims()
+    {
+        var user = await userManager.GetUserAsync(User);
+        if (user == null)
+            return NotFound();
+
+        var claims = await userManager.GetClaimsAsync(user);
+        var result = claims.Select(c => new ClaimDto { Type = c.Type, Value = c.Value });
+        return Ok(result);
     }
 }
 

--- a/PhotoBank.ViewModel.Dto/ClaimDto.cs
+++ b/PhotoBank.ViewModel.Dto/ClaimDto.cs
@@ -1,0 +1,7 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class ClaimDto
+{
+    public required string Type { get; set; } = string.Empty;
+    public required string Value { get; set; } = string.Empty;
+}

--- a/Photobank.Ts/packages/shared/src/api/auth.ts
+++ b/Photobank.Ts/packages/shared/src/api/auth.ts
@@ -4,6 +4,7 @@ import type {
   RegisterRequestDto,
   UserDto,
   UpdateUserDto,
+  ClaimDto,
 } from '../types';
 import { apiClient } from './client';
 
@@ -64,6 +65,11 @@ export const updateUser = async (
   data: UpdateUserDto,
 ): Promise<void> => {
   await apiClient.put('/auth/user', data);
+};
+
+export const getUserClaims = async (): Promise<ClaimDto[]> => {
+  const response = await apiClient.get<ClaimDto[]>('/auth/claims');
+  return response.data;
 };
 
 export const logout = () => {

--- a/Photobank.Ts/packages/shared/src/types/dto/ClaimDto.ts
+++ b/Photobank.Ts/packages/shared/src/types/dto/ClaimDto.ts
@@ -1,0 +1,4 @@
+export interface ClaimDto {
+  type: string;
+  value: string;
+}

--- a/Photobank.Ts/packages/shared/src/types/index.ts
+++ b/Photobank.Ts/packages/shared/src/types/index.ts
@@ -16,3 +16,4 @@ export * from './dto/LoginResponseDto';
 export * from './dto/RegisterRequestDto';
 export * from './dto/UpdateUserDto';
 export * from './dto/UserDto';
+export * from './dto/ClaimDto';

--- a/Photobank.Ts/packages/shared/test/auth.test.ts
+++ b/Photobank.Ts/packages/shared/test/auth.test.ts
@@ -102,4 +102,13 @@ describe('auth utilities', () => {
     await auth.updateUser({ phoneNumber: '123' });
     expect(putMock).toHaveBeenCalledWith('/auth/user', { phoneNumber: '123' });
   });
+
+  it('getUserClaims fetches claims', async () => {
+    const getMock = vi.fn().mockResolvedValue({ data: [{ type: 't', value: 'v' }] });
+    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const auth = await import('../src/api/auth');
+    const claims = await auth.getUserClaims();
+    expect(getMock).toHaveBeenCalledWith('/auth/claims');
+    expect(claims).toEqual([{ type: 't', value: 'v' }]);
+  });
 });

--- a/Photobank.Ts/packages/telegram-bot/src/commands/claims.ts
+++ b/Photobank.Ts/packages/telegram-bot/src/commands/claims.ts
@@ -1,0 +1,17 @@
+import { Context } from "grammy";
+import { getUserClaims } from "@photobank/shared/api";
+
+export async function claimsCommand(ctx: Context) {
+    try {
+        const claims = await getUserClaims();
+        if (!claims.length) {
+            await ctx.reply("Нет данных о правах пользователя.");
+            return;
+        }
+        const lines = claims.map(c => `${c.type}: ${c.value}`);
+        await ctx.reply(lines.join("\n"));
+    } catch (error) {
+        console.error("Ошибка при получении прав:", error);
+        await ctx.reply("🚫 Не удалось получить список прав.");
+    }
+}

--- a/Photobank.Ts/packages/telegram-bot/src/index.ts
+++ b/Photobank.Ts/packages/telegram-bot/src/index.ts
@@ -4,6 +4,7 @@ import {sendThisDayPage, thisDayCommand} from "./commands/thisday";
 import { loadDictionaries } from "@photobank/shared/dictionaries";
 import {photoByIdCommand} from "./commands/photoById";
 import { registerPhotoRoutes } from "./commands/photoRouter";
+import { claimsCommand } from "./commands/claims";
 import { login, setImpersonateUser } from "@photobank/shared/api";
 
 const bot = new Bot(BOT_TOKEN);
@@ -33,6 +34,8 @@ bot.callbackQuery(/^thisday:(\d+)$/, async (ctx) => {
 });
 
 bot.command("photo", photoByIdCommand);
+
+bot.command("claims", claimsCommand);
 
 bot.callbackQuery(/^thisday:(\d+)$/, async (ctx) => {
     const page = parseInt(ctx.match[1], 10);


### PR DESCRIPTION
## Summary
- add new ClaimDto model for API responses
- expose `api/auth/claims` endpoint
- add TypeScript ClaimDto and API helper `getUserClaims`
- test the auth helper
- add `/claims` command in Telegram bot to show current user claims

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*
- `pnpm --filter shared test` *(fails: vitest not found / failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6867f7dae53c832887931842fbb9d76e