### PR TITLE
Add Docker Compose setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Connection string to external MS SQL
+DB_CONNECTION=Server=server;Database=Photobank;User Id=user;Password=pass;Encrypt=False;
+
+# Telegram bot credentials
+BOT_TOKEN=your_token
+API_EMAIL=admin@example.com
+API_PASSWORD=secret

--- a/PhotoBank.Api/Dockerfile
+++ b/PhotoBank.Api/Dockerfile
@@ -1,0 +1,13 @@
+# build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish PhotoBank.Api/PhotoBank.Api.csproj -c Release -o /app/publish
+
+# runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:5066
+EXPOSE 5066
+ENTRYPOINT ["dotnet", "PhotoBank.Api.dll"]

--- a/Photobank.Ts/Dockerfile.frontend
+++ b/Photobank.Ts/Dockerfile.frontend
@@ -2,4 +2,4 @@ FROM node:20-alpine
 WORKDIR /app
 COPY . .
 RUN corepack enable && pnpm install
-CMD ["pnpm", "--filter", "telegram-bot", "start"]
+CMD ["pnpm", "--filter", "frontend", "dev"]

--- a/Photobank.Ts/packages/shared/src/config.ts
+++ b/Photobank.Ts/packages/shared/src/config.ts
@@ -1,4 +1,6 @@
-export const API_BASE_URL: string = "http://192.168.1.45:5066"
+export const API_BASE_URL: string =
+    (typeof process !== 'undefined' && process.env.API_BASE_URL) ||
+    "http://192.168.1.45:5066";
 
 export function isBrowser(): boolean {
     return typeof window !== 'undefined' && typeof window.crypto !== 'undefined';

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ cd Photobank.Ts
 pnpm -r test
 ```
 
+### Docker Compose
+
+```
+cp .env.example .env
+docker compose up --build
+```
+
 ## Лицензия
 
 Проект распространяется под лицензией MIT. Текст лицензии находится в файле [LICENSE](LICENSE).
@@ -172,6 +179,13 @@ For Node.js packages:
 ```bash
 cd Photobank.Ts
 pnpm -r test
+```
+
+### Docker Compose
+
+```
+cp .env.example .env
+docker compose up --build
 ```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  api:
+    build:
+      context: .
+      dockerfile: PhotoBank.Api/Dockerfile
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ConnectionStrings__DefaultConnection=${DB_CONNECTION}
+    ports:
+      - "5066:5066"
+  frontend:
+    build:
+      context: ./Photobank.Ts
+      dockerfile: Dockerfile.frontend
+    environment:
+      - API_BASE_URL=http://api:5066
+    ports:
+      - "5173:5173"
+    depends_on:
+      - api
+  bot:
+    build:
+      context: ./Photobank.Ts
+      dockerfile: packages/telegram-bot/Dockerfile
+    environment:
+      - BOT_TOKEN=${BOT_TOKEN}
+      - API_EMAIL=${API_EMAIL}
+      - API_PASSWORD=${API_PASSWORD}
+      - API_BASE_URL=http://api:5066
+    depends_on:
+      - api


### PR DESCRIPTION
## Summary
- add Dockerfiles for API, frontend, and telegram bot
- configure docker-compose and environment example
- allow API base URL to come from env
- document docker compose workflow

## Testing
- `pnpm -r test`
- ❌ `dotnet test PhotoBank.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a93e38fc83288b772a34b50f3370