### PR TITLE
Add login error message

### DIFF
--- a/Photobank.Ts/packages/frontend/src/pages/auth/LoginPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/auth/LoginPage.tsx
@@ -1,5 +1,6 @@
 import {useNavigate} from 'react-router-dom';
 import {useForm} from 'react-hook-form';
+import {useState} from 'react';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {z} from 'zod';
 import {login} from '@photobank/shared/api';
@@ -19,6 +20,7 @@ type FormData = z.infer<typeof formSchema>;
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -34,12 +36,18 @@ export default function LoginPage() {
       navigate('/filter');
     } catch (e) {
       console.error(e);
+      setErrorMessage('Invalid email or password');
     }
   };
 
   return (
     <div className="w-full max-w-sm mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">Login</h1>
+      {errorMessage && (
+        <p className="text-destructive text-sm mb-2" role="alert">
+          {errorMessage}
+        </p>
+      )}
       <Form {...form}>
         {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">

--- a/Photobank.Ts/packages/frontend/test/LoginPage.test.tsx
+++ b/Photobank.Ts/packages/frontend/test/LoginPage.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+class RO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// @ts-ignore
+global.ResizeObserver = RO;
+
+const renderPage = async (loginMock: any) => {
+  vi.doMock('@photobank/shared/api', () => ({ login: loginMock }));
+  const { default: LoginPage } = await import('../src/pages/auth/LoginPage');
+  render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('shows error when login fails', async () => {
+    const loginMock = vi.fn().mockRejectedValue(new Error('bad'));
+    await renderPage(loginMock);
+
+    fireEvent.input(screen.getByLabelText('Email'), { target: { value: 'e@e.com' } });
+    fireEvent.input(screen.getByLabelText('Password'), { target: { value: 'p' } });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await screen.findByRole('alert');
+    expect(loginMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- display error message on failed login
- test that LoginPage shows error

## Testing
- `pnpm -r test`
- `dotnet test PhotoBank.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68714ecd76788328bd076bdc783a055d