### PR TITLE
Add show face boxes toggle

### DIFF
--- a/Photobank.Ts/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -9,6 +9,7 @@ import {Label} from '@/components/ui/label';
 import {Input} from '@/components/ui/input';
 import {Textarea} from '@/components/ui/textarea';
 import {ScrollArea} from '@/components/ui/scroll-area';
+import {Checkbox} from '@/components/ui/checkbox';
 import type { FaceBoxDto } from '@photobank/shared/types';
 import {useGetPhotoByIdQuery} from "@/entities/photo/api.ts";
 import {ScoreBar} from '@/components/ScoreBar';
@@ -40,6 +41,7 @@ interface PhotoDetailsPageProps {
 const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
     const [imageDisplaySize, setImageDisplaySize] = useState({width: 0, height: 0, scale: 1});
     const [containerSize, setContainerSize] = useState({width: 0, height: 0});
+    const [showFaceBoxes, setShowFaceBoxes] = useState(true);
     const persons = useSelector((state: RootState) => state.metadata.persons);
 
     const containerRef = useRef<HTMLDivElement>(null);
@@ -155,14 +157,15 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                     alt={photo.name}
                                     className="max-h-full max-w-full object-contain"
                                 />
-                                {photo.faces?.map((face, index) => (
-                                    <FaceOverlay
-                                        key={face.id}
-                                        face={face}
-                                        index={index}
-                                        style={calculateFacePosition(face.faceBox)}
-                                    />
-                                ))}
+                                {showFaceBoxes &&
+                                    photo.faces?.map((face, index) => (
+                                        <FaceOverlay
+                                            key={face.id}
+                                            face={face}
+                                            index={index}
+                                            style={calculateFacePosition(face.faceBox)}
+                                        />
+                                    ))}
                             </div>
                         </CardContent>
                     </Card>
@@ -281,11 +284,23 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                             {/* Faces Summary */}
                             {photo.faces && photo.faces.length > 0 && (
                                 <Card className="bg-card border-border">
-                                    <CardHeader className="pb-3">
+                                <CardHeader className="pb-3">
+                                    <div className="flex items-center justify-between">
                                         <CardTitle className="text-lg">
                                             Detected Faces ({photo.faces.length})
                                         </CardTitle>
-                                    </CardHeader>
+                                        <div className="flex items-center space-x-2">
+                                            <Checkbox
+                                                id="show-face-boxes"
+                                                checked={showFaceBoxes}
+                                                onCheckedChange={(v) => setShowFaceBoxes(!!v)}
+                                            />
+                                            <Label htmlFor="show-face-boxes" className="text-sm">
+                                                Show face boxes
+                                            </Label>
+                                        </div>
+                                    </div>
+                                </CardHeader>
                                     <CardContent>
                                         <p className="text-sm text-muted-foreground mb-3">
                                             Hover over the blue boxes on the image to see face details.

--- a/Photobank.Ts/packages/frontend/test/PhotoDetailsPage.test.tsx
+++ b/Photobank.Ts/packages/frontend/test/PhotoDetailsPage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -83,5 +83,17 @@ describe('PhotoDetailsPage', () => {
     expect(screen.getByText('Photo Properties')).toBeTruthy();
     expect(screen.getByDisplayValue('Test Photo')).toBeTruthy();
     expect(screen.getAllByDisplayValue('1').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Show face boxes')).toBeTruthy();
+  });
+
+  it('toggles face boxes visibility', async () => {
+    await renderPage();
+    const checkbox = screen.getByLabelText('Show face boxes');
+    expect(checkbox.getAttribute('data-state')).toBe('checked');
+    expect(document.querySelectorAll('.face-box').length).toBeGreaterThan(0);
+    fireEvent.click(checkbox);
+    await waitFor(() => {
+      expect(checkbox.getAttribute('data-state')).toBe('unchecked');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add ability to toggle face boxes on PhotoDetailsPage
- include checkbox in Detected Faces header
- test new toggle behaviour

## Testing
- `pnpm -r test`
- `dotnet test PhotoBank.sln -v minimal` *(fails: .NET SDK 9.0 required)*

------
https://chatgpt.com/codex/tasks/task_e_6872053b26a08328833b96235b6ce4a2