### PR TITLE
Implement default photo filter logic

### DIFF
--- a/Photobank.Ts/packages/frontend/src/features/photo/model/photoSlice.ts
+++ b/Photobank.Ts/packages/frontend/src/features/photo/model/photoSlice.ts
@@ -1,5 +1,7 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
+import { DEFAULT_PHOTO_FILTER } from '@/shared/constants.ts';
+
 import type { FilterDto, PhotoItemDto } from '@photobank/shared/types';
 
 interface PhotoState {
@@ -9,7 +11,7 @@ interface PhotoState {
 }
 
 const initialState: PhotoState = {
-  filter: { top: 10 },
+  filter: { ...DEFAULT_PHOTO_FILTER },
   selectedPhotos: [],
   lastResult: [],
 };
@@ -22,7 +24,7 @@ const photoSlice = createSlice({
       state.filter = action.payload;
     },
     resetFilter(state) {
-      state.filter = { top: 10 };
+      state.filter = { ...DEFAULT_PHOTO_FILTER };
     },
     setSelectedPhotos(state, action: PayloadAction<number[]>) {
       state.selectedPhotos = action.payload;

--- a/Photobank.Ts/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -2,7 +2,7 @@ import {useForm} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import type {z} from 'zod';
 
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useAppDispatch } from '@/app/hook.ts';
 import { useSelector } from 'react-redux';
 import type { RootState } from '@/app/store.ts';
@@ -12,6 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Form } from '@/components/ui/form';
 import { formSchema } from '@/features/filter/lib/form-schema.ts';
 import { FilterFormFields } from '@/components/FilterFormFields.tsx';
+import { DEFAULT_FORM_VALUES } from '@/shared/constants.ts';
 
 // Infer FormData type from formSchema to ensure compatibility
 type FormData = z.infer<typeof formSchema>;
@@ -19,23 +20,28 @@ type FormData = z.infer<typeof formSchema>;
 function FilterPage() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
   const savedFilter = useSelector((state: RootState) => state.photo.filter);
+
+  const useCurrentFilter = (location.state as { useCurrentFilter?: boolean } | null)?.useCurrentFilter;
+
+  const savedDefaults = {
+    caption: savedFilter.caption,
+    storages: savedFilter.storages?.map(String) ?? [],
+    paths: savedFilter.paths?.map(String) ?? [],
+    persons: savedFilter.persons?.map(String) ?? [],
+    tags: savedFilter.tags?.map(String) ?? [],
+    isBW: savedFilter.isBW,
+    isAdultContent: savedFilter.isAdultContent,
+    isRacyContent: savedFilter.isRacyContent,
+    thisDay: savedFilter.thisDay,
+    dateFrom: savedFilter.takenDateFrom ? new Date(savedFilter.takenDateFrom) : undefined,
+    dateTo: savedFilter.takenDateTo ? new Date(savedFilter.takenDateTo) : undefined,
+  } as const;
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
-      caption: savedFilter.caption,
-      storages: savedFilter.storages?.map(String) ?? [],
-      paths: savedFilter.paths?.map(String) ?? [],
-      persons: savedFilter.persons?.map(String) ?? [],
-      tags: savedFilter.tags?.map(String) ?? [],
-      isBW: savedFilter.isBW,
-      isAdultContent: savedFilter.isAdultContent,
-      isRacyContent: savedFilter.isRacyContent,
-      thisDay: savedFilter.thisDay,
-      dateFrom: savedFilter.takenDateFrom ? new Date(savedFilter.takenDateFrom) : undefined,
-      dateTo: savedFilter.takenDateTo ? new Date(savedFilter.takenDateTo) : undefined,
-    },
+    defaultValues: useCurrentFilter ? savedDefaults : { ...DEFAULT_FORM_VALUES },
   });
 
   const onSubmit = (data: FormData) => {

--- a/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -86,7 +86,7 @@ const PhotoListPage = () => {
         <Button
           variant="outline"
           onClick={() => {
-            navigate('/filter');
+            navigate('/filter', { state: { useCurrentFilter: true } });
           }}
         >
           Filter

--- a/Photobank.Ts/packages/frontend/src/shared/constants.ts
+++ b/Photobank.Ts/packages/frontend/src/shared/constants.ts
@@ -9,3 +9,23 @@ export const MAX_VISIBLE_TAGS_SM = 2;
 
 export const PHOTOS_CACHE_KEY = 'photobank_photos_cache';
 export const PHOTOS_CACHE_VERSION = 1;
+
+export const DEFAULT_PHOTO_FILTER = {
+  thisDay: true,
+  skip: 0,
+  top: 10,
+} as const;
+
+export const DEFAULT_FORM_VALUES = {
+  caption: undefined,
+  storages: [],
+  paths: [],
+  persons: [],
+  tags: [],
+  isBW: undefined,
+  isAdultContent: undefined,
+  isRacyContent: undefined,
+  thisDay: undefined,
+  dateFrom: undefined,
+  dateTo: undefined,
+} as const;

--- a/Photobank.Ts/packages/frontend/test/photoSlice.test.ts
+++ b/Photobank.Ts/packages/frontend/test/photoSlice.test.ts
@@ -6,13 +6,14 @@ import reducer, {
   resetFilter,
   setLastResult,
 } from '../src/features/photo/model/photoSlice';
+import { DEFAULT_PHOTO_FILTER } from '../src/shared/constants';
 
 describe('photoSlice', () => {
   it('sets and resets filter', () => {
     let state = reducer(undefined, setFilter({ caption: 'foo' } as any));
     expect(state.filter).toEqual({ caption: 'foo' });
     state = reducer(state, resetFilter());
-    expect(state.filter).toEqual({ top: 10 });
+    expect(state.filter).toEqual(DEFAULT_PHOTO_FILTER);
   });
 
   it('manages selected photos without duplicates', () => {


### PR DESCRIPTION
## Summary
- add constants for default filter and form values
- default redux state uses new default filter
- adjust FilterPage to optionally load current filter
- keep filter when navigating from photo list page
- update slice test cases

## Testing
- `pnpm test` in `Photobank.Ts/packages/frontend`
- `pnpm -r test` in `Photobank.Ts`

------
https://chatgpt.com/codex/tasks/task_e_6872751a6e088328a878c32d04a429f8