### PR TITLE
Fix login page reloading loop

### DIFF
--- a/frontend/packages/frontend/src/app/App.tsx
+++ b/frontend/packages/frontend/src/app/App.tsx
@@ -14,10 +14,10 @@ export default function App() {
   const loggedIn = Boolean(getAuthToken());
 
   useEffect(() => {
-    if (!loaded) {
+    if (loggedIn && !loaded) {
       dispatch(loadMetadata());
     }
-  }, [loaded, dispatch]);
+  }, [loaded, loggedIn, dispatch]);
 
   return (
     <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">


### PR DESCRIPTION
## Summary
- load metadata only once user is authenticated to avoid unauthorized API requests that force redirects

## Testing
- `pnpm -C frontend install --frozen-lockfile`
- `pnpm -C frontend/packages/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_687a3d0c336c8328bc261d6825d0ca22