### PR TITLE
Add registration and admin user management

### DIFF
--- a/frontend/packages/frontend/src/app/RequireAdmin.tsx
+++ b/frontend/packages/frontend/src/app/RequireAdmin.tsx
@@ -1,0 +1,24 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { getAuthToken, getUserRoles } from '@photobank/shared/api';
+
+export default function RequireAdmin() {
+  const location = useLocation();
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  useEffect(() => {
+    const token = getAuthToken();
+    if (!token) {
+      setIsAdmin(false);
+      return;
+    }
+    getUserRoles()
+      .then((roles) => {
+        setIsAdmin(roles.some((r) => r.name === 'Administrator'));
+      })
+      .catch(() => setIsAdmin(false));
+  }, []);
+
+  if (isAdmin === null) return null;
+  if (!isAdmin) return <Navigate to="/filter" state={{ from: location }} replace />;
+  return <Outlet />;
+}

--- a/frontend/packages/frontend/src/components/NavBar.tsx
+++ b/frontend/packages/frontend/src/components/NavBar.tsx
@@ -1,5 +1,6 @@
 import { NavLink, useLocation } from 'react-router-dom';
-import { getAuthToken } from '@photobank/shared/api';
+import { useEffect, useState } from 'react';
+import { getAuthToken, getUserRoles } from '@photobank/shared/api';
 import { Button } from '@/components/ui/button';
 import {
   navbarFilterLabel,
@@ -7,12 +8,27 @@ import {
   navbarProfileLabel,
   navbarLoginLabel,
   navbarLogoutLabel,
+  navbarRegisterLabel,
+  navbarUsersLabel,
 } from '@photobank/shared/constants';
 
 export default function NavBar() {
   // useLocation to trigger re-render on route changes
   useLocation();
   const loggedIn = Boolean(getAuthToken());
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    if (loggedIn) {
+      getUserRoles()
+        .then((roles) => {
+          setIsAdmin(roles.some((r) => r.name === 'Administrator'));
+        })
+        .catch(() => setIsAdmin(false));
+    } else {
+      setIsAdmin(false);
+    }
+  }, [loggedIn]);
 
   const linkClass = 'text-sm';
 
@@ -34,6 +50,13 @@ export default function NavBar() {
             <NavLink to="/profile">{navbarProfileLabel}</NavLink>
           </Button>
         </li>
+        {isAdmin && (
+          <li>
+            <Button variant="link" className={linkClass} asChild>
+              <NavLink to="/admin/users">{navbarUsersLabel}</NavLink>
+            </Button>
+          </li>
+        )}
         {loggedIn ? (
           <li className="ml-auto">
             <Button variant="link" className={linkClass} asChild>
@@ -41,11 +64,18 @@ export default function NavBar() {
             </Button>
           </li>
         ) : (
-          <li className="ml-auto">
-            <Button variant="link" className={linkClass} asChild>
-              <NavLink to="/login">{navbarLoginLabel}</NavLink>
-            </Button>
-          </li>
+          <>
+            <li className="ml-auto">
+              <Button variant="link" className={linkClass} asChild>
+                <NavLink to="/login">{navbarLoginLabel}</NavLink>
+              </Button>
+            </li>
+            <li>
+              <Button variant="link" className={linkClass} asChild>
+                <NavLink to="/register">{navbarRegisterLabel}</NavLink>
+              </Button>
+            </li>
+          </>
         )}
       </ul>
     </nav>

--- a/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+import { getAllUsers, updateUserById, setUserClaims } from '@photobank/shared/api';
+import type { UserWithClaimsDto } from '@photobank/shared/types';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { manageUsersTitle, saveUserButtonText, phoneNumberLabel, telegramLabel } from '@photobank/shared/constants';
+
+const schema = z.object({
+  phoneNumber: z.string().optional(),
+  telegram: z.string().optional(),
+  claims: z.string().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function UsersPage() {
+  const [users, setUsers] = useState<UserWithClaimsDto[]>([]);
+
+  useEffect(() => {
+    getAllUsers().then(setUsers).catch(console.error);
+  }, []);
+
+  const handleSave = async (id: string, data: FormData) => {
+    await updateUserById(id, data);
+    const claims = (data.claims ?? '').split('\n').filter(Boolean).map((l) => {
+      const [type, value] = l.split(':');
+      return { type: type.trim(), value: value.trim() };
+    });
+    if (claims.length) {
+      await setUserClaims(id, claims);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-6">
+      <h1 className="text-2xl font-bold">{manageUsersTitle}</h1>
+      {users.map((u) => {
+        const defaultValues = {
+          phoneNumber: u.phoneNumber ?? '',
+          telegram: u.telegram ?? '',
+          claims: u.claims.map((c) => `${c.type}:${c.value}`).join('\n'),
+        };
+        const form = useForm<FormData>({ resolver: zodResolver(schema), defaultValues });
+        return (
+          <div key={u.id} className="border p-4 rounded space-y-2">
+            <h2 className="font-semibold">{u.email}</h2>
+            <Form {...form}>
+              {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+              <form onSubmit={form.handleSubmit((d) => handleSave(u.id, d))} className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="phoneNumber"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{phoneNumberLabel}</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="telegram"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{telegramLabel}</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="claims"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Claims (type:value per line)</FormLabel>
+                      <FormControl>
+                        <Textarea {...field} className="min-h-24" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit">{saveUserButtonText}</Button>
+              </form>
+            </Form>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/packages/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/packages/frontend/src/pages/auth/RegisterPage.tsx
@@ -1,0 +1,93 @@
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { register } from '@photobank/shared/api';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  registerTitle,
+  emailLabel,
+  passwordLabel,
+  registerButtonText,
+} from '@photobank/shared/constants';
+
+const formSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+export default function RegisterPage() {
+  const navigate = useNavigate();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: '', password: '' },
+  });
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      await register(data);
+      navigate('/login');
+    } catch (e) {
+      console.error(e);
+      setErrorMessage('Failed to register');
+    }
+  };
+
+  return (
+    <div className="w-full max-w-sm mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">{registerTitle}</h1>
+      {errorMessage && (
+        <p className="text-destructive text-sm mb-2" role="alert">
+          {errorMessage}
+        </p>
+      )}
+      <Form {...form}>
+        {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{emailLabel}</FormLabel>
+                <FormControl>
+                  <Input {...field} type="email" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{passwordLabel}</FormLabel>
+                <FormControl>
+                  <Input {...field} type="password" />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="w-full">
+            {registerButtonText}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/frontend/packages/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/packages/frontend/src/routes/AppRoutes.tsx
@@ -1,16 +1,20 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import RequireAuth from '@/app/RequireAuth.tsx';
+import RequireAdmin from '@/app/RequireAdmin.tsx';
 
 import PhotoListPage from '@/pages/list/PhotoListPage.tsx';
 import FilterPage from '@/pages/filter/FilterPage.tsx';
 import PhotoDetailsPage from '@/pages/detail/PhotoDetailsPage.tsx';
 import LoginPage from '@/pages/auth/LoginPage.tsx';
+import RegisterPage from '@/pages/auth/RegisterPage.tsx';
 import LogoutPage from '@/pages/auth/LogoutPage.tsx';
 import MyProfilePage from '@/pages/profile/MyProfilePage.tsx';
+import UsersPage from '@/pages/admin/UsersPage.tsx';
 
 export const AppRoutes = () => (
   <Routes>
     <Route path="/login" element={<LoginPage />} />
+    <Route path="/register" element={<RegisterPage />} />
     <Route element={<RequireAuth />}>
       <Route path="/" element={<Navigate to="/filter" />} />
       <Route path="/logout" element={<LogoutPage />} />
@@ -18,6 +22,9 @@ export const AppRoutes = () => (
       <Route path="/filter" element={<FilterPage />} />
       <Route path="/photos" element={<PhotoListPage />} />
       <Route path="/photos/:id" element={<PhotoDetailsPage />} />
+      <Route element={<RequireAdmin />}>
+        <Route path="/admin/users" element={<UsersPage />} />
+      </Route>
     </Route>
     <Route path="*" element={<Navigate to="/login" replace />} />
   </Routes>

--- a/frontend/packages/frontend/test/RegisterPage.test.tsx
+++ b/frontend/packages/frontend/test/RegisterPage.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+class RO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// @ts-ignore
+global.ResizeObserver = RO;
+
+const renderPage = async (regMock: any) => {
+  vi.doMock('@photobank/shared/api', () => ({ register: regMock }));
+  const { default: RegisterPage } = await import('../src/pages/auth/RegisterPage');
+  render(
+    <MemoryRouter initialEntries={["/register"]}>
+      <Routes>
+        <Route path="/register" element={<RegisterPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('RegisterPage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('submits registration data', async () => {
+    const regMock = vi.fn().mockResolvedValue({});
+    await renderPage(regMock);
+    fireEvent.input(screen.getByLabelText('Email'), { target: { value: 'a@b.co' } });
+    fireEvent.input(screen.getByLabelText('Password'), { target: { value: '123' } });
+    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+    await waitFor(() => {
+      expect(regMock).toHaveBeenCalledWith({ email: 'a@b.co', password: '123' });
+    });
+  });
+});

--- a/frontend/packages/shared/src/api/index.ts
+++ b/frontend/packages/shared/src/api/index.ts
@@ -5,3 +5,4 @@ export * from './tags';
 export * from './paths';
 export * from './storages';
 export * from './auth';
+export * from './users';

--- a/frontend/packages/shared/src/api/users.ts
+++ b/frontend/packages/shared/src/api/users.ts
@@ -1,0 +1,21 @@
+import type { UserWithClaimsDto, UpdateUserDto, ClaimDto } from '../types';
+import { apiClient } from './client';
+
+export const getAllUsers = async (): Promise<UserWithClaimsDto[]> => {
+  const res = await apiClient.get<UserWithClaimsDto[]>('/admin/users');
+  return res.data;
+};
+
+export const updateUserById = async (
+  id: string,
+  data: UpdateUserDto,
+): Promise<void> => {
+  await apiClient.put(`/admin/users/${id}`, data);
+};
+
+export const setUserClaims = async (
+  id: string,
+  claims: ClaimDto[],
+): Promise<void> => {
+  await apiClient.put(`/admin/users/${id}/claims`, claims);
+};

--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -58,6 +58,8 @@ export const navbarPhotosLabel = 'Photos';
 export const navbarProfileLabel = 'Profile';
 export const navbarLoginLabel = 'Login';
 export const navbarLogoutLabel = 'Logout';
+export const navbarRegisterLabel = 'Register';
+export const navbarUsersLabel = 'Users';
 
 // PhotoPreviewModal
 export const previewModalFallbackTitle = 'Preview';
@@ -108,6 +110,11 @@ export const passwordLabel = 'Password';
 export const stayLoggedInLabel = 'Stay logged in';
 export const loginButtonText = 'Login';
 
+// Register page
+export const registerTitle = 'Register';
+export const registerButtonText = 'Register';
+
+
 // Logout page
 export const loggingOutMsg = 'Logging out...';
 
@@ -156,3 +163,7 @@ export const colDateLabel = 'Date';
 export const colStorageLabel = 'Storage';
 export const colFlagsLabel = 'Flags';
 export const colDetailsLabel = 'Details';
+
+// Admin pages
+export const manageUsersTitle = 'Manage Users';
+export const saveUserButtonText = 'Save User';

--- a/frontend/packages/shared/src/types/dto/UserWithClaimsDto.ts
+++ b/frontend/packages/shared/src/types/dto/UserWithClaimsDto.ts
@@ -1,0 +1,7 @@
+export interface UserWithClaimsDto {
+  id: string;
+  email: string;
+  phoneNumber?: string;
+  telegram?: string;
+  claims: { type: string; value: string }[];
+}

--- a/frontend/packages/shared/src/types/index.ts
+++ b/frontend/packages/shared/src/types/index.ts
@@ -18,3 +18,4 @@ export * from './dto/UpdateUserDto';
 export * from './dto/UserDto';
 export * from './dto/ClaimDto';
 export * from './dto/RoleDto';
+export * from './dto/UserWithClaimsDto';

--- a/frontend/packages/shared/test/users.test.ts
+++ b/frontend/packages/shared/test/users.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('admin users api', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('getAllUsers fetches users', async () => {
+    const getMock = vi.fn().mockResolvedValue({ data: [{ id: '1' }] });
+    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const { getAllUsers } = await import('../src/api/users');
+    const res = await getAllUsers();
+    expect(getMock).toHaveBeenCalledWith('/admin/users');
+    expect(res).toEqual([{ id: '1' }]);
+  });
+
+  it('updateUserById sends data', async () => {
+    const putMock = vi.fn().mockResolvedValue({});
+    vi.doMock('../src/api/client', () => ({ apiClient: { put: putMock } }));
+    const { updateUserById } = await import('../src/api/users');
+    await updateUserById('5', { phoneNumber: '1' });
+    expect(putMock).toHaveBeenCalledWith('/admin/users/5', { phoneNumber: '1' });
+  });
+
+  it('setUserClaims posts claims', async () => {
+    const putMock = vi.fn().mockResolvedValue({});
+    vi.doMock('../src/api/client', () => ({ apiClient: { put: putMock } }));
+    const { setUserClaims } = await import('../src/api/users');
+    await setUserClaims('3', [{ type: 't', value: 'v' }]);
+    expect(putMock).toHaveBeenCalledWith('/admin/users/3/claims', [
+      { type: 't', value: 'v' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add register and admin navigation constants
- add DTOs and admin user API functions
- implement Register page
- add Admin Users page with forms to update users and claims
- add RequireAdmin gate and routes
- update navigation to show new links for registration and admin
- add tests for new API and Register page

## Testing
- `pnpm --filter shared test`
- `pnpm --filter frontend test`

------
https://chatgpt.com/codex/tasks/task_e_687a6bfd66d88328b6539a318deaa2ad