### PR TITLE
Implement tri-state checkboxes in filter form

### DIFF
--- a/Photobank.Ts/packages/frontend/src/components/FilterFormFields.tsx
+++ b/Photobank.Ts/packages/frontend/src/components/FilterFormFields.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import {format} from 'date-fns';
 
 import {Input} from '@/components/ui/input';
-import {Checkbox} from '@/components/ui/checkbox';
+import {TriStateCheckbox} from '@/components/ui/tri-state-checkbox';
 import {MultiSelect} from '@/components/ui/multi-select';
 import {FormControl, FormField, FormItem, FormLabel, FormMessage,} from '@/components/ui/form';
 import type {FormData} from '@/features/filter/lib/form-schema.ts';
@@ -240,9 +240,9 @@ export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
                     render={({field}) => (
                         <FormItem className="flex flex-row items-start space-x-3 space-y-0">
                             <FormControl>
-                                <Checkbox
-                                    checked={field.value}
-                                    onCheckedChange={field.onChange}
+                                <TriStateCheckbox
+                                    value={field.value}
+                                    onValueChange={field.onChange}
                                 />
                             </FormControl>
                             <div className="space-y-1 leading-none">
@@ -258,9 +258,9 @@ export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
                     render={({field}) => (
                         <FormItem className="flex flex-row items-start space-x-3 space-y-0">
                             <FormControl>
-                                <Checkbox
-                                    checked={field.value}
-                                    onCheckedChange={field.onChange}
+                                <TriStateCheckbox
+                                    value={field.value}
+                                    onValueChange={field.onChange}
                                 />
                             </FormControl>
                             <div className="space-y-1 leading-none">
@@ -276,9 +276,9 @@ export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
                     render={({field}) => (
                         <FormItem className="flex flex-row items-start space-x-3 space-y-0">
                             <FormControl>
-                                <Checkbox
-                                    checked={field.value}
-                                    onCheckedChange={field.onChange}
+                                <TriStateCheckbox
+                                    value={field.value}
+                                    onValueChange={field.onChange}
                                 />
                             </FormControl>
                             <div className="space-y-1 leading-none">
@@ -294,9 +294,9 @@ export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
                     render={({field}) => (
                         <FormItem className="flex flex-row items-start space-x-3 space-y-0">
                             <FormControl>
-                                <Checkbox
-                                    checked={field.value}
-                                    onCheckedChange={field.onChange}
+                                <TriStateCheckbox
+                                    value={field.value}
+                                    onValueChange={field.onChange}
                                 />
                             </FormControl>
                             <div className="space-y-1 leading-none">

--- a/Photobank.Ts/packages/frontend/src/components/ui/tri-state-checkbox.tsx
+++ b/Photobank.Ts/packages/frontend/src/components/ui/tri-state-checkbox.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import * as React from "react"
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
+import { CheckIcon, MinusIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+interface TriStateCheckboxProps extends Omit<React.ComponentProps<typeof CheckboxPrimitive.Root>, "checked" | "onCheckedChange"> {
+  value: boolean | undefined
+  onValueChange: (value: boolean | undefined) => void
+}
+
+function TriStateCheckbox({
+  className,
+  value,
+  onValueChange,
+  ...props
+}: TriStateCheckboxProps) {
+  const handleChange = React.useCallback(() => {
+    if (value === true) {
+      onValueChange(false)
+    } else if (value === false) {
+      onValueChange(undefined)
+    } else {
+      onValueChange(true)
+    }
+  }, [value, onValueChange])
+
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      checked={value === undefined ? "indeterminate" : value}
+      onCheckedChange={handleChange}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current transition-none"
+      >
+        {value === undefined ? <MinusIcon className="size-3.5" /> : <CheckIcon className="size-3.5" />}
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { TriStateCheckbox }

--- a/Photobank.Ts/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -32,7 +32,7 @@ function FilterPage() {
       isBW: savedFilter.isBW,
       isAdultContent: savedFilter.isAdultContent,
       isRacyContent: savedFilter.isRacyContent,
-      thisDay: savedFilter.thisDay ?? true,
+      thisDay: savedFilter.thisDay,
       dateFrom: savedFilter.takenDateFrom ? new Date(savedFilter.takenDateFrom) : undefined,
       dateTo: savedFilter.takenDateTo ? new Date(savedFilter.takenDateTo) : undefined,
     },


### PR DESCRIPTION
## Summary
- add `TriStateCheckbox` to allow `undefined` values
- use tri-state checkboxes in filter form fields
- keep checkbox default values undefined

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68710ab7b3b883289145b52dceeda4d2