### PR TITLE
Fix PhotoDetailsModal fullscreen opening

### DIFF
--- a/Photobank.Ts/packages/frontend/src/components/PhotoDetailsModal.tsx
+++ b/Photobank.Ts/packages/frontend/src/components/PhotoDetailsModal.tsx
@@ -9,7 +9,10 @@ interface PhotoDetailsModalProps {
 const PhotoDetailsModal = ({ photoId, onOpenChange }: PhotoDetailsModalProps) => {
     return (
         <Dialog open={photoId !== null} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-none w-screen h-screen top-0 left-0 translate-x-0 translate-y-0 p-0" showCloseButton={true}>
+            <DialogContent
+                className="!max-w-none sm:!max-w-none w-screen h-screen top-0 left-0 translate-x-0 translate-y-0 p-0"
+                showCloseButton={true}
+            >
                 {photoId !== null && <PhotoDetailsPage photoId={photoId} />}
             </DialogContent>
         </Dialog>


### PR DESCRIPTION
## Summary
- make PhotoDetailsModal fully overwrite max-width styles so it fills the screen immediately

## Testing
- `pnpm run lint` *(fails: import/order and other existing issues)*
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_6872063e60fc8328a3ccaceb2156f47d