### PR TITLE
Fix endless loop when restoring filters

### DIFF
--- a/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -84,11 +84,18 @@ const PhotoListPage = () => {
 
     useEffect(() => {
         const cached = loadCache(filter);
-        const activeFilter = cached ? cached.filter : filter;
+
         if (cached) {
-            dispatch(setFilter(cached.filter));
+            const cachedSignature = filterSignature(cached.filter);
+            const currentSignature = filterSignature(filter);
+
+            if (cachedSignature !== currentSignature) {
+                dispatch(setFilter(cached.filter));
+                return; // wait for filter update before searching
+            }
         }
 
+        const activeFilter = cached ? cached.filter : filter;
         const initialSkip = cached?.skip ?? 0;
         const queryTop = initialSkip > 0 ? initialSkip : activeFilter.top ?? top;
 


### PR DESCRIPTION
## Summary
- avoid dispatching duplicate filter state in `PhotoListPage`
- skip the search call until the stored filter has been applied

## Testing
- `pnpm -r test` *(fails: vitest not found)*
- `dotnet test PhotoBank.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686953ef9d848328b501556706a76dd2