### PR TITLE
Add modal for photo details

### DIFF
--- a/Photobank.Ts/packages/frontend/src/components/PhotoDetailsModal.tsx
+++ b/Photobank.Ts/packages/frontend/src/components/PhotoDetailsModal.tsx
@@ -1,0 +1,19 @@
+import PhotoDetailsPage from '@/pages/detail/PhotoDetailsPage';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+
+interface PhotoDetailsModalProps {
+    photoId: number | null;
+    onOpenChange: (open: boolean) => void;
+}
+
+const PhotoDetailsModal = ({ photoId, onOpenChange }: PhotoDetailsModalProps) => {
+    return (
+        <Dialog open={photoId !== null} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-none w-screen h-screen top-0 left-0 translate-x-0 translate-y-0 p-0" showCloseButton={true}>
+                {photoId !== null && <PhotoDetailsPage photoId={photoId} />}
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default PhotoDetailsModal;

--- a/Photobank.Ts/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -33,7 +33,11 @@ const calculateImageSize = (naturalWidth: number, naturalHeight: number, contain
     };
 };
 
-const PhotoDetailsPage = () => {
+interface PhotoDetailsPageProps {
+    photoId?: number;
+}
+
+const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
     const [imageDisplaySize, setImageDisplaySize] = useState({width: 0, height: 0, scale: 1});
     const [containerSize, setContainerSize] = useState({width: 0, height: 0});
     const persons = useSelector((state: RootState) => state.metadata.persons);
@@ -41,8 +45,8 @@ const PhotoDetailsPage = () => {
     const containerRef = useRef<HTMLDivElement>(null);
 
     const {id} = useParams<{ id: string }>();
-    const photoId = id ? +id : 0;
-    const {data: photo, error} = useGetPhotoByIdQuery(photoId);
+    const photoId = propPhotoId ?? (id ? +id : 0);
+    const {data: photo, error} = useGetPhotoByIdQuery(photoId, { skip: photoId === 0 });
 
     const formattedTakenDate = useMemo(() => photo?.takenDate && formatDate(photo.takenDate), [photo?.takenDate]);
 

--- a/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/shared/constants';
 
 import PhotoPreview from './PhotoPreview';
-import PhotoPreviewModal from '@/components/PhotoPreviewModal';
+import PhotoDetailsModal from '@/components/PhotoDetailsModal';
 
 
 const PhotoListPage = () => {
@@ -41,7 +41,7 @@ const PhotoListPage = () => {
     const navigate = useNavigate();
     const scrollAreaRef = useRef<HTMLDivElement>(null);
 
-    const [previewId, setPreviewId] = useState<number | null>(null);
+    const [detailsId, setDetailsId] = useState<number | null>(null);
 
 
     useEffect(() => {
@@ -100,7 +100,7 @@ const PhotoListPage = () => {
                         <div className="space-y-3">
                             {photos.map((photo) => (
                                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                                <Card key={photo.id} className="p-4 hover:shadow-md transition-shadow cursor-pointer" onClick={() => { setPreviewId(photo.id); }}>
+                                <Card key={photo.id} className="p-4 hover:shadow-md transition-shadow cursor-pointer" onClick={() => { setDetailsId(photo.id); }}>
                                     <div className="grid grid-cols-12 gap-4 items-center">
                                         <div className="col-span-1">
                                             <Badge variant="outline" className="font-mono text-xs">
@@ -187,7 +187,7 @@ const PhotoListPage = () => {
                         <div className="grid gap-4 sm:grid-cols-2">
                             {photos.map((photo) => (
                                 // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                                <Card key={photo.id} className="p-4 hover:shadow-md transition-shadow cursor-pointer" onClick={() => { setPreviewId(photo.id); }}>
+                                <Card key={photo.id} className="p-4 hover:shadow-md transition-shadow cursor-pointer" onClick={() => { setDetailsId(photo.id); }}>
                                     <div className="space-y-3">
                                         <div className="flex items-start gap-3">
                                             <PhotoPreview
@@ -263,9 +263,9 @@ const PhotoListPage = () => {
                     )}
                 </div>
             </ScrollArea>
-            <PhotoPreviewModal
-                photoId={previewId}
-                onOpenChange={(open) => { if (!open) setPreviewId(null); }}
+            <PhotoDetailsModal
+                photoId={detailsId}
+                onOpenChange={(open) => { if (!open) setDetailsId(null); }}
             />
         </div>
     );


### PR DESCRIPTION
## Summary
- add `PhotoDetailsModal` component
- allow `PhotoDetailsPage` to accept a photoId prop
- open details dialog from `PhotoListPage`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6870f546b9f8832897cd22caf4543de0