### PR TITLE
Remove unused photo item caching

### DIFF
--- a/Photobank.Ts/packages/shared/src/cache/photosCache.ts
+++ b/Photobank.Ts/packages/shared/src/cache/photosCache.ts
@@ -1,54 +1,30 @@
 import Dexie, { type Table } from 'dexie';
 import { LRUCache } from 'lru-cache';
 import { isBrowser } from '../config';
-import type { PhotoItemDto, PhotoDto } from '../types';
-
-export interface CachedPhotoItem extends PhotoItemDto {
-  added: number;
-}
+import type { PhotoDto } from '../types';
 
 export interface CachedPhoto extends PhotoDto {
   added: number;
 }
 
 class PhotoCacheDb extends Dexie {
-  photoItems!: Table<CachedPhotoItem, number>;
   photos!: Table<CachedPhoto, number>;
 
   constructor() {
     super('photobank-cache');
     this.version(1).stores({
-      photoItems: 'id,added',
       photos: 'id,added',
     });
   }
 }
 
 let db: PhotoCacheDb | undefined;
-let photoItemCache: LRUCache<number, CachedPhotoItem> | undefined;
 let photoCache: LRUCache<number, CachedPhoto> | undefined;
 
 if (isBrowser()) {
   db = new PhotoCacheDb();
 } else {
-  photoItemCache = new LRUCache({ max: 1000 });
   photoCache = new LRUCache({ max: 100 });
-}
-
-export async function cachePhotoItem(item: PhotoItemDto): Promise<void> {
-  const cached = { ...item, added: Date.now() };
-  if (isBrowser()) {
-    await db!.photoItems.put(cached);
-  } else {
-    photoItemCache!.set(item.id, cached);
-  }
-}
-
-export async function getCachedPhotoItem(id: number): Promise<CachedPhotoItem | undefined> {
-  if (isBrowser()) {
-    return db!.photoItems.get(id);
-  }
-  return Promise.resolve(photoItemCache!.get(id));
 }
 
 export async function cachePhoto(photo: PhotoDto): Promise<void> {

--- a/Photobank.Ts/packages/shared/src/index.ts
+++ b/Photobank.Ts/packages/shared/src/index.ts
@@ -16,8 +16,6 @@ export const getGenderText = (gender?: boolean) => {
 
 export { getFilterHash } from './utils/getFilterHash';
 export {
-  cachePhotoItem,
-  getCachedPhotoItem,
   cachePhoto,
   getCachedPhoto,
 } from './cache/photosCache';


### PR DESCRIPTION
## Summary
- remove unused `cachePhotoItem` and `getCachedPhotoItem` APIs
- drop empty constants file

## Testing
- `pnpm --filter @photobank/shared test`


------
https://chatgpt.com/codex/tasks/task_e_686a60503f808328ad72e627a193f0c3