### PR TITLE
Add orientation helper

### DIFF
--- a/Photobank.Ts/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import { formatDate } from '@photobank/shared';
+import { formatDate, getOrientation } from '@photobank/shared';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {Badge} from '@/components/ui/badge';
@@ -222,7 +222,7 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                     {photo.orientation && (
                                         <div>
                                             <Label className="text-muted-foreground text-xs">Orientation</Label>
-                                            <Input value={photo.orientation.toString()} readOnly
+                                            <Input value={getOrientation(photo.orientation)} readOnly
                                                    className="mt-1 bg-muted"/>
                                         </div>
                                     )}

--- a/Photobank.Ts/packages/shared/src/index.ts
+++ b/Photobank.Ts/packages/shared/src/index.ts
@@ -15,6 +15,7 @@ export const getGenderText = (gender?: boolean) => {
 };
 
 export { getFilterHash } from './utils/getFilterHash';
+export { getOrientation } from './utils/getOrientation';
 export {
   cachePhoto,
   getCachedPhoto,

--- a/Photobank.Ts/packages/shared/src/utils/getOrientation.ts
+++ b/Photobank.Ts/packages/shared/src/utils/getOrientation.ts
@@ -1,0 +1,14 @@
+export function getOrientation(orientation?: number): string {
+  const map: Record<number, string> = {
+    1: 'Normal',
+    2: 'Flip horizontal',
+    3: 'Rotate 180°',
+    4: 'Flip vertical',
+    5: 'Flip horizontal and rotate 270°',
+    6: 'Rotate 90°',
+    7: 'Flip horizontal and rotate 90°',
+    8: 'Rotate 270°',
+  };
+  if (orientation === undefined) return 'unknown';
+  return map[orientation] ?? `unknown (${orientation})`;
+}

--- a/Photobank.Ts/packages/shared/test/getOrientation.test.ts
+++ b/Photobank.Ts/packages/shared/test/getOrientation.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { getOrientation } from '../src/utils/getOrientation';
+
+describe('getOrientation', () => {
+  it('returns friendly text for known values', () => {
+    expect(getOrientation(1)).toBe('Normal');
+    expect(getOrientation(6)).toBe('Rotate 90°');
+  });
+
+  it('handles unknown values', () => {
+    expect(getOrientation(99)).toBe('unknown (99)');
+  });
+
+  it('handles undefined', () => {
+    expect(getOrientation()).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary
- add getOrientation helper in shared package to convert EXIF orientation codes
- show orientation with getOrientation on photo detail page
- export getOrientation from shared index
- test the new helper

## Testing
- `pnpm -r test`
- `dotnet test PhotoBank.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68724d7ae19c8328869eca6705f98964