### PR TITLE
Add geocode service to shared library

### DIFF
--- a/frontend/packages/shared/src/config.ts
+++ b/frontend/packages/shared/src/config.ts
@@ -1,14 +1,11 @@
-// Determine API base URL from environment variables for both Node and browser
-// contexts. Vite exposes variables prefixed with `VITE_` to the client.
+// Determine API base URL from environment variables for both Node and browser contexts. Vite exposes variables prefixed with `VITE_` to the client.
 export const API_BASE_URL: string = (() => {
-    // Vite during build replaces `import.meta.env` with the actual environment
-    // values. Use `VITE_API_BASE_URL` if present.
+    // Vite during build replaces `import.meta.env` with the actual environment values. Use `VITE_API_BASE_URL` if present.
     if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE_URL) {
         return (import.meta as any).env.VITE_API_BASE_URL as string;
     }
 
-    // When running under Node (e.g. in the Telegram bot) fall back to standard
-    // environment variables.
+    // When running under Node (e.g. in the Telegram bot) fall back to standard environment variables.
     if (typeof process !== 'undefined') {
         if (process.env.VITE_API_BASE_URL) {
             return process.env.VITE_API_BASE_URL;
@@ -20,6 +17,16 @@ export const API_BASE_URL: string = (() => {
 
     // Default value used in development when no environment variable is set.
     return "http://localhost:5066";
+})();
+
+export const GOOGLE_API_KEY: string | undefined = (() => {
+    if (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_GOOGLE_API_KEY) {
+        return (import.meta as any).env.VITE_GOOGLE_API_KEY as string;
+    }
+    if (typeof process !== 'undefined') {
+        return process.env.VITE_GOOGLE_API_KEY ?? process.env.GOOGLE_API_KEY;
+    }
+    return undefined;
 })();
 
 export function isBrowser(): boolean {

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -39,3 +39,4 @@ export const firstNWords = (sentence: string, count: number): string => {
 
 export { checkIsAdmin } from './utils/admin';
 export { useIsAdmin } from './hooks/useIsAdmin';
+export { getPlaceByGeoPoint } from './utils/geocode';

--- a/frontend/packages/shared/src/utils/geocode.ts
+++ b/frontend/packages/shared/src/utils/geocode.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import type { GeoPointDto } from '../types';
+import { GOOGLE_API_KEY } from '../config';
+
+/**
+ * Returns a human friendly place name for the given coordinates using
+ * Google Geocoding API. Falls back to "lat, lng" when the request fails
+ * or API key is not provided.
+ */
+export async function getPlaceByGeoPoint(point: GeoPointDto): Promise<string> {
+  if (!GOOGLE_API_KEY) {
+    return `${point.latitude.toFixed(4)}, ${point.longitude.toFixed(4)}`;
+  }
+
+  try {
+    const res = await axios.get('https://maps.googleapis.com/maps/api/geocode/json', {
+      params: {
+        latlng: `${point.latitude},${point.longitude}`,
+        key: GOOGLE_API_KEY,
+      },
+    });
+    const name = res.data?.results?.[0]?.formatted_address;
+    return name ?? `${point.latitude.toFixed(4)}, ${point.longitude.toFixed(4)}`;
+  } catch {
+    return `${point.latitude.toFixed(4)}, ${point.longitude.toFixed(4)}`;
+  }
+}

--- a/frontend/packages/shared/test/geocode.test.ts
+++ b/frontend/packages/shared/test/geocode.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const point = { latitude: 10, longitude: 20 };
+
+describe('getPlaceByGeoPoint', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('requests google with api key and returns address', async () => {
+    const getMock = vi.fn().mockResolvedValue({ data: { results: [{ formatted_address: 'Nice place' }] } });
+    vi.doMock('axios', () => ({ default: { get: getMock } }));
+    vi.doMock('../src/config', () => ({ GOOGLE_API_KEY: 'abc' }));
+    const { getPlaceByGeoPoint } = await import('../src/utils/geocode');
+    const result = await getPlaceByGeoPoint(point);
+    expect(getMock).toHaveBeenCalledWith('https://maps.googleapis.com/maps/api/geocode/json', {
+      params: { latlng: '10,20', key: 'abc' },
+    });
+    expect(result).toBe('Nice place');
+  });
+
+  it('falls back to coordinates when request fails', async () => {
+    const getMock = vi.fn().mockRejectedValue(new Error('fail'));
+    vi.doMock('axios', () => ({ default: { get: getMock } }));
+    vi.doMock('../src/config', () => ({ GOOGLE_API_KEY: 'abc' }));
+    const { getPlaceByGeoPoint } = await import('../src/utils/geocode');
+    const result = await getPlaceByGeoPoint(point);
+    expect(result).toBe('10.0000, 20.0000');
+  });
+});


### PR DESCRIPTION
## Summary
- add `GOOGLE_API_KEY` config variable
- implement `getPlaceByGeoPoint` for reverse geocoding
- export new helper
- add unit tests

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_687b5785ee1c83289668faad15b8d9cf