### PR TITLE
Add custom claim support in JWT generation

### DIFF
--- a/PhotoBank.Api/Controllers/AuthController.cs
+++ b/PhotoBank.Api/Controllers/AuthController.cs
@@ -31,7 +31,18 @@ public class AuthController(
         if (user == null)
             return BadRequest();
 
-        var token = tokenService.CreateToken(user, request.RememberMe);
+        var claims = await userManager.GetClaimsAsync(user);
+        var roleNames = await userManager.GetRolesAsync(user);
+        foreach (var name in roleNames)
+        {
+            var role = await roleManager.FindByNameAsync(name);
+            if (role == null)
+                continue;
+            var roleClaims = await roleManager.GetClaimsAsync(role);
+            claims = claims.Concat(roleClaims).ToList();
+        }
+
+        var token = tokenService.CreateToken(user, request.RememberMe, claims);
         return Ok(new LoginResponseDto { Token = token });
     }
 

--- a/PhotoBank.Services/Api/TokenService.cs
+++ b/PhotoBank.Services/Api/TokenService.cs
@@ -11,12 +11,12 @@ namespace PhotoBank.Services.Api;
 
 public interface ITokenService
 {
-    string CreateToken(ApplicationUser user, bool rememberMe = false);
+    string CreateToken(ApplicationUser user, bool rememberMe = false, IEnumerable<Claim>? additionalClaims = null);
 }
 
 public class TokenService(IConfiguration configuration) : ITokenService
 {
-    public string CreateToken(ApplicationUser user, bool rememberMe = false)
+    public string CreateToken(ApplicationUser user, bool rememberMe = false, IEnumerable<Claim>? additionalClaims = null)
     {
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["Jwt:Key"]!));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
@@ -28,6 +28,11 @@ public class TokenService(IConfiguration configuration) : ITokenService
             new(ClaimTypes.NameIdentifier, user.Id),
             new(ClaimTypes.Name, user.UserName ?? string.Empty)
         };
+
+        if (additionalClaims != null)
+        {
+            claims.AddRange(additionalClaims);
+        }
 
         var token = new JwtSecurityToken(
             issuer: configuration["Jwt:Issuer"],

--- a/PhotoBank.UnitTests/TokenServiceTests.cs
+++ b/PhotoBank.UnitTests/TokenServiceTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Api;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class TokenServiceTests
+{
+    [Test]
+    public void CreateToken_WithAdditionalClaims_ShouldContainThem()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Key"] = "VerySecretKeyVerySecretKeyVerySecretKey",
+                ["Jwt:Issuer"] = "test",
+                ["Jwt:Audience"] = "test"
+            })
+            .Build();
+
+        var service = new TokenService(configuration);
+        var user = new ApplicationUser
+        {
+            Id = "1",
+            Email = "user@example.com",
+            UserName = "user"
+        };
+
+        var claims = new[] { new Claim("AllowAdultContent", "True") };
+
+        var token = service.CreateToken(user, false, claims);
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(token);
+
+        Assert.That(jwt.Claims.Any(c => c.Type == "AllowAdultContent" && c.Value == "True"));
+    }
+}


### PR DESCRIPTION
## Summary
- allow `TokenService` to accept additional claims
- include user and role claims when logging in
- test that custom claims appear in generated JWTs

## Testing
- `dotnet test PhotoBank.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715ba144748328a2b31326b1408d8c