### PR TITLE
Fix thisday pagination to edit existing message

### DIFF
--- a/Photobank.Ts/packages/telegram-bot/src/index.ts
+++ b/Photobank.Ts/packages/telegram-bot/src/index.ts
@@ -27,11 +27,6 @@ bot.command(
 
 bot.command("thisday", thisDayCommand);
 
-bot.callbackQuery(/^thisday:(\d+)$/, async (ctx) => {
-    const page = parseInt(ctx.match[1], 10);
-    await ctx.answerCallbackQuery();
-    await sendThisDayPage(ctx, page);
-});
 
 bot.command("photo", photoByIdCommand);
 


### PR DESCRIPTION
## Summary
- avoid creating new messages on thisday pagination callback

## Testing
- `pnpm -r test` *(fails: formatDate test expectation mismatch)*
- `dotnet test PhotoBank.sln` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686807f97f508328bc717756d80f88ca