### PR TITLE
Fix frontend build by updating checkbox props

### DIFF
--- a/Photobank.Ts/package.json
+++ b/Photobank.Ts/package.json
@@ -16,8 +16,8 @@
   "license": "ISC",
   "packageManager": "pnpm@10.12.4",
   "devDependencies": {
+    "@types/object-hash": "^3.0.6",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.8.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/Photobank.Ts/packages/frontend/src/components/ui/tri-state-checkbox.tsx
+++ b/Photobank.Ts/packages/frontend/src/components/ui/tri-state-checkbox.tsx
@@ -6,9 +6,12 @@ import { CheckIcon, MinusIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-interface TriStateCheckboxProps extends Omit<React.ComponentProps<typeof CheckboxPrimitive.Root>, "checked" | "onCheckedChange"> {
-  value: boolean | undefined
-  onValueChange: (value: boolean | undefined) => void
+interface TriStateCheckboxProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>,
+  "checked" | "onCheckedChange" | "value"
+> {
+  value: CheckboxPrimitive.CheckedState | undefined
+  onValueChange: (value: CheckboxPrimitive.CheckedState | undefined) => void
 }
 
 function TriStateCheckbox({

--- a/Photobank.Ts/packages/frontend/src/main.tsx
+++ b/Photobank.Ts/packages/frontend/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';

--- a/Photobank.Ts/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/Photobank.Ts/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -37,7 +37,7 @@ function FilterPage() {
     thisDay: savedFilter.thisDay,
     dateFrom: savedFilter.takenDateFrom ? new Date(savedFilter.takenDateFrom) : undefined,
     dateTo: savedFilter.takenDateTo ? new Date(savedFilter.takenDateTo) : undefined,
-  } as const;
+  };
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),

--- a/Photobank.Ts/packages/frontend/src/shared/constants.ts
+++ b/Photobank.Ts/packages/frontend/src/shared/constants.ts
@@ -19,4 +19,4 @@ export const DEFAULT_FORM_VALUES = {
   thisDay: undefined,
   dateFrom: undefined,
   dateTo: undefined,
-} as const;
+};

--- a/Photobank.Ts/packages/shared/src/constants.ts
+++ b/Photobank.Ts/packages/shared/src/constants.ts
@@ -1,4 +1,4 @@
-import {FilterDto} from "@photobank/shared/types";
+import type { FilterDto } from "@photobank/shared/types";
 
 export const DEFAULT_PHOTO_FILTER: FilterDto = {
     thisDay: true,

--- a/Photobank.Ts/pnpm-lock.yaml
+++ b/Photobank.Ts/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/object-hash':
+        specifier: ^3.0.6
+        version: 3.0.6
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@24.0.13)(typescript@5.8.3)
@@ -2149,6 +2152,9 @@ packages:
 
   '@types/node@24.0.7':
     resolution: {integrity: sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==}
+
+  '@types/object-hash@3.0.6':
+    resolution: {integrity: sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==}
 
   '@types/react-dom@19.1.6':
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
@@ -7869,6 +7875,8 @@ snapshots:
   '@types/node@24.0.7':
     dependencies:
       undici-types: 7.8.0
+
+  '@types/object-hash@3.0.6': {}
 
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
     dependencies:


### PR DESCRIPTION
## Summary
- add `@types/object-hash` dev dependency
- adjust TriStateCheckbox props typing
- drop unused React import
- remove readonly casts from filter defaults
- import FilterDto as a type-only reference
- update lockfile

## Testing
- `pnpm --filter frontend build`
- `pnpm -r run test`


------
https://chatgpt.com/codex/tasks/task_e_6877b65e78948328a1b5256e94473e99