### PR TITLE
Fix impersonated user role retrieval

### DIFF
--- a/PhotoBank.Api/Controllers/AuthController.cs
+++ b/PhotoBank.Api/Controllers/AuthController.cs
@@ -4,8 +4,10 @@ using Microsoft.AspNetCore.Mvc;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
+using PhotoBank.Api.Middleware;
 using System.Linq;
 using System.Collections.Generic;
+using System.Security.Claims;
 
 namespace PhotoBank.Api.Controllers;
 
@@ -65,7 +67,11 @@ public class AuthController(
     [ProducesResponseType(typeof(UserDto), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetUser()
     {
-        var user = await userManager.GetUserAsync(User);
+        var principal = HttpContext.Items.ContainsKey(ImpersonationMiddleware.ImpersonatedPrincipalKey) &&
+                        HttpContext.Items[ImpersonationMiddleware.ImpersonatedPrincipalKey] is ClaimsPrincipal impersonated
+            ? impersonated
+            : User;
+        var user = await userManager.GetUserAsync(principal);
         if (user == null)
             return NotFound();
 
@@ -83,7 +89,11 @@ public class AuthController(
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> UpdateUser([FromBody] UpdateUserDto dto)
     {
-        var user = await userManager.GetUserAsync(User);
+        var principal = HttpContext.Items.ContainsKey(ImpersonationMiddleware.ImpersonatedPrincipalKey) &&
+                        HttpContext.Items[ImpersonationMiddleware.ImpersonatedPrincipalKey] is ClaimsPrincipal impersonated
+            ? impersonated
+            : User;
+        var user = await userManager.GetUserAsync(principal);
         if (user == null)
             return NotFound();
 
@@ -101,7 +111,11 @@ public class AuthController(
     [ProducesResponseType(typeof(IEnumerable<ClaimDto>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetUserClaims()
     {
-        var user = await userManager.GetUserAsync(User);
+        var principal = HttpContext.Items.ContainsKey(ImpersonationMiddleware.ImpersonatedPrincipalKey) &&
+                        HttpContext.Items[ImpersonationMiddleware.ImpersonatedPrincipalKey] is ClaimsPrincipal impersonated
+            ? impersonated
+            : User;
+        var user = await userManager.GetUserAsync(principal);
         if (user == null)
             return NotFound();
 
@@ -115,7 +129,11 @@ public class AuthController(
     [ProducesResponseType(typeof(IEnumerable<RoleDto>), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetUserRoles()
     {
-        var user = await userManager.GetUserAsync(User);
+        var principal = HttpContext.Items.ContainsKey(ImpersonationMiddleware.ImpersonatedPrincipalKey) &&
+                        HttpContext.Items[ImpersonationMiddleware.ImpersonatedPrincipalKey] is ClaimsPrincipal impersonated
+            ? impersonated
+            : User;
+        var user = await userManager.GetUserAsync(principal);
         if (user == null)
             return NotFound();
 

--- a/PhotoBank.Api/Middleware/ImpersonationMiddleware.cs
+++ b/PhotoBank.Api/Middleware/ImpersonationMiddleware.cs
@@ -28,7 +28,13 @@ public class ImpersonationMiddleware
             {
                 var userClaims = await userManager.GetClaimsAsync(user);
 
-                var impersonatedIdentity = new ClaimsIdentity(userClaims,
+                var impersonatedClaims = new List<Claim>(userClaims)
+                {
+                    new Claim(ClaimTypes.NameIdentifier, user.Id),
+                    new Claim(ClaimTypes.Name, user.UserName ?? string.Empty)
+                };
+
+                var impersonatedIdentity = new ClaimsIdentity(impersonatedClaims,
                     context.User.Identity?.AuthenticationType ?? "Impersonation");
                 var impersonatedPrincipal = new ClaimsPrincipal(impersonatedIdentity);
 
@@ -38,7 +44,7 @@ public class ImpersonationMiddleware
                 {
                     new Claim("ImpersonatedUser", username!)
                 };
-                claims.AddRange(userClaims);
+                claims.AddRange(impersonatedClaims);
                 var identity = new ClaimsIdentity(claims,
                     context.User.Identity?.AuthenticationType ?? "Impersonation");
                 context.User = new ClaimsPrincipal(identity);


### PR DESCRIPTION
## Summary
- ensure the impersonated principal contains identifying claims
- use the impersonated principal when fetching user claims and roles

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68724e94a45c8328833e5b68f0e18656