### PR TITLE
Enable photo preview modal in list page

### DIFF
--- a/Photobank.Ts/packages/frontend/src/components/PhotoPreviewModal.tsx
+++ b/Photobank.Ts/packages/frontend/src/components/PhotoPreviewModal.tsx
@@ -1,0 +1,32 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useGetPhotoByIdQuery } from '@/entities/photo/api';
+
+interface PhotoPreviewModalProps {
+    photoId: number | null;
+    onOpenChange: (open: boolean) => void;
+}
+
+const PhotoPreviewModal = ({ photoId, onOpenChange }: PhotoPreviewModalProps) => {
+    const { data: photo, isFetching } = useGetPhotoByIdQuery(photoId ?? 0, { skip: photoId === null });
+
+    return (
+        <Dialog open={photoId !== null} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-3xl">
+                <DialogHeader>
+                    <DialogTitle>{photo?.name || 'Preview'}</DialogTitle>
+                </DialogHeader>
+                {isFetching || !photo ? (
+                    <p className="p-4">Loading...</p>
+                ) : (
+                    <img
+                        src={`data:image/jpeg;base64,${photo.previewImage}`}
+                        alt={photo.name}
+                        className="max-h-[80vh] w-auto mx-auto"
+                    />
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default PhotoPreviewModal;

--- a/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -16,6 +16,7 @@ import { setLastResult } from '@/features/photo/model/photoSlice.ts';
 import {MAX_VISIBLE_PERSONS_LG, MAX_VISIBLE_TAGS_LG, MAX_VISIBLE_PERSONS_SM, MAX_VISIBLE_TAGS_SM} from '@/shared/constants';
 
 import PhotoPreview from './PhotoPreview';
+import PhotoPreviewModal from '@/components/PhotoPreviewModal';
 
 const PhotoListPage = () => {
     const dispatch = useAppDispatch();
@@ -32,6 +33,7 @@ const PhotoListPage = () => {
     const [skip, setSkip] = useState(filter.skip ?? 0);
     const top = filter.top ?? 10;
     const navigate = useNavigate();
+    const [previewId, setPreviewId] = useState<number | null>(null);
 
     useEffect(() => {
         searchPhotos({ ...filter, skip: 0, top }).unwrap().then(result => {
@@ -84,7 +86,7 @@ const PhotoListPage = () => {
                         <div className="space-y-3">
                             {photos.map((photo) => (
                                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                                <Card key={photo.id} className="p-4 hover:shadow-md transition-shadow cursor-pointer" onClick={() => { navigate(`/photos/${photo.id?.toString()}`); }}>
+                                <Card key={photo.id} className="p-4 hover:shadow-md transition-shadow cursor-pointer" onClick={() => { setPreviewId(photo.id); }}>
                                     <div className="grid grid-cols-12 gap-4 items-center">
                                         <div className="col-span-1">
                                             <Badge variant="outline" className="font-mono text-xs">
@@ -171,7 +173,7 @@ const PhotoListPage = () => {
                         <div className="grid gap-4 sm:grid-cols-2">
                             {photos.map((photo) => (
                                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                                <Card key={photo.id} className="p-4 hover:shadow-md transition-shadow cursor-pointer" onClick={() => { navigate(`/photos/${photo.id?.toString()}`); }}>
+                                <Card key={photo.id} className="p-4 hover:shadow-md transition-shadow cursor-pointer" onClick={() => { setPreviewId(photo.id); }}>
                                     <div className="space-y-3">
                                         <div className="flex items-start gap-3">
                                             <PhotoPreview
@@ -247,6 +249,10 @@ const PhotoListPage = () => {
                     )}
                 </div>
             </ScrollArea>
+            <PhotoPreviewModal
+                photoId={previewId}
+                onOpenChange={(open) => { if (!open) setPreviewId(null); }}
+            />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- add a `PhotoPreviewModal` component to fetch full preview via API
- open the modal from the photo list page instead of navigating to details

## Testing
- `pnpm -r test` *(fails: MissingAPIError and assertion failures)*
- `dotnet test PhotoBank.sln` *(fails: `dotnet` not found)*
- `pnpm --filter frontend build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_686812618714832880321b12b9ba4f0e