### PR TITLE
Fix tsconfig extend

### DIFF
--- a/Photobank.Ts/packages/shared/tsconfig.json
+++ b/Photobank.Ts/packages/shared/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
     "declaration": true,

--- a/Photobank.Ts/packages/tsconfig.base.json
+++ b/Photobank.Ts/packages/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": "./",
+    "paths": {
+      "@photobank/shared/*": ["shared/src/*"]
+    },
+    "jsx": "react"
+  }
+}

--- a/Photobank.Ts/tsconfig.json
+++ b/Photobank.Ts/tsconfig.json
@@ -1,20 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
-    "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
-    "paths": {
-      "@photobank/shared/*": ["packages/shared/src/*"]
-    },
-    "jsx": "react"
-  }
+  "extends": "./packages/tsconfig.base.json"
 }


### PR DESCRIPTION
## Summary
- add tsconfig.base.json inside packages
- point root tsconfig.json and shared package at the base config
- keep shared compiler options the same

## Testing
- `pnpm --filter shared test`
- `pnpm --filter frontend build`
- `pnpm -r test`


------
https://chatgpt.com/codex/tasks/task_e_6877e77f17648328b564b0d14ecf6c13