### PR TITLE
Add auth guard and update face box checkbox

### DIFF
--- a/Photobank.Ts/packages/frontend/src/app/App.tsx
+++ b/Photobank.Ts/packages/frontend/src/app/App.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 
 import { ThemeProvider } from '@/app/providers/ThemeProvider.tsx';
 import NavBar from '@/components/NavBar.tsx';
+import { getAuthToken } from '@photobank/shared/api';
 import type { AppDispatch, RootState } from '@/app/store.ts';
 import { loadMetadata } from '@/features/meta/model/metaSlice.ts';
 import { AppRoutes } from '@/routes/AppRoutes.tsx';
@@ -10,6 +11,7 @@ import { AppRoutes } from '@/routes/AppRoutes.tsx';
 export default function App() {
   const dispatch = useDispatch<AppDispatch>();
   const loaded = useSelector((s: RootState) => s.metadata.loaded);
+  const loggedIn = Boolean(getAuthToken());
 
   useEffect(() => {
     if (!loaded) {
@@ -19,7 +21,7 @@ export default function App() {
 
   return (
     <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
-      <NavBar />
+      {loggedIn && <NavBar />}
       <AppRoutes />
     </ThemeProvider>
   );

--- a/Photobank.Ts/packages/frontend/src/app/RequireAuth.tsx
+++ b/Photobank.Ts/packages/frontend/src/app/RequireAuth.tsx
@@ -1,0 +1,13 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { getAuthToken } from '@photobank/shared/api';
+
+export default function RequireAuth() {
+  const location = useLocation();
+  const token = getAuthToken();
+
+  if (!token) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
+}

--- a/Photobank.Ts/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -41,7 +41,7 @@ interface PhotoDetailsPageProps {
 const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
     const [imageDisplaySize, setImageDisplaySize] = useState({width: 0, height: 0, scale: 1});
     const [containerSize, setContainerSize] = useState({width: 0, height: 0});
-    const [showFaceBoxes, setShowFaceBoxes] = useState(true);
+    const [showFaceBoxes, setShowFaceBoxes] = useState(false);
     const persons = useSelector((state: RootState) => state.metadata.persons);
 
     const containerRef = useRef<HTMLDivElement>(null);

--- a/Photobank.Ts/packages/frontend/src/routes/AppRoutes.tsx
+++ b/Photobank.Ts/packages/frontend/src/routes/AppRoutes.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
+import RequireAuth from '@/app/RequireAuth.tsx';
 
 import PhotoListPage from '@/pages/list/PhotoListPage.tsx';
 import FilterPage from '@/pages/filter/FilterPage.tsx';
@@ -9,12 +10,15 @@ import MyProfilePage from '@/pages/profile/MyProfilePage.tsx';
 
 export const AppRoutes = () => (
   <Routes>
-    <Route path="/" element={<Navigate to="/filter" />} />
     <Route path="/login" element={<LoginPage />} />
-    <Route path="/logout" element={<LogoutPage />} />
-    <Route path="/profile" element={<MyProfilePage />} />
-    <Route path="/filter" element={<FilterPage />} />
-    <Route path="/photos" element={<PhotoListPage />} />
-    <Route path="/photos/:id" element={<PhotoDetailsPage />} />
+    <Route element={<RequireAuth />}>
+      <Route path="/" element={<Navigate to="/filter" />} />
+      <Route path="/logout" element={<LogoutPage />} />
+      <Route path="/profile" element={<MyProfilePage />} />
+      <Route path="/filter" element={<FilterPage />} />
+      <Route path="/photos" element={<PhotoListPage />} />
+      <Route path="/photos/:id" element={<PhotoDetailsPage />} />
+    </Route>
+    <Route path="*" element={<Navigate to="/login" replace />} />
   </Routes>
 );

--- a/Photobank.Ts/packages/frontend/test/PhotoDetailsPage.test.tsx
+++ b/Photobank.Ts/packages/frontend/test/PhotoDetailsPage.test.tsx
@@ -89,11 +89,12 @@ describe('PhotoDetailsPage', () => {
   it('toggles face boxes visibility', async () => {
     await renderPage();
     const checkbox = screen.getByLabelText('Show face boxes');
-    expect(checkbox.getAttribute('data-state')).toBe('checked');
-    expect(document.querySelectorAll('.face-box').length).toBeGreaterThan(0);
+    expect(checkbox.getAttribute('data-state')).toBe('unchecked');
+    expect(document.querySelectorAll('.face-box').length).toBe(0);
     fireEvent.click(checkbox);
     await waitFor(() => {
-      expect(checkbox.getAttribute('data-state')).toBe('unchecked');
+      expect(checkbox.getAttribute('data-state')).toBe('checked');
+      expect(document.querySelectorAll('.face-box').length).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
- show face boxes unchecked by default
- redirect unauthorized users to login
- hide navigation when logged out
- update tests for new checkbox behavior

## Testing
- `pnpm test` in `Photobank.Ts/packages/frontend`
- `pnpm test` in `Photobank.Ts/packages/shared`


------
https://chatgpt.com/codex/tasks/task_e_68726daa943483289dcbadded78dddd3