### PR TITLE
Fix DateTimePicker compile error in tv app

### DIFF
--- a/Photobank.Ts/packages/frontend/test/photoSlice.test.ts
+++ b/Photobank.Ts/packages/frontend/test/photoSlice.test.ts
@@ -6,7 +6,7 @@ import reducer, {
   resetFilter,
   setLastResult,
 } from '../src/features/photo/model/photoSlice';
-import { DEFAULT_PHOTO_FILTER } from '../src/shared/constants';
+import { DEFAULT_PHOTO_FILTER } from '@photobank/shared/constants';
 
 describe('photoSlice', () => {
   it('sets and resets filter', () => {

--- a/Photobank.Ts/packages/shared/src/utils/getFilterHash.ts
+++ b/Photobank.Ts/packages/shared/src/utils/getFilterHash.ts
@@ -26,7 +26,7 @@ export async function getFilterHash(filter: FilterDto): Promise<string> {
 
     if (isNode()) {
         // Node.js: use built-in crypto
-        const { createHash } = await import('node:crypto');
+        const { createHash } = await import('crypto');
         return createHash('sha256').update(json).digest('hex');
     }
 

--- a/Photobank.Ts/packages/shared/tsconfig.json
+++ b/Photobank.Ts/packages/shared/tsconfig.json
@@ -6,6 +6,7 @@
     "declarationMap": true,
     "emitDeclarationOnly": false,
     "outDir": "dist",
+    "types": ["node"],
     "rootDir": "src"
   },
   "include": ["src"]

--- a/Photobank.Ts/packages/tv/components/PhotoFilters.tsx
+++ b/Photobank.Ts/packages/tv/components/PhotoFilters.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { View, Text, Button, StyleSheet } from "react-native";
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
+import type { ComponentType } from "react";
 import { FilterDto } from "@photobank/shared/types";
 import { DEFAULT_PHOTO_FILTER } from '@photobank/shared/constants';
 
@@ -11,6 +12,7 @@ export const PhotoFilters = ({
 }) => {
   const [filter, setFilter] = useState<FilterDto>(DEFAULT_PHOTO_FILTER);
   const [showDatePicker, setShowDatePicker] = useState(false);
+  const Picker = DateTimePicker as unknown as ComponentType<any>;
 
   const applyFilter = () => {
     onApply(filter);
@@ -21,11 +23,11 @@ export const PhotoFilters = ({
       <Text style={styles.title}>Фильтры</Text>
       <Button title="Выбрать дату" onPress={() => setShowDatePicker(true)} />
       {showDatePicker && (
-        <DateTimePicker
+        <Picker
           value={new Date()}
           mode="date"
           display="default"
-          onChange={(e, date) => {
+          onChange={(e: DateTimePickerEvent, date?: Date) => {
             setShowDatePicker(false);
             setFilter({ ...filter, takenDateFrom: date?.toISOString() });
           }}

--- a/Photobank.Ts/packages/tv/components/PhotoGrid.tsx
+++ b/Photobank.Ts/packages/tv/components/PhotoGrid.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, FlatList, StyleSheet } from "react-native";
+import { View, FlatList, StyleSheet, Text } from "react-native";
 import { FilterDto } from "@photobank/shared/types";
 import { PhotoCard } from "./PhotoCard";
 import { usePhotos } from "../hooks/usePhotoApi";

--- a/Photobank.Ts/packages/tv/package.json
+++ b/Photobank.Ts/packages/tv/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@types/node": "^24.0.13",
     "@types/react": "~19.0.10",
     "typescript": "~5.8.3"
   },

--- a/Photobank.Ts/packages/tv/tsconfig.json
+++ b/Photobank.Ts/packages/tv/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "types": ["node"],
     "paths": {
       "@photobank/shared/*": ["../shared/src/*"]
     }

--- a/Photobank.Ts/pnpm-lock.yaml
+++ b/Photobank.Ts/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     devDependencies:
       ts-node-dev:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@24.0.7)(typescript@5.8.3)
+        version: 2.0.0(@types/node@24.0.13)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -257,7 +257,7 @@ importers:
     devDependencies:
       ts-node-dev:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@24.0.7)(typescript@5.8.3)
+        version: 2.0.0(@types/node@24.0.13)(typescript@5.8.3)
       tsx:
         specifier: ^4.20.3
         version: 4.20.3
@@ -301,6 +301,9 @@ importers:
       '@babel/core':
         specifier: ^7.25.2
         version: 7.27.7
+      '@types/node':
+        specifier: ^24.0.13
+        version: 24.0.13
       '@types/react':
         specifier: ~19.0.10
         version: 19.0.14
@@ -2089,6 +2092,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/node@24.0.13':
+    resolution: {integrity: sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==}
 
   '@types/node@24.0.7':
     resolution: {integrity: sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==}
@@ -6794,14 +6800,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -6835,7 +6841,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -7676,7 +7682,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -7691,6 +7697,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/node@24.0.13':
+    dependencies:
+      undici-types: 7.8.0
 
   '@types/node@24.0.7':
     dependencies:
@@ -8152,7 +8162,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.27.7
+      '@babel/types': 7.28.1
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.7
 
@@ -8380,7 +8390,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -8389,7 +8399,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -9596,7 +9606,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.27.7
-      '@babel/parser': 7.27.7
+      '@babel/parser': 7.28.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -9623,7 +9633,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -9633,7 +9643,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9660,7 +9670,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -9668,7 +9678,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -9685,7 +9695,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -10039,7 +10049,7 @@ snapshots:
   metro-transform-plugins@0.82.5:
     dependencies:
       '@babel/core': 7.27.7
-      '@babel/generator': 7.27.5
+      '@babel/generator': 7.28.0
       '@babel/template': 7.27.2
       '@babel/traverse': 7.27.7
       flow-enums-runtime: 0.0.6
@@ -10050,9 +10060,9 @@ snapshots:
   metro-transform-worker@0.82.5:
     dependencies:
       '@babel/core': 7.27.7
-      '@babel/generator': 7.27.5
-      '@babel/parser': 7.27.7
-      '@babel/types': 7.27.7
+      '@babel/generator': 7.28.0
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.1
       flow-enums-runtime: 0.0.6
       metro: 0.82.5
       metro-babel-transformer: 0.82.5
@@ -11199,7 +11209,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node-dev@2.0.0(@types/node@24.0.7)(typescript@5.8.3):
+  ts-node-dev@2.0.0(@types/node@24.0.13)(typescript@5.8.3):
     dependencies:
       chokidar: 3.6.0
       dynamic-dedupe: 0.3.0
@@ -11209,7 +11219,7 @@ snapshots:
       rimraf: 2.7.1
       source-map-support: 0.5.21
       tree-kill: 1.2.2
-      ts-node: 10.9.2(@types/node@24.0.7)(typescript@5.8.3)
+      ts-node: 10.9.2(@types/node@24.0.13)(typescript@5.8.3)
       tsconfig: 7.0.0
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -11217,14 +11227,14 @@ snapshots:
       - '@swc/wasm'
       - '@types/node'
 
-  ts-node@10.9.2(@types/node@24.0.7)(typescript@5.8.3):
+  ts-node@10.9.2(@types/node@24.0.13)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 24.0.7
+      '@types/node': 24.0.13
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3


### PR DESCRIPTION
## Summary
- alias DateTimePicker for React 19 compatibility and type onChange params
- include missing `Text` import in `PhotoGrid`
- tweak `getFilterHash` to import `crypto`
- add Node types to shared and tv tsconfigs
- add `@types/node` dev dep for tv package
- fix test import path for `DEFAULT_PHOTO_FILTER`

## Testing
- `pnpm -r test`
- `npx tsc -p Photobank.Ts/packages/tv/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6872af23b9648328903048d6db684bb5