### PR TITLE
Add TV auto login

### DIFF
--- a/Photobank.Ts/packages/shared/src/api/auth.ts
+++ b/Photobank.Ts/packages/shared/src/api/auth.ts
@@ -16,9 +16,9 @@ export const getAuthToken = () => authToken;
 
 export const setAuthToken = (token: string, remember = true) => {
   authToken = token;
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
     const hasSession = typeof window.sessionStorage !== 'undefined';
-    const storage = remember || !hasSession ? localStorage : window.sessionStorage;
+    const storage = remember || !hasSession ? window.localStorage : window.sessionStorage;
     storage.setItem(AUTH_TOKEN_KEY, token);
     if (hasSession) {
       const other = storage === window.localStorage ? window.sessionStorage : window.localStorage;
@@ -29,15 +29,15 @@ export const setAuthToken = (token: string, remember = true) => {
 
 export const clearAuthToken = () => {
   authToken = null;
-  if (typeof window !== 'undefined') {
-    localStorage.removeItem(AUTH_TOKEN_KEY);
+  if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
+    window.localStorage.removeItem(AUTH_TOKEN_KEY);
   }
 };
 
 export const loadAuthToken = () => {
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && typeof window.localStorage !== 'undefined') {
     const saved =
-      localStorage.getItem(AUTH_TOKEN_KEY) ??
+      window.localStorage.getItem(AUTH_TOKEN_KEY) ??
       (typeof window.sessionStorage !== 'undefined'
         ? window.sessionStorage.getItem(AUTH_TOKEN_KEY)
         : null);

--- a/Photobank.Ts/packages/tv/App.tsx
+++ b/Photobank.Ts/packages/tv/App.tsx
@@ -1,10 +1,13 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { HomeScreen } from './screens/HomeScreen';
+import { useAutoLogin } from './hooks/useAutoLogin';
 
 export default function App() {
+  useAutoLogin();
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
+      <HomeScreen />
       <StatusBar style="auto" />
     </View>
   );

--- a/Photobank.Ts/packages/tv/config.ts
+++ b/Photobank.Ts/packages/tv/config.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_EMAIL = 'admin@example.com';
+export const DEFAULT_PASSWORD = 'secret';

--- a/Photobank.Ts/packages/tv/hooks/useAutoLogin.ts
+++ b/Photobank.Ts/packages/tv/hooks/useAutoLogin.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { login } from '@photobank/shared/api';
+import { DEFAULT_EMAIL, DEFAULT_PASSWORD } from '../config';
+
+export function useAutoLogin() {
+  useEffect(() => {
+    async function doLogin() {
+      try {
+        console.log('Logging in with default credentials');
+        await login({ email: DEFAULT_EMAIL, password: DEFAULT_PASSWORD });
+        console.log('Login success');
+      } catch (e) {
+        console.error('Login failed', e);
+      }
+    }
+
+    void doLogin();
+  }, []);
+}


### PR DESCRIPTION
## Summary
- support optional `localStorage` in auth helpers
- add default credentials config for TV app
- auto-login in TV app on startup

## Testing
- `pnpm -r test`
- `dotnet test PhotoBank.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687297e85ccc8328a788cfe199826648