### PR TITLE
Add filter result cache

### DIFF
--- a/Photobank.Ts/packages/shared/src/api/photos.ts
+++ b/Photobank.Ts/packages/shared/src/api/photos.ts
@@ -2,12 +2,19 @@ import type { FilterDto, PhotoDto, QueryResult } from '../types';
 import { apiClient } from './client';
 import { isBrowser } from '../config';
 import { cachePhotoItem, cachePhoto, getCachedPhoto } from '../cache/photosCache';
+import { cacheFilterResult } from '../cache/filterResultsCache';
+import { getFilterHash } from '../utils/getFilterHash';
 
 export const searchPhotos = async (filter: FilterDto): Promise<QueryResult> => {
   const response = await apiClient.post<QueryResult>('/photos/search', filter);
-  if (isBrowser && response.data.photos) {
-    for (const item of response.data.photos) {
-      void cachePhotoItem(item);
+  if (response.data.photos) {
+    const ids = response.data.photos.map((p) => p.id);
+    const hash = await getFilterHash(filter);
+    void cacheFilterResult(hash, ids);
+    if (isBrowser) {
+      for (const item of response.data.photos) {
+        void cachePhotoItem(item);
+      }
     }
   }
   return response.data;

--- a/Photobank.Ts/packages/shared/src/cache/filterResultsCache.ts
+++ b/Photobank.Ts/packages/shared/src/cache/filterResultsCache.ts
@@ -1,0 +1,45 @@
+import Dexie, { type Table } from 'dexie';
+import { LRUCache } from 'lru-cache';
+import { isBrowser } from '../config';
+
+export interface CachedFilterResult {
+  hash: string;
+  ids: number[];
+  added: number;
+}
+
+class FilterResultsDb extends Dexie {
+  filterResults!: Table<CachedFilterResult, string>;
+
+  constructor() {
+    super('photobank-filter-cache');
+    this.version(1).stores({
+      filterResults: 'hash,added',
+    });
+  }
+}
+
+let db: FilterResultsDb | undefined;
+let memoryCache: LRUCache<string, CachedFilterResult> | undefined;
+
+if (isBrowser) {
+  db = new FilterResultsDb();
+} else {
+  memoryCache = new LRUCache({ max: 100 });
+}
+
+export async function cacheFilterResult(hash: string, ids: number[]): Promise<void> {
+  const cached: CachedFilterResult = { hash, ids, added: Date.now() };
+  if (isBrowser) {
+    await db!.filterResults.put(cached);
+  } else {
+    memoryCache!.set(hash, cached);
+  }
+}
+
+export async function getCachedFilterResult(hash: string): Promise<CachedFilterResult | undefined> {
+  if (isBrowser) {
+    return db!.filterResults.get(hash);
+  }
+  return Promise.resolve(memoryCache!.get(hash));
+}

--- a/Photobank.Ts/packages/shared/src/index.ts
+++ b/Photobank.Ts/packages/shared/src/index.ts
@@ -21,3 +21,7 @@ export {
   cachePhoto,
   getCachedPhoto,
 } from './cache/photosCache';
+export {
+  cacheFilterResult,
+  getCachedFilterResult,
+} from './cache/filterResultsCache';

--- a/Photobank.Ts/packages/shared/test/filterResultsCache.test.ts
+++ b/Photobank.Ts/packages/shared/test/filterResultsCache.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('filterResultsCache', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // ensure non-browser environment
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (global as any).window;
+  });
+
+  it('stores and retrieves ids by hash', async () => {
+    const { cacheFilterResult, getCachedFilterResult } = await import('../src/cache/filterResultsCache');
+    await cacheFilterResult('abc', [1, 2, 3]);
+    const cached = await getCachedFilterResult('abc');
+    expect(cached?.ids).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
## Summary
- cache lists of photo ids by filter hash
- expose filter result cache from `@photobank/shared`
- store search results in the cache when requesting photos
- test filter result cache

## Testing
- `pnpm -r test` *(fails: MissingAPIError IndexedDB API missing)*
- `dotnet test PhotoBank.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868296c87508328bf65e405a079a31b