### PR TITLE
Fix API base URL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ pnpm install
 pnpm dev
 ```
 
-Перед запуском задайте `API_BASE_URL` (или в `.env` файл) – адрес API, например:
+Перед запуском задайте `VITE_API_BASE_URL` (или в `.env` файл) – адрес API,
+например:
 
 ```bash
-API_BASE_URL=http://localhost:5066
+VITE_API_BASE_URL=http://localhost:5066
 ```
 
 ### Телеграм‑бот
@@ -136,10 +137,10 @@ pnpm install
 pnpm dev
 ```
 
-Before running set `API_BASE_URL` (or put it into `.env`) – the API address, for example:
+Before running set `VITE_API_BASE_URL` (or put it into `.env`) – the API address, for example:
 
 ```bash
-API_BASE_URL=http://localhost:5066
+VITE_API_BASE_URL=http://localhost:5066
 ```
 
 ### Telegram bot

--- a/frontend/packages/shared/src/config.ts
+++ b/frontend/packages/shared/src/config.ts
@@ -1,6 +1,26 @@
-export const API_BASE_URL: string =
-    (typeof process !== 'undefined' && process.env.API_BASE_URL) ||
-    "http://localhost:5066";
+// Determine API base URL from environment variables for both Node and browser
+// contexts. Vite exposes variables prefixed with `VITE_` to the client.
+export const API_BASE_URL: string = (() => {
+    // Vite during build replaces `import.meta.env` with the actual environment
+    // values. Use `VITE_API_BASE_URL` if present.
+    if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE_URL) {
+        return (import.meta as any).env.VITE_API_BASE_URL as string;
+    }
+
+    // When running under Node (e.g. in the Telegram bot) fall back to standard
+    // environment variables.
+    if (typeof process !== 'undefined') {
+        if (process.env.VITE_API_BASE_URL) {
+            return process.env.VITE_API_BASE_URL;
+        }
+        if (process.env.API_BASE_URL) {
+            return process.env.API_BASE_URL;
+        }
+    }
+
+    // Default value used in development when no environment variable is set.
+    return "http://localhost:5066";
+})();
 
 export function isBrowser(): boolean {
     return typeof window !== 'undefined' && typeof window.crypto !== 'undefined';


### PR DESCRIPTION
## Summary
- support `VITE_API_BASE_URL` for frontend builds
- document new env variable name in README

## Testing
- `pnpm -r test`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879f71a22548328b8b8e5a491267e5b