### PR TITLE
Add password visibility toggle

### DIFF
--- a/frontend/packages/frontend/src/components/ui/password-input.tsx
+++ b/frontend/packages/frontend/src/components/ui/password-input.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { Eye, EyeOff } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Input } from "./input"
+
+function PasswordInput({ className, id, ...props }: React.ComponentProps<"input">) {
+  const [visible, setVisible] = React.useState(false)
+
+  return (
+    <div className="relative">
+      <Input
+        id={id}
+        data-testid="password-input"
+        type={visible ? "text" : "password"}
+        className={cn("pr-10", className)}
+        {...props}
+      />
+      <button
+        type="button"
+        onClick={() => setVisible(v => !v)}
+        className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+      >
+        {visible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        <span className="sr-only">{visible ? "Hide password" : "Show password"}</span>
+      </button>
+    </div>
+  )
+}
+
+export { PasswordInput }

--- a/frontend/packages/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/packages/frontend/src/pages/auth/LoginPage.tsx
@@ -9,6 +9,7 @@ import {Button} from '@/components/ui/button';
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
 import {Checkbox} from '@/components/ui/checkbox';
 import {Input} from '@/components/ui/input';
+import {PasswordInput} from '@/components/ui/password-input';
 
 const formSchema = z.object({
   email: z.string().email(),
@@ -71,7 +72,7 @@ export default function LoginPage() {
               <FormItem>
                 <FormLabel>Password</FormLabel>
                 <FormControl>
-                  <Input {...field} type="password" />
+                  <PasswordInput {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/frontend/packages/frontend/test/LoginPage.test.tsx
+++ b/frontend/packages/frontend/test/LoginPage.test.tsx
@@ -40,4 +40,21 @@ describe('LoginPage', () => {
     await screen.findByRole('alert');
     expect(loginMock).toHaveBeenCalled();
   });
+
+  it('toggles password visibility', async () => {
+    const loginMock = vi.fn();
+    await renderPage(loginMock);
+
+    const passwordField = screen.getAllByTestId('password-input')[0];
+    const toggle = screen.getAllByRole('button', { name: /show password/i })[0];
+
+    expect(passwordField.getAttribute('type')).toBe('password');
+
+    fireEvent.click(toggle);
+    expect(passwordField.getAttribute('type')).toBe('text');
+    expect(toggle.textContent).toBe('Hide password');
+
+    fireEvent.click(toggle);
+    expect(passwordField.getAttribute('type')).toBe('password');
+  });
 });


### PR DESCRIPTION
## Summary
- add a PasswordInput component with visibility toggle using lucide icons
- use PasswordInput on the login page
- test toggling password visibility

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_687a00cc5c2483288df618f8bb8ce01e