### PR TITLE
Fix Telegram bot persons count display

### DIFF
--- a/Photobank.Ts/packages/telegram-bot/src/commands/thisday.ts
+++ b/Photobank.Ts/packages/telegram-bot/src/commands/thisday.ts
@@ -55,8 +55,14 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
                     const peopleCount = photo.persons?.length ?? 0;
                     const isAdult = photo.isAdultContent ? "🔞" : "";
                     const isRacy = photo.isRacyContent ? "⚠️" : "";
-                    sections.push(`• <b>${title}</b>
-👥 ${peopleCount} чел. ${isAdult}${isRacy}
+
+                    const metaParts: string[] = [];
+                    if (peopleCount > 0) metaParts.push(`👥 ${peopleCount} чел.`);
+                    if (isAdult) metaParts.push(isAdult);
+                    if (isRacy) metaParts.push(isRacy);
+
+                    const metaLine = metaParts.length ? `\n${metaParts.join(" ")}` : "";
+                    sections.push(`• <b>${title}</b>${metaLine}
 🔗 /photo${photo.id}`);
                 });
             });


### PR DESCRIPTION
## Summary
- hide persons info in /thisday command if no persons are detected

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `pnpm -r test` *(fails: vitest tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_686933ab91008328a07b1ded74c15849