### PR TITLE
Frontend admin checkbox restriction

### DIFF
--- a/frontend/packages/frontend/src/app/RequireAdmin.tsx
+++ b/frontend/packages/frontend/src/app/RequireAdmin.tsx
@@ -1,22 +1,9 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { useEffect, useState } from 'react';
-import { getAuthToken, getUserRoles } from '@photobank/shared/api';
+import { useIsAdmin } from '@photobank/shared';
 
 export default function RequireAdmin() {
   const location = useLocation();
-  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
-  useEffect(() => {
-    const token = getAuthToken();
-    if (!token) {
-      setIsAdmin(false);
-      return;
-    }
-    getUserRoles()
-      .then((roles) => {
-        setIsAdmin(roles.some((r) => r.name === 'Administrator'));
-      })
-      .catch(() => setIsAdmin(false));
-  }, []);
+  const isAdmin = useIsAdmin();
 
   if (isAdmin === null) return null;
   if (!isAdmin) return <Navigate to="/filter" state={{ from: location }} replace />;

--- a/frontend/packages/frontend/src/components/FilterFormFields.tsx
+++ b/frontend/packages/frontend/src/components/FilterFormFields.tsx
@@ -12,6 +12,7 @@ import {FormControl, FormField, FormItem, FormLabel, FormMessage,} from '@/compo
 import type {FormData} from '@/features/filter/lib/form-schema.ts';
 import type {RootState} from '@/app/store.ts';
 import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover.tsx";
+import { useIsAdmin } from '@photobank/shared';
 
 import {Button} from './ui/button';
 import {Calendar} from './ui/calendar';
@@ -42,6 +43,7 @@ interface FilterFormFieldsProps {
 export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
     const [openFrom, setOpenFrom] = React.useState(false)
     const [openTo, setOpenTo] = React.useState(false)
+    const isAdmin = useIsAdmin()
 
     const tags = useSelector((state: RootState) => state.metadata.tags)
     const persons = useSelector((state: RootState) => state.metadata.persons)
@@ -271,41 +273,45 @@ export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
                     )}
                 />
 
-                <FormField
-                    control={control}
-                    name="isAdultContent"
-                    render={({field}) => (
-                        <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                            <FormControl>
-                                <TriStateCheckbox
-                                    value={field.value}
-                                    onValueChange={field.onChange}
-                                />
-                            </FormControl>
-                            <div className="space-y-1 leading-none">
-                                <FormLabel>{adultContentLabel}</FormLabel>
-                            </div>
-                        </FormItem>
-                    )}
-                />
+                {isAdmin && (
+                    <FormField
+                        control={control}
+                        name="isAdultContent"
+                        render={({field}) => (
+                            <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                                <FormControl>
+                                    <TriStateCheckbox
+                                        value={field.value}
+                                        onValueChange={field.onChange}
+                                    />
+                                </FormControl>
+                                <div className="space-y-1 leading-none">
+                                    <FormLabel>{adultContentLabel}</FormLabel>
+                                </div>
+                            </FormItem>
+                        )}
+                    />
+                )}
 
-                <FormField
-                    control={control}
-                    name="isRacyContent"
-                    render={({field}) => (
-                        <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-                            <FormControl>
-                                <TriStateCheckbox
-                                    value={field.value}
-                                    onValueChange={field.onChange}
-                                />
-                            </FormControl>
-                            <div className="space-y-1 leading-none">
-                                <FormLabel>{racyContentLabel}</FormLabel>
-                            </div>
-                        </FormItem>
-                    )}
-                />
+                {isAdmin && (
+                    <FormField
+                        control={control}
+                        name="isRacyContent"
+                        render={({field}) => (
+                            <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                                <FormControl>
+                                    <TriStateCheckbox
+                                        value={field.value}
+                                        onValueChange={field.onChange}
+                                    />
+                                </FormControl>
+                                <div className="space-y-1 leading-none">
+                                    <FormLabel>{racyContentLabel}</FormLabel>
+                                </div>
+                            </FormItem>
+                        )}
+                    />
+                )}
 
                 <FormField
                     control={control}

--- a/frontend/packages/frontend/src/components/NavBar.tsx
+++ b/frontend/packages/frontend/src/components/NavBar.tsx
@@ -1,6 +1,6 @@
 import { NavLink, useLocation } from 'react-router-dom';
-import { useEffect, useState } from 'react';
-import { getAuthToken, getUserRoles } from '@photobank/shared/api';
+import { getAuthToken } from '@photobank/shared/api';
+import { useIsAdmin } from '@photobank/shared';
 import { Button } from '@/components/ui/button';
 import {
   navbarFilterLabel,
@@ -16,19 +16,7 @@ export default function NavBar() {
   // useLocation to trigger re-render on route changes
   useLocation();
   const loggedIn = Boolean(getAuthToken());
-  const [isAdmin, setIsAdmin] = useState(false);
-
-  useEffect(() => {
-    if (loggedIn) {
-      getUserRoles()
-        .then((roles) => {
-          setIsAdmin(roles.some((r) => r.name === 'Administrator'));
-        })
-        .catch(() => setIsAdmin(false));
-    } else {
-      setIsAdmin(false);
-    }
-  }, [loggedIn]);
+  const isAdmin = useIsAdmin();
 
   const linkClass = 'text-sm';
 

--- a/frontend/packages/frontend/test/FilterFormFields.test.tsx
+++ b/frontend/packages/frontend/test/FilterFormFields.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { useForm } from 'react-hook-form';
+import metaReducer from '../src/features/meta/model/metaSlice';
+import { Form } from '../src/components/ui/form';
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+
+class RO {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// @ts-ignore
+global.ResizeObserver = RO;
+
+declare module '@testing-library/react' {
+  interface RenderOptions {
+    wrapper?: React.ComponentType;
+  }
+}
+
+const renderWithRoles = async (roles: any[]) => {
+  const getUserRoles = vi.fn().mockImplementation(() => {
+    console.log('getUserRoles called with', roles);
+    return Promise.resolve(roles);
+  });
+  vi.doMock('@photobank/shared/api', () => ({
+    getAuthToken: () => 'token',
+    getUserRoles,
+  }));
+
+  const { FilterFormFields } = await import('../src/components/FilterFormFields');
+
+  const store = configureStore({
+    reducer: { metadata: metaReducer },
+    preloadedState: {
+      metadata: {
+        tags: [],
+        persons: [],
+        paths: [],
+        storages: [],
+        version: 1,
+        loaded: true,
+        loading: false,
+        error: undefined,
+      },
+    },
+  });
+
+  function Wrapper() {
+    const form = useForm({
+      defaultValues: {
+        caption: '',
+        storages: [],
+        paths: [],
+        persons: [],
+        tags: [],
+        isBW: undefined,
+        isAdultContent: undefined,
+        isRacyContent: undefined,
+        thisDay: undefined,
+        dateFrom: undefined,
+        dateTo: undefined,
+      },
+    });
+
+    return (
+      <Provider store={store}>
+        <Form {...form}>
+          <form>
+            <FilterFormFields control={form.control} />
+          </form>
+        </Form>
+      </Provider>
+    );
+  }
+
+  render(<Wrapper />);
+  return { getUserRoles };
+};
+
+describe('FilterFormFields', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('shows admin checkboxes for administrators', async () => {
+    const { getUserRoles } = await renderWithRoles([{ name: 'Administrator' }]);
+    expect(getUserRoles).toHaveBeenCalled();
+    expect(await screen.findByText('Adult Content')).toBeTruthy();
+    expect(screen.getByText('Racy Content')).toBeTruthy();
+  });
+
+});

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -18,6 +18,9 @@
     "dotenv": "^17.0.0",
     "lru-cache": "^10.4.3"
   },
+  "peerDependencies": {
+    "react": "^19.1.0"
+  },
   "scripts": {
     "test": "vitest run"
   }

--- a/frontend/packages/shared/src/hooks/useIsAdmin.ts
+++ b/frontend/packages/shared/src/hooks/useIsAdmin.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'react';
+import { checkIsAdmin } from '../utils/admin';
+
+export const useIsAdmin = (): boolean | null => {
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  useEffect(() => {
+    checkIsAdmin().then(setIsAdmin).catch(() => setIsAdmin(false));
+  }, []);
+  return isAdmin;
+};

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -37,3 +37,5 @@ export const firstNWords = (sentence: string, count: number): string => {
   return words.slice(0, count).join(' ') + '... ';
 };
 
+export { checkIsAdmin } from './utils/admin';
+export { useIsAdmin } from './hooks/useIsAdmin';

--- a/frontend/packages/shared/src/utils/admin.ts
+++ b/frontend/packages/shared/src/utils/admin.ts
@@ -1,0 +1,11 @@
+import { getAuthToken, getUserRoles } from '../api';
+
+export const checkIsAdmin = async (): Promise<boolean> => {
+  if (!getAuthToken()) return false;
+  try {
+    const roles = await getUserRoles();
+    return roles.some((r) => r.name === 'Administrator');
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- hide Adult/Racy filter options for non-admin users in `FilterFormFields`
- add a shared `useIsAdmin` hook and `checkIsAdmin` util
- use new admin hook in `NavBar` and `RequireAdmin`

## Testing
- `pnpm --filter @photobank/frontend test --run test/FilterFormFields.test.tsx`
- `pnpm --filter @photobank/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_687aa45cc0a8832898d0bb492fe4248e