### PR TITLE
Add faceId to UpdateFaceDto

### DIFF
--- a/backend/PhotoBank.Api/Controllers/FacesController.cs
+++ b/backend/PhotoBank.Api/Controllers/FacesController.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PhotoBank.Services.Api;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Api.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[Authorize]
+public class FacesController(IPhotoService photoService) : ControllerBase
+{
+    [HttpPut]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpdateAsync([FromBody] UpdateFaceDto dto)
+    {
+        await photoService.UpdateFaceAsync(dto.FaceId, dto.PersonId);
+        return Ok();
+    }
+}

--- a/backend/PhotoBank.ViewModel.Dto/UpdateFaceDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/UpdateFaceDto.cs
@@ -1,0 +1,7 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class UpdateFaceDto
+{
+    public int FaceId { get; set; }
+    public int PersonId { get; set; }
+}

--- a/frontend/packages/frontend/src/entities/photo/api.ts
+++ b/frontend/packages/frontend/src/entities/photo/api.ts
@@ -1,5 +1,10 @@
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
-import { searchPhotos as searchPhotosApi, getPhotoById as getPhotoByIdApi } from '@photobank/shared/api';
+import {
+  searchPhotos as searchPhotosApi,
+  getPhotoById as getPhotoByIdApi,
+  updateFace as updateFaceApi,
+} from '@photobank/shared/api';
+import type { UpdateFaceDto } from '@photobank/shared/types';
 
 import type { FilterDto, PhotoDto, QueryResult } from '@photobank/shared/types';
 
@@ -27,7 +32,21 @@ export const api = createApi({
         }
       },
     }),
+    updateFace: builder.mutation<void, UpdateFaceDto>({
+      async queryFn(dto) {
+        try {
+          await updateFaceApi(dto);
+          return { data: undefined };
+        } catch (error) {
+          return { error: error as unknown as Error };
+        }
+      },
+    }),
   }),
 });
 
-export const { useGetPhotoByIdQuery, useSearchPhotosMutation } = api;
+export const {
+  useGetPhotoByIdQuery,
+  useSearchPhotosMutation,
+  useUpdateFaceMutation,
+} = api;

--- a/frontend/packages/shared/src/api/faces.ts
+++ b/frontend/packages/shared/src/api/faces.ts
@@ -1,0 +1,6 @@
+import { apiClient } from './client';
+import type { UpdateFaceDto } from '../types';
+
+export const updateFace = async (dto: UpdateFaceDto): Promise<void> => {
+  await apiClient.put('/faces', dto);
+};

--- a/frontend/packages/shared/src/api/index.ts
+++ b/frontend/packages/shared/src/api/index.ts
@@ -6,3 +6,4 @@ export * from './paths';
 export * from './storages';
 export * from './auth';
 export * from './users';
+export * from './faces';

--- a/frontend/packages/shared/src/types/dto/UpdateFaceDto.ts
+++ b/frontend/packages/shared/src/types/dto/UpdateFaceDto.ts
@@ -1,0 +1,4 @@
+export interface UpdateFaceDto {
+  faceId: number;
+  personId: number;
+}

--- a/frontend/packages/shared/src/types/index.ts
+++ b/frontend/packages/shared/src/types/index.ts
@@ -19,3 +19,4 @@ export * from './dto/UserDto';
 export * from './dto/ClaimDto';
 export * from './dto/RoleDto';
 export * from './dto/UserWithClaimsDto';
+export * from './dto/UpdateFaceDto';

--- a/frontend/packages/shared/test/api.test.ts
+++ b/frontend/packages/shared/test/api.test.ts
@@ -80,4 +80,12 @@ describe('api helpers', () => {
     expect(getMock).toHaveBeenCalledWith('/tags');
     expect(res).toEqual([{ id: 3 }]);
   });
+
+  it('updateFace sends data', async () => {
+    const putMock = vi.fn().mockResolvedValue({});
+    vi.doMock('../src/api/client', () => ({ apiClient: { put: putMock } }));
+    const { updateFace } = await import('../src/api/faces');
+    await updateFace({ faceId: 5, personId: 2 });
+    expect(putMock).toHaveBeenCalledWith('/faces', { faceId: 5, personId: 2 });
+  });
 });


### PR DESCRIPTION
## Summary
- accept faceId in UpdateFaceDto
- adjust FacesController to read IDs from body
- update shared client and redux API to use new DTO
- update tests for new updateFace helper

## Testing
- `pnpm install`
- `pnpm -r test`
- ❌ `dotnet test PhotoBank.sln` *(dotnet unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687aa4f19dec83288d44bbbb2e3ebd0c