### PR TITLE
Implement error handling and status UI

### DIFF
--- a/frontend/packages/frontend/src/app/store.ts
+++ b/frontend/packages/frontend/src/app/store.ts
@@ -2,12 +2,14 @@ import { configureStore } from '@reduxjs/toolkit';
 
 import metaReducer from '@/features/meta/model/metaSlice.ts';
 import photoReducer from '@/features/photo/model/photoSlice.ts';
+import botReducer from '@/features/bot/model/botSlice.ts';
 import { api } from '@/entities/photo/api.ts';
 
 export const store = configureStore({
   reducer: {
     metadata: metaReducer,
     photo: photoReducer,
+    bot: botReducer,
     [api.reducerPath]: api.reducer,
   },
   middleware: (getDefaultMiddleware) =>

--- a/frontend/packages/frontend/src/components/StatusCard.tsx
+++ b/frontend/packages/frontend/src/components/StatusCard.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { AlertTriangle } from 'lucide-react';
+import { useAppSelector } from '@/app/hook';
+
+export function StatusCard() {
+  const { lastError } = useAppSelector((s) => (s as any).bot);
+  return (
+    <Card className="mx-auto mt-6 max-w-md">
+      <CardContent>
+        {lastError ? (
+          <div className="flex items-center text-red-600">
+            <AlertTriangle className="mr-2" /> {lastError}
+          </div>
+        ) : (
+          <p className="text-green-700">Bot is running</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/packages/frontend/src/features/bot/model/botSlice.ts
+++ b/frontend/packages/frontend/src/features/bot/model/botSlice.ts
@@ -1,0 +1,22 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+interface BotState {
+  lastError: string | null;
+}
+
+const initialState: BotState = {
+  lastError: null,
+};
+
+export const botSlice = createSlice({
+  name: 'bot',
+  initialState,
+  reducers: {
+    setLastError(state, action: PayloadAction<string | null>) {
+      state.lastError = action.payload;
+    },
+  },
+});
+
+export const { setLastError } = botSlice.actions;
+export default botSlice.reducer;

--- a/frontend/packages/frontend/test/botSlice.test.ts
+++ b/frontend/packages/frontend/test/botSlice.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import reducer, { setLastError } from '../src/features/bot/model/botSlice';
+
+describe('botSlice', () => {
+  it('sets lastError correctly', () => {
+    let state = reducer(undefined, setLastError('oops'));
+    expect(state.lastError).toBe('oops');
+    state = reducer(state, setLastError(null));
+    expect(state.lastError).toBeNull();
+  });
+});

--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "tsx src/index.ts",
-    "dev": "tsx watch --inspect-brk=9229 src/index.ts"
+    "dev": "tsx watch --inspect-brk=9229 src/index.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@photobank/shared": "workspace:*",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "ts-node-dev": "^2.0.0",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/packages/telegram-bot/src/commands/thisday.ts
+++ b/frontend/packages/telegram-bot/src/commands/thisday.ts
@@ -1,6 +1,6 @@
 import { Context, InlineKeyboard } from "grammy";
 import { searchPhotos } from "@photobank/shared/api/photos";
-import {firstNWords} from "@photobank/shared/index";
+import { firstNWords } from "@photobank/shared/index";
 
 export const captionCache = new Map<number, string>();
 
@@ -12,14 +12,23 @@ function parsePage(text?: string): number {
     return match ? parseInt(match[1], 10) || 1 : 1;
 }
 
-export async function thisDayCommand(ctx: Context) {
+export async function handleThisDay(ctx: Context) {
     const page = parsePage(ctx.message?.text);
     await sendThisDayPage(ctx, page);
 }
 
+export const thisDayCommand = handleThisDay;
+
 export async function sendThisDayPage(ctx: Context, page: number, edit = false) {
     const skip = (page - 1) * PAGE_SIZE;
-    const queryResult = await searchPhotos({ thisDay: true, top: PAGE_SIZE, skip });
+    let queryResult;
+    try {
+        queryResult = await searchPhotos({ thisDay: true, top: PAGE_SIZE, skip });
+    } catch (err) {
+        console.error("API error:", err);
+        await ctx.reply("Sorry, try to request later.");
+        return;
+    }
 
     if (!queryResult.count || !queryResult.photos?.length) {
         const fallback = "📭 Сегодняшних фото пока нет.";

--- a/frontend/packages/telegram-bot/test/bot.test.ts
+++ b/frontend/packages/telegram-bot/test/bot.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleThisDay } from '../src/commands/thisday';
+import * as photosApi from '@photobank/shared/api/photos';
+
+describe('handleThisDay', () => {
+  it('replies with fallback message on API failure', async () => {
+    const ctx = { reply: vi.fn(), message: { text: '/thisday' } } as any;
+    vi.spyOn(photosApi, 'searchPhotos').mockRejectedValue(new Error('fail'));
+    await handleThisDay(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith('Sorry, try to request later.');
+  });
+});

--- a/frontend/packages/telegram-bot/vitest.config.ts
+++ b/frontend/packages/telegram-bot/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@photobank/shared': path.resolve(__dirname, '../shared/src'),
+      '@photobank/shared/': path.resolve(__dirname, '../shared/src/'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- add `handleThisDay` handler and catch API errors in telegram bot
- add Redux slice to track bot errors
- provide StatusCard component for displaying bot status
- update store configuration
- add vitest configs and tests for new code

## Testing
- `pnpm install`
- `pnpm -r test` *(fails: packages/frontend test failed)*

------
https://chatgpt.com/codex/tasks/task_e_687a404897608328aec9f7db682f238c