### PR TITLE
Move bot strings to shared constants

### DIFF
--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -10,3 +10,20 @@ export const getPhotoErrorMsg = "🚫 Не удалось получить фо�
 export const getProfileErrorMsg = "🚫 Не удалось получить профиль пользователя.";
 export const sorryTryToRequestLaterMsg = "🚫 Извините, попробуйте позже.";
 export const apiErrorMsg = "API error:";
+
+// Telegram bot messages
+export const welcomeBotMsg = "Добро пожаловать. Запущен и работает!";
+export const captionMissingMsg = "Без подписи.";
+export const unknownMessageReplyMsg = "Получил другое сообщение!";
+export const photoCommandUsageMsg = "❗ Используй: /photo <id>";
+export const photoNotFoundMsg = "❌ Фото не найдено.";
+export const todaysPhotosEmptyMsg = "📭 Сегодняшних фото пока нет.";
+export const unknownYearLabel = "Неизвестный год";
+export const prevPageText = "◀ Назад";
+export const nextPageText = "Вперёд ▶";
+export const rolesLabel = "Роли:";
+export const rolesEmptyLabel = "Роли отсутствуют.";
+export const claimsLabel = "Права пользователя:";
+export const claimsEmptyLabel = "Права пользователя отсутствуют.";
+export const botTokenNotDefinedError = "BOT_TOKEN is not defined";
+export const apiCredentialsNotDefinedError = "API_EMAIL or API_PASSWORD is not defined";

--- a/frontend/packages/telegram-bot/src/commands/photoById.ts
+++ b/frontend/packages/telegram-bot/src/commands/photoById.ts
@@ -1,14 +1,19 @@
 import { Context, InputFile } from "grammy";
 import { getPhotoById } from "@photobank/shared/api";
 import { formatPhotoMessage } from "@photobank/shared/utils/formatPhotoMessage";
-import {apiErrorMsg, getPhotoErrorMsg} from "@photobank/shared/constants";
+import {
+    apiErrorMsg,
+    getPhotoErrorMsg,
+    photoCommandUsageMsg,
+    photoNotFoundMsg,
+} from "@photobank/shared/constants";
 
 export async function photoByIdCommand(ctx: Context) {
     const parts = ctx.message?.text?.split(" ");
     const id = Number(parts?.[1]);
 
     if (!id || isNaN(id)) {
-        await ctx.reply("❗ Используй: /photo <id>");
+        await ctx.reply(photoCommandUsageMsg);
         return;
     }
 
@@ -16,7 +21,7 @@ export async function photoByIdCommand(ctx: Context) {
         const photo = await getPhotoById(id);
 
         if (!photo) {
-            await ctx.reply("❌ Фото не найдено.");
+            await ctx.reply(photoNotFoundMsg);
             return;
         }
 

--- a/frontend/packages/telegram-bot/src/commands/photoRouter.ts
+++ b/frontend/packages/telegram-bot/src/commands/photoRouter.ts
@@ -1,5 +1,6 @@
 import { Bot, Context } from "grammy";
-import {sendPhotoById} from "../photo";
+import { sendPhotoById } from "../photo";
+import { photoCommandUsageMsg } from "@photobank/shared/constants";
 
 // Основная команда
 export function registerPhotoRoutes(bot: Bot) {
@@ -8,7 +9,7 @@ export function registerPhotoRoutes(bot: Bot) {
         const parts = ctx.message?.text?.split(" ");
         const id = Number(parts?.[1]);
         if (!id || isNaN(id)) {
-            await ctx.reply("❗ Используй: /photo <id>");
+            await ctx.reply(photoCommandUsageMsg);
             return;
         }
         await sendPhotoById(ctx, id);

--- a/frontend/packages/telegram-bot/src/commands/profile.ts
+++ b/frontend/packages/telegram-bot/src/commands/profile.ts
@@ -1,6 +1,13 @@
 import { Context } from "grammy";
 import { getUserRoles, getUserClaims } from "@photobank/shared/api";
-import {apiErrorMsg, getProfileErrorMsg} from "@photobank/shared/constants";
+import {
+    apiErrorMsg,
+    getProfileErrorMsg,
+    rolesLabel,
+    rolesEmptyLabel,
+    claimsLabel,
+    claimsEmptyLabel,
+} from "@photobank/shared/constants";
 
 export async function profileCommand(ctx: Context) {
     const username = ctx.from?.username ?? String(ctx.from?.id ?? "");
@@ -15,7 +22,7 @@ export async function profileCommand(ctx: Context) {
         ];
 
         if (roles.length) {
-            lines.push("Роли:");
+            lines.push(rolesLabel);
             for (const role of roles) {
                 lines.push(`- ${role.name}`);
                 for (const claim of role.claims) {
@@ -23,16 +30,16 @@ export async function profileCommand(ctx: Context) {
                 }
             }
         } else {
-            lines.push("Роли отсутствуют.");
+            lines.push(rolesEmptyLabel);
         }
 
         if (claims.length) {
-            lines.push("Права пользователя:");
+            lines.push(claimsLabel);
             for (const claim of claims) {
                 lines.push(`- ${claim.type}: ${claim.value}`);
             }
         } else {
-            lines.push("Права пользователя отсутствуют.");
+            lines.push(claimsEmptyLabel);
         }
 
         await ctx.reply(lines.join("\n"));

--- a/frontend/packages/telegram-bot/src/commands/thisday.ts
+++ b/frontend/packages/telegram-bot/src/commands/thisday.ts
@@ -1,7 +1,14 @@
 import {Context, InlineKeyboard} from "grammy";
 import {searchPhotos} from "@photobank/shared/api/photos";
 import {firstNWords} from "@photobank/shared/index";
-import {apiErrorMsg, sorryTryToRequestLaterMsg} from "@photobank/shared/constants";
+import {
+    apiErrorMsg,
+    sorryTryToRequestLaterMsg,
+    todaysPhotosEmptyMsg,
+    unknownYearLabel,
+    prevPageText,
+    nextPageText,
+} from "@photobank/shared/constants";
 
 export const captionCache = new Map<number, string>();
 
@@ -32,7 +39,7 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
     }
 
     if (!queryResult.count || !queryResult.photos?.length) {
-        const fallback = "📭 Сегодняшних фото пока нет.";
+        const fallback = todaysPhotosEmptyMsg;
         if (edit) {
             await ctx.editMessageText(fallback).catch(() => ctx.reply(fallback));
         } else {
@@ -61,7 +68,7 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
     [...byYear.entries()]
         .sort(([a], [b]) => b - a)
         .forEach(([year, folders]) => {
-            sections.push(`📅 <b>${year || "Неизвестный год"}</b>`);
+            sections.push(`📅 <b>${year || unknownYearLabel}</b>`);
             [...folders.entries()].forEach(([folder, photos]) => {
                 sections.push(`📁 ${folder}`);
                 photos.forEach(photo => {
@@ -86,8 +93,8 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
     sections.push(`\n📄 Страница ${page} из ${totalPages}`);
     keyboard.row();
 
-    if (page > 1) keyboard.text("◀ Назад", `thisday:${page - 1}`);
-    if (page < totalPages) keyboard.text("Вперёд ▶", `thisday:${page + 1}`);
+    if (page > 1) keyboard.text(prevPageText, `thisday:${page - 1}`);
+    if (page < totalPages) keyboard.text(nextPageText, `thisday:${page + 1}`);
 
     const text = sections.join("\n\n");
 

--- a/frontend/packages/telegram-bot/src/config.ts
+++ b/frontend/packages/telegram-bot/src/config.ts
@@ -1,13 +1,17 @@
 // packages/telegram-bot/src/config.ts
 import * as dotenv from 'dotenv';
+import {
+  apiCredentialsNotDefinedError,
+  botTokenNotDefinedError,
+} from '@photobank/shared/constants';
 dotenv.config();
 
 export const BOT_TOKEN: string = process.env.BOT_TOKEN || '';
-if (!BOT_TOKEN) throw new Error('BOT_TOKEN is not defined');
+if (!BOT_TOKEN) throw new Error(botTokenNotDefinedError);
 
 export const API_EMAIL: string = process.env.API_EMAIL || '';
 export const API_PASSWORD: string = process.env.API_PASSWORD || '';
 if (!API_EMAIL || !API_PASSWORD) {
-  throw new Error('API_EMAIL or API_PASSWORD is not defined');
+  throw new Error(apiCredentialsNotDefinedError);
 }
 

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -2,10 +2,15 @@ import { Bot } from "grammy";
 import {BOT_TOKEN, API_EMAIL, API_PASSWORD} from "./config";
 import {sendThisDayPage, thisDayCommand, captionCache} from "./commands/thisday";
 import { loadDictionaries } from "@photobank/shared/dictionaries";
-import {photoByIdCommand} from "./commands/photoById";
+import { photoByIdCommand } from "./commands/photoById";
 import { registerPhotoRoutes } from "./commands/photoRouter";
 import { profileCommand } from "./commands/profile";
 import { login, setImpersonateUser } from "@photobank/shared/api";
+import {
+    captionMissingMsg,
+    unknownMessageReplyMsg,
+    welcomeBotMsg,
+} from "@photobank/shared/constants";
 
 const bot = new Bot(BOT_TOKEN);
 
@@ -22,7 +27,7 @@ await loadDictionaries();
 
 bot.command(
     "start",
-    (ctx) => ctx.reply("Добро пожаловать. Запущен и работает!"),
+    (ctx) => ctx.reply(welcomeBotMsg),
 );
 
 bot.command("thisday", thisDayCommand);
@@ -40,9 +45,9 @@ bot.callbackQuery(/^thisday:(\d+)$/, async (ctx) => {
 bot.callbackQuery(/^caption:(\d+)$/, async (ctx) => {
     const id = parseInt(ctx.match[1], 10);
     const caption = captionCache.get(id);
-    await ctx.answerCallbackQuery(caption ?? "Без подписи.", { show_alert: true });
+    await ctx.answerCallbackQuery(caption ?? captionMissingMsg, { show_alert: true });
 });
 
-bot.on("message", (ctx) => ctx.reply("Получил другое сообщение!"));
+bot.on("message", (ctx) => ctx.reply(unknownMessageReplyMsg));
 
 bot.start();

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -1,6 +1,7 @@
 import { Context, InputFile } from "grammy";
 import { getPhotoById } from "@photobank/shared/api/photos";
 import { formatPhotoMessage } from "@photobank/shared/utils/formatPhotoMessage";
+import { photoNotFoundMsg } from "@photobank/shared/constants";
 
 export async function sendPhotoById(ctx: Context, id: number) {
     let photo;
@@ -8,7 +9,7 @@ export async function sendPhotoById(ctx: Context, id: number) {
     try {
         photo = await getPhotoById(id);
     } catch {
-        await ctx.reply("❌ Фото не найдено.");
+        await ctx.reply(photoNotFoundMsg);
         return;
     }
 

--- a/frontend/packages/telegram-bot/test/bot.test.ts
+++ b/frontend/packages/telegram-bot/test/bot.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi } from 'vitest';
 import { handleThisDay } from '../src/commands/thisday';
 import * as photosApi from '@photobank/shared/api/photos';
+import { sorryTryToRequestLaterMsg } from '@photobank/shared/constants';
 
 describe('handleThisDay', () => {
   it('replies with fallback message on API failure', async () => {
     const ctx = { reply: vi.fn(), message: { text: '/thisday' } } as any;
     vi.spyOn(photosApi, 'searchPhotos').mockRejectedValue(new Error('fail'));
     await handleThisDay(ctx);
-    expect(ctx.reply).toHaveBeenCalledWith('Sorry, try to request later.');
+    expect(ctx.reply).toHaveBeenCalledWith(sorryTryToRequestLaterMsg);
   });
 });


### PR DESCRIPTION
## Summary
- centralize telegram bot messages in `@photobank/shared/constants`
- update telegram bot sources to use shared constants
- fix bot test to use shared string constant

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_687a52e89d9083288a9b2ba5e36892b6