### PR TITLE
Add metadata overlay to TV PhotoCard

### DIFF
--- a/frontend/packages/tv/components/PhotoCard.tsx
+++ b/frontend/packages/tv/components/PhotoCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TouchableOpacity, Image, StyleSheet } from 'react-native';
+import { TouchableOpacity, Image, StyleSheet, Text, View } from 'react-native';
 import { PhotoItemDto } from '@photobank/shared/types';
 
 export const PhotoCard = ({ photo, onPress }: { photo: PhotoItemDto; onPress: () => void }) => (
@@ -9,16 +9,35 @@ export const PhotoCard = ({ photo, onPress }: { photo: PhotoItemDto; onPress: ()
           style={styles.image}
           resizeMode="cover"
       />
+      <View style={styles.infoContainer}>
+          <Text style={styles.name}>{photo.name}</Text>
+          {photo.takenDate && <Text style={styles.date}>{photo.takenDate}</Text>}
+          {photo.captions && photo.captions.length > 0 && (
+              <Text style={styles.caption}>{photo.captions[0]}</Text>
+          )}
+      </View>
     </TouchableOpacity>
 );
 
 const styles = StyleSheet.create({
   card: {
-    width: 640,
-    height: 360,
+    width: 50,
+    height: 50,
     marginHorizontal: 20,
-    borderRadius: 20,
+    borderRadius: 10,
     overflow: 'hidden',
+    backgroundColor: '#000',
   },
   image: { width: '100%', height: '100%' },
+  infoContainer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    width: '100%',
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    padding: 2,
+  },
+  name: { color: '#fff', fontSize: 8 },
+  date: { color: '#ccc', fontSize: 6 },
+  caption: { color: '#aaa', fontSize: 6 },
 });


### PR DESCRIPTION
## Summary
- tweak TV PhotoCard thumbnail sizing
- show picture name, taken date and caption on the card

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68795290b2348328abff719492a3561c