### PR TITLE
Add telegram bot subscription command

### DIFF
--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -17,6 +17,7 @@ export const captionMissingMsg = "Без подписи.";
 export const unknownMessageReplyMsg = "Получил другое сообщение!";
 export const photoCommandUsageMsg = "❗ Используй: /photo <id>";
 export const photoNotFoundMsg = "❌ Фото не найдено.";
+export const subscribeCommandUsageMsg = "❗ Используй: /subscribe HH:MM";
 export const todaysPhotosEmptyMsg = "📭 Сегодняшних фото пока нет.";
 export const unknownYearLabel = "Неизвестный год";
 export const prevPageText = "◀ Назад";

--- a/frontend/packages/telegram-bot/src/commands/subscribe.ts
+++ b/frontend/packages/telegram-bot/src/commands/subscribe.ts
@@ -1,0 +1,40 @@
+import { Bot, Context } from "grammy";
+import { sendThisDayPage } from "./thisday";
+import { subscribeCommandUsageMsg } from "@photobank/shared/constants";
+
+export const subscriptions = new Map<number, string>();
+
+export function parseSubscribeTime(text?: string): string | null {
+    if (!text) return null;
+    const match = text.match(/\/subscribe\s+(\d{1,2}:\d{2})/);
+    if (!match) return null;
+    const [hours, minutes] = match[1].split(":").map(Number);
+    if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+    return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
+}
+
+export async function subscribeCommand(ctx: Context) {
+    const time = parseSubscribeTime(ctx.message?.text);
+    if (!time) {
+        await ctx.reply(subscribeCommandUsageMsg);
+        return;
+    }
+    subscriptions.set(ctx.chat.id, time);
+    await ctx.reply(`✅ Подписка на ежедневную рассылку в ${time} оформлена.`);
+}
+
+export function initSubscriptionScheduler(bot: Bot) {
+    setInterval(async () => {
+        const now = new Date();
+        const current = `${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+        for (const [chatId, t] of subscriptions.entries()) {
+            if (t === current) {
+                const ctxLike = {
+                    message: { text: "/thisday" },
+                    reply: (text: string, opts?: any) => bot.api.sendMessage(chatId, text, opts),
+                } as unknown as Context;
+                await sendThisDayPage(ctxLike, 1);
+            }
+        }
+    }, 60 * 1000);
+}

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -1,6 +1,7 @@
 import { Bot } from "grammy";
 import {BOT_TOKEN, API_EMAIL, API_PASSWORD} from "./config";
 import {sendThisDayPage, thisDayCommand, captionCache} from "./commands/thisday";
+import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
 import { loadDictionaries } from "@photobank/shared/dictionaries";
 import { photoByIdCommand } from "./commands/photoById";
 import { registerPhotoRoutes } from "./commands/photoRouter";
@@ -36,6 +37,8 @@ bot.command("photo", photoByIdCommand);
 
 bot.command("profile", profileCommand);
 
+bot.command("subscribe", subscribeCommand);
+
 bot.callbackQuery(/^thisday:(\d+)$/, async (ctx) => {
     const page = parseInt(ctx.match[1], 10);
     await ctx.answerCallbackQuery();
@@ -51,3 +54,4 @@ bot.callbackQuery(/^caption:(\d+)$/, async (ctx) => {
 bot.on("message", (ctx) => ctx.reply(unknownMessageReplyMsg));
 
 bot.start();
+initSubscriptionScheduler(bot);

--- a/frontend/packages/telegram-bot/test/subscribe.test.ts
+++ b/frontend/packages/telegram-bot/test/subscribe.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { subscribeCommand, parseSubscribeTime, subscriptions } from '../src/commands/subscribe';
+import { subscribeCommandUsageMsg } from '@photobank/shared/constants';
+
+describe('parseSubscribeTime', () => {
+  it('parses valid time', () => {
+    expect(parseSubscribeTime('/subscribe 08:30')).toBe('08:30');
+  });
+
+  it('returns null for invalid time', () => {
+    expect(parseSubscribeTime('/subscribe 25:00')).toBeNull();
+  });
+});
+
+describe('subscribeCommand', () => {
+  it('replies with usage on wrong input', async () => {
+    const ctx = { reply: vi.fn(), message: { text: '/subscribe' }, chat: { id: 1 } } as any;
+    await subscribeCommand(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith(subscribeCommandUsageMsg);
+  });
+
+  it('stores subscription on valid input', async () => {
+    const ctx = { reply: vi.fn(), message: { text: '/subscribe 07:15' }, chat: { id: 42 } } as any;
+    await subscribeCommand(ctx);
+    expect(subscriptions.get(42)).toBe('07:15');
+  });
+});


### PR DESCRIPTION
## Summary
- add `/subscribe` command to register daily thisday reminders
- schedule daily notification based on configured time
- expose usage message constant
- test subscribe command logic with Vitest

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_687a727f443c83288933d237eabf1bd0