### PR TITLE
Add captions to photo item dto

### DIFF
--- a/PhotoBank.Services/Api/PhotoService.cs
+++ b/PhotoBank.Services/Api/PhotoService.cs
@@ -59,6 +59,7 @@ namespace PhotoBank.Services.Api
                 .Include(p => p.Storage)
                 .Include(p => p.PhotoTags)
                 .Include(p => p.Faces)
+                .Include(p => p.Captions)
                 .AsQueryable();
 
             if (filter.IsBW.HasValue)

--- a/PhotoBank.Services/MappingProfile.cs
+++ b/PhotoBank.Services/MappingProfile.cs
@@ -31,6 +31,7 @@ namespace PhotoBank.Services
             CreateMap<Photo, PhotoItemDto>()
                 .ForMember(dest => dest.Tags, opt => opt.MapFrom(src => src.PhotoTags))
                 .ForMember(dest => dest.Persons, opt => opt.MapFrom(src => src.Faces))
+                .ForMember(dest => dest.Captions, opt => opt.MapFrom(src => src.Captions))
                 .ForMember(dest => dest.StorageName, opt => opt.MapFrom(src => src.Storage.Name))
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 

--- a/PhotoBank.ViewModel.Dto/PhotoItemDto.cs
+++ b/PhotoBank.ViewModel.Dto/PhotoItemDto.cs
@@ -26,5 +26,6 @@ namespace PhotoBank.ViewModel.Dto
         public required string RelativePath { get; set; }
         public IEnumerable<TagItemDto>? Tags { get; set; }
         public IEnumerable<PersonItemDto>? Persons { get; set; }
+        public List<string>? Captions { get; set; }
     }
 }

--- a/Photobank.Ts/packages/shared/src/types/dto/PhotoItemDto.ts
+++ b/Photobank.Ts/packages/shared/src/types/dto/PhotoItemDto.ts
@@ -15,4 +15,5 @@ export interface PhotoItemDto {
   relativePath: string;
   tags?: TagItemDto[];
   persons?: PersonItemDto[];
+  captions?: string[];
 }


### PR DESCRIPTION
## Summary
- extend `PhotoItemDto` with captions field
- map captions from entity to dto
- include captions in photo search query
- expose captions in TypeScript type

## Testing
- `pnpm -r test` *(fails: getFilterHash.test.ts and index.test.ts)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68693b1f81508328aef85075548d2f35