### PR TITLE
Fix API env naming

### DIFF
--- a/Photobank.Ts/packages/frontend/.env
+++ b/Photobank.Ts/packages/frontend/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=http://192.168.1.45:5066
+API_BASE_URL=http://localhost:5066

--- a/Photobank.Ts/packages/frontend/src/shared/constants.ts
+++ b/Photobank.Ts/packages/frontend/src/shared/constants.ts
@@ -1,4 +1,4 @@
-export const BASE_URL: string = import.meta.env.VITE_API_URL as string;
+export const BASE_URL: string = import.meta.env.API_BASE_URL as string;
 export const METADATA_CACHE_KEY = 'photobank_metadata_cache';
 export const METADATA_CACHE_VERSION = 1;
 

--- a/Photobank.Ts/packages/shared/.env
+++ b/Photobank.Ts/packages/shared/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=http://192.168.1.45:5066
+API_BASE_URL=http://localhost:5066

--- a/Photobank.Ts/packages/shared/src/config.ts
+++ b/Photobank.Ts/packages/shared/src/config.ts
@@ -9,6 +9,6 @@ export function isNode(): boolean {
 }
 
 export const API_BASE_URL = isBrowser()
-    ? (import.meta as any).env?.VITE_API_BASE_URL
+    ? (import.meta as any).env?.API_BASE_URL
     // @ts-ignore
-    : (typeof process !== 'undefined' ? process.env.API_BASE_URL : undefined) ?? 'http://192.168.1.45:5066';
+    : (typeof process !== 'undefined' ? process.env.API_BASE_URL : undefined) ?? 'http://localhost:5066';

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ pnpm install
 pnpm dev
 ```
 
-Перед запуском задайте `VITE_API_BASE_URL` (или в `.env` файл) – адрес API, например:
+Перед запуском задайте `API_BASE_URL` (или в `.env` файл) – адрес API, например:
 
 ```bash
-VITE_API_BASE_URL=http://localhost:5066
+API_BASE_URL=http://localhost:5066
 ```
 
 ### Телеграм‑бот
@@ -129,10 +129,10 @@ pnpm install
 pnpm dev
 ```
 
-Before running set `VITE_API_BASE_URL` (or put it into `.env`) – the API address, for example:
+Before running set `API_BASE_URL` (or put it into `.env`) – the API address, for example:
 
 ```bash
-VITE_API_BASE_URL=http://localhost:5066
+API_BASE_URL=http://localhost:5066
 ```
 
 ### Telegram bot


### PR DESCRIPTION
## Summary
- sync env vars for API base URL
- reference `API_BASE_URL` in docs and code

## Testing
- `pnpm -r test` *(fails: vitest not found)*
- `dotnet test PhotoBank.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fdbe7380832882f5a58a9243378a