### PR TITLE
Update /thisday caption handling

### DIFF
--- a/Photobank.Ts/packages/telegram-bot/src/commands/thisday.ts
+++ b/Photobank.Ts/packages/telegram-bot/src/commands/thisday.ts
@@ -1,6 +1,8 @@
 import { Context, InlineKeyboard } from "grammy";
 import { searchPhotos } from "@photobank/shared/api/photos";
 
+export const captionCache = new Map<number, string>();
+
 const PAGE_SIZE = 10;
 
 function parsePage(text?: string): number {
@@ -43,6 +45,7 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
     }
 
     const sections: string[] = [];
+    const keyboard = new InlineKeyboard();
 
     [...byYear.entries()]
         .sort(([a], [b]) => b - a)
@@ -62,21 +65,20 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
                     if (isRacy) metaParts.push(isRacy);
 
                     const caption = photo.captions?.join(" ") ?? "";
-                    const shortCaption = caption
-                        ? caption.slice(0, 30) + (caption.length > 30 ? "..." : "")
-                        : "";
-                    const captionLine = shortCaption ? `\n📝 ${shortCaption}` : "";
 
                     const metaLine = metaParts.length ? `\n${metaParts.join(" ")}` : "";
-                    sections.push(`• <b>${title}</b>${captionLine}${metaLine}
-🔗 /photo${photo.id}`);
+                    sections.push(`• <b>${title}</b>${metaLine} 🔗 /photo${photo.id}`);
+                    if (caption) {
+                        captionCache.set(photo.id, caption);
+                        keyboard.text("ℹ️", `caption:${photo.id}`).row();
+                    }
                 });
             });
         });
 
     sections.push(`\n📄 Страница ${page} из ${totalPages}`);
+    keyboard.row();
 
-    const keyboard = new InlineKeyboard();
     if (page > 1) keyboard.text("◀ Назад", `thisday:${page - 1}`);
     if (page < totalPages) keyboard.text("Вперёд ▶", `thisday:${page + 1}`);
 

--- a/Photobank.Ts/packages/telegram-bot/src/index.ts
+++ b/Photobank.Ts/packages/telegram-bot/src/index.ts
@@ -1,6 +1,6 @@
 import { Bot } from "grammy";
 import {BOT_TOKEN, API_EMAIL, API_PASSWORD} from "./config";
-import {sendThisDayPage, thisDayCommand} from "./commands/thisday";
+import {sendThisDayPage, thisDayCommand, captionCache} from "./commands/thisday";
 import { loadDictionaries } from "@photobank/shared/dictionaries";
 import {photoByIdCommand} from "./commands/photoById";
 import { registerPhotoRoutes } from "./commands/photoRouter";
@@ -36,6 +36,12 @@ bot.callbackQuery(/^thisday:(\d+)$/, async (ctx) => {
     const page = parseInt(ctx.match[1], 10);
     await ctx.answerCallbackQuery();
     await sendThisDayPage(ctx, page, true);
+});
+
+bot.callbackQuery(/^caption:(\d+)$/, async (ctx) => {
+    const id = parseInt(ctx.match[1], 10);
+    const caption = captionCache.get(id);
+    await ctx.answerCallbackQuery(caption ?? "Без подписи.", { show_alert: true });
 });
 
 bot.on("message", (ctx) => ctx.reply("Получил другое сообщение!"));


### PR DESCRIPTION
## Summary
- maintain caption cache when listing photos in `/thisday`
- use cached captions for ℹ️ popup instead of extra API call

## Testing
- `pnpm -r test` *(fails: vitest not found)*
- `dotnet test PhotoBank.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869421a26208328969a259f36338a2a