### PR TITLE
Fix multiselect fields show saved filter values

### DIFF
--- a/frontend/packages/frontend/src/components/ui/multi-select.tsx
+++ b/frontend/packages/frontend/src/components/ui/multi-select.tsx
@@ -53,6 +53,7 @@ interface MultiSelectProps
         icon?: React.ComponentType<{ className?: string }>;
     }[];
     onValueChange: (value: string[]) => void;
+    value?: string[];
     defaultValue?: string[];
     placeholder?: string;
     animation?: number;
@@ -71,6 +72,7 @@ export const MultiSelect = React.forwardRef<
         {
             options,
             onValueChange,
+            value,
             variant,
             defaultValue = [],
             placeholder = "Select options",
@@ -85,10 +87,16 @@ export const MultiSelect = React.forwardRef<
         ref
     ) => {
         const [selectedValues, setSelectedValues] =
-            React.useState<string[]>(defaultValue);
+            React.useState<string[]>(value ?? defaultValue);
         const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
         const [isAnimating, setIsAnimating] = React.useState(false);
         const [query, setQuery] = React.useState("");
+
+        React.useEffect(() => {
+            if (value !== undefined) {
+                setSelectedValues(value);
+            }
+        }, [value]);
 
         const visibleOptions = React.useMemo(() => {
             const lower = query.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- sync MultiSelect internal state with external `value` prop
- ensure filter dropdowns display saved selections when filter is reopened

## Testing
- `pnpm --filter @photobank/frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68791f75a4b0832899b3337381115f06