### PR TITLE
Replace crypto hashing with object-hash

### DIFF
--- a/Photobank.Ts/package.json
+++ b/Photobank.Ts/package.json
@@ -19,7 +19,5 @@
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.8.3"
   },
-  "dependencies": {
-    "crypto-js": "^4.2.0"
-  }
+  "dependencies": {}
 }

--- a/Photobank.Ts/packages/shared/package.json
+++ b/Photobank.Ts/packages/shared/package.json
@@ -6,14 +6,13 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "devDependencies": {
-    "@types/crypto-js": "^4.2.2",
     "@types/node": "^24.0.7",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },
   "dependencies": {
     "axios": "^1.10.0",
-    "crypto-js": "^4.2.0",
+    "object-hash": "^3.0.0",
     "date-fns": "^4.1.0",
     "dexie": "^4.0.11",
     "dotenv": "^17.0.0",

--- a/Photobank.Ts/packages/shared/src/utils/getFilterHash.ts
+++ b/Photobank.Ts/packages/shared/src/utils/getFilterHash.ts
@@ -1,9 +1,9 @@
 import type {FilterDto} from '../types';
-import {isNode} from "@photobank/shared/config";
+import objectHash from 'object-hash';
 
 /**
  * Creates a stable hash for a filter. Works in both Node.js and browser.
- * Uses SHA-256 (secure and supported everywhere).
+ * Uses the `object-hash` package for consistent results.
  */
 export async function getFilterHash(filter: FilterDto): Promise<string> {
     const now = new Date();
@@ -22,29 +22,5 @@ export async function getFilterHash(filter: FilterDto): Promise<string> {
         }
     }
 
-    const json = JSON.stringify(normalized);
-
-    if (isNode()) {
-        // Node.js: use built-in crypto
-        const { createHash } = await import('crypto');
-        return createHash('sha256').update(json).digest('hex');
-    }
-
-    if (typeof crypto !== 'undefined' && crypto.subtle) {
-        const encoder = new TextEncoder();
-        const data = encoder.encode(json);
-        const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-        return bufferToHex(hashBuffer);
-    }
-
-    // Fallback for older browsers
-    const { default: SHA256 } = await import('crypto-js/sha256');
-    return SHA256(json).toString();
-}
-
-// Helper: convert ArrayBuffer to hex string
-function bufferToHex(buffer: ArrayBuffer): string {
-    return Array.from(new Uint8Array(buffer))
-        .map(b => b.toString(16).padStart(2, '0'))
-        .join('');
+    return objectHash(normalized);
 }

--- a/Photobank.Ts/pnpm-lock.yaml
+++ b/Photobank.Ts/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      crypto-js:
-        specifier: ^4.2.0
-        version: 4.2.0
     devDependencies:
       ts-node-dev:
         specifier: ^2.0.0
@@ -211,9 +207,6 @@ importers:
       axios:
         specifier: ^1.10.0
         version: 1.10.0
-      crypto-js:
-        specifier: ^4.2.0
-        version: 4.2.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -226,10 +219,10 @@ importers:
       lru-cache:
         specifier: ^10.4.3
         version: 10.4.3
+      object-hash:
+        specifier: ^3.0.0
+        version: 3.0.0
     devDependencies:
-      '@types/crypto-js':
-        specifier: ^4.2.2
-        version: 4.2.2
       '@types/node':
         specifier: ^24.0.7
         version: 24.0.7
@@ -2066,9 +2059,6 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
-  '@types/crypto-js@4.2.2':
-    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2800,9 +2790,6 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  crypto-js@4.2.0:
-    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -4303,6 +4290,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -7674,8 +7665,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
-  '@types/crypto-js@4.2.2': {}
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -8533,8 +8522,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  crypto-js@4.2.0: {}
 
   crypto-random-string@2.0.0: {}
 
@@ -10213,6 +10200,8 @@ snapshots:
       flow-enums-runtime: 0.0.6
 
   object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 


### PR DESCRIPTION
## Summary
- remove unused crypto-js dependency
- use `object-hash` to compute cache keys
- update lockfile

## Testing
- `pnpm -r test`
- `pnpm --filter @photobank/shared test`


------
https://chatgpt.com/codex/tasks/task_e_6873bf785d88832896d2c506fe92e0d6