### PR TITLE
Add geo data to PhotoDto

### DIFF
--- a/backend/PhotoBank.Services/MappingProfile.cs
+++ b/backend/PhotoBank.Services/MappingProfile.cs
@@ -12,6 +12,14 @@ namespace PhotoBank.Services
             CreateMap<Photo, PhotoDto>()
                 .ForMember(dest => dest.Captions, opt => opt.MapFrom(src => src.Captions))
                 .ForMember(dest => dest.Tags, opt => opt.MapFrom(src => src.PhotoTags))
+                .ForMember(dest => dest.Location,
+                    opt => opt.MapFrom(src => src.Location == null
+                        ? null
+                        : new GeoPointDto
+                        {
+                            Latitude = src.Location.Coordinate.X,
+                            Longitude = src.Location.Coordinate.Y
+                        }))
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
             CreateMap<Caption, string>().ConvertUsing(c => c.Text);

--- a/backend/PhotoBank.ViewModel.Dto/GeoPointDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/GeoPointDto.cs
@@ -1,0 +1,8 @@
+namespace PhotoBank.ViewModel.Dto
+{
+    public class GeoPointDto
+    {
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+    }
+}

--- a/backend/PhotoBank.ViewModel.Dto/PhotoDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/PhotoDto.cs
@@ -14,6 +14,7 @@ namespace PhotoBank.ViewModel.Dto
         public DateTime? TakenDate { get; set; }
         [System.ComponentModel.DataAnnotations.Required]
         public required byte[] PreviewImage { get; set; }
+        public GeoPointDto? Location { get; set; }
         public int? Orientation { get; set; }
         public List<FaceDto>? Faces { get; set; }
         public List<string>? Captions { get; set; }

--- a/frontend/packages/shared/src/types/dto/GeoPointDto.ts
+++ b/frontend/packages/shared/src/types/dto/GeoPointDto.ts
@@ -1,0 +1,4 @@
+export interface GeoPointDto {
+  latitude: number;
+  longitude: number;
+}

--- a/frontend/packages/shared/src/types/dto/PhotoDto.ts
+++ b/frontend/packages/shared/src/types/dto/PhotoDto.ts
@@ -1,4 +1,5 @@
 import type { FaceDto } from './FaceDto';
+import type { GeoPointDto } from './GeoPointDto';
 
 export interface PhotoDto {
   id: number;
@@ -6,6 +7,7 @@ export interface PhotoDto {
   scale: number;
   takenDate?: string;
   previewImage: string;
+  location?: GeoPointDto;
   orientation?: number;
   faces?: FaceDto[];
   captions?: string[];

--- a/frontend/packages/shared/src/types/index.ts
+++ b/frontend/packages/shared/src/types/index.ts
@@ -3,6 +3,7 @@ export * from './dto/PhotoDto';
 export * from './dto/PhotoItemDto';
 export * from './dto/FaceDto';
 export * from './dto/FaceBoxDto';
+export * from './dto/GeoPointDto';
 export * from './dto/TagDto';
 export * from './dto/TagItemDto';
 export * from './dto/PersonDto';


### PR DESCRIPTION
## Summary
- add `GeoPointDto` for geolocation
- include location data in `PhotoDto` and update mappings
- export the new DTO in shared types
- add TypeScript equivalent for `GeoPointDto`

## Testing
- `pnpm -r run test`
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b55571d8c83289184961691bb2e2c