### PR TITLE
Add photo captions to /thisday command

### DIFF
--- a/Photobank.Ts/packages/telegram-bot/src/commands/thisday.ts
+++ b/Photobank.Ts/packages/telegram-bot/src/commands/thisday.ts
@@ -61,8 +61,14 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
                     if (isAdult) metaParts.push(isAdult);
                     if (isRacy) metaParts.push(isRacy);
 
+                    const caption = photo.captions?.join(" ") ?? "";
+                    const shortCaption = caption
+                        ? caption.slice(0, 30) + (caption.length > 30 ? "..." : "")
+                        : "";
+                    const captionLine = shortCaption ? `\n📝 ${shortCaption}` : "";
+
                     const metaLine = metaParts.length ? `\n${metaParts.join(" ")}` : "";
-                    sections.push(`• <b>${title}</b>${metaLine}
+                    sections.push(`• <b>${title}</b>${captionLine}${metaLine}
 🔗 /photo${photo.id}`);
                 });
             });


### PR DESCRIPTION
## Summary
- show short caption for each photo in the Telegram bot's `/thisday` command

## Testing
- `pnpm -r test` *(fails: vitest tests in @photobank/shared)*

------
https://chatgpt.com/codex/tasks/task_e_68693e10532c8328ba19d63349f499e4