### PR TITLE
Add photo count and fullscreen preview

### DIFF
--- a/Photobank.Ts/packages/frontend/src/components/PhotoPreviewModal.tsx
+++ b/Photobank.Ts/packages/frontend/src/components/PhotoPreviewModal.tsx
@@ -11,7 +11,7 @@ const PhotoPreviewModal = ({ photoId, onOpenChange }: PhotoPreviewModalProps) =>
 
     return (
         <Dialog open={photoId !== null} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-3xl">
+            <DialogContent className="max-w-none w-screen h-screen top-0 left-0 translate-x-0 translate-y-0">
                 <DialogHeader>
                     <DialogTitle>{photo?.name || 'Preview'}</DialogTitle>
                 </DialogHeader>
@@ -21,7 +21,7 @@ const PhotoPreviewModal = ({ photoId, onOpenChange }: PhotoPreviewModalProps) =>
                     <img
                         src={`data:image/jpeg;base64,${photo.previewImage}`}
                         alt={photo.name}
-                        className="max-h-[80vh] w-auto mx-auto"
+                        className="max-h-full max-w-full w-auto h-auto mx-auto object-contain"
                     />
                 )}
             </DialogContent>

--- a/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -74,7 +74,9 @@ const PhotoListPage = () => {
             <div className="p-6 border-b flex items-center justify-between">
                 <div>
                     <h1 className="text-3xl font-bold">Photo Gallery</h1>
-                    <p className="text-muted-foreground mt-2">{photos.length} photos</p>
+                    <p className="text-muted-foreground mt-2">
+                        {photos.length} of {total} photos
+                    </p>
                 </div>
                 <Button variant="outline" onClick={() => { navigate('/filter'); }}>
                     Filter


### PR DESCRIPTION
## Summary
- show loaded vs total photo count on the list page
- expand preview modal to full screen

## Testing
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870dc746bd083289dedcaaf4156610e