### PR TITLE
Replace Google geocoding with Nominatim

### DIFF
--- a/frontend/packages/shared/src/utils/geocode.ts
+++ b/frontend/packages/shared/src/utils/geocode.ts
@@ -1,25 +1,25 @@
 import axios from 'axios';
 import type { GeoPointDto } from '../types';
-import { GOOGLE_API_KEY } from '../config';
 
 /**
  * Returns a human friendly place name for the given coordinates using
- * Google Geocoding API. Falls back to "lat, lng" when the request fails
- * or API key is not provided.
+ * the Nominatim reverse geocoding API. Falls back to "lat, lng" when the
+ * request fails.
  */
 export async function getPlaceByGeoPoint(point: GeoPointDto): Promise<string> {
-  if (!GOOGLE_API_KEY) {
-    return `${point.latitude.toFixed(4)}, ${point.longitude.toFixed(4)}`;
-  }
-
   try {
-    const res = await axios.get('https://maps.googleapis.com/maps/api/geocode/json', {
+    const res = await axios.get('https://nominatim.openstreetmap.org/reverse', {
       params: {
-        latlng: `${point.latitude},${point.longitude}`,
-        key: GOOGLE_API_KEY,
+        format: 'json',
+        lat: point.latitude,
+        lon: point.longitude,
+      },
+      headers: {
+        'User-Agent': 'photobank',
       },
     });
-    const name = res.data?.results?.[0]?.formatted_address;
+
+    const name = res.data?.display_name as string | undefined;
     return name ?? `${point.latitude.toFixed(4)}, ${point.longitude.toFixed(4)}`;
   } catch {
     return `${point.latitude.toFixed(4)}, ${point.longitude.toFixed(4)}`;

--- a/frontend/packages/shared/test/geocode.test.ts
+++ b/frontend/packages/shared/test/geocode.test.ts
@@ -7,14 +7,14 @@ describe('getPlaceByGeoPoint', () => {
     vi.resetModules();
   });
 
-  it('requests google with api key and returns address', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: { results: [{ formatted_address: 'Nice place' }] } });
+  it('requests Nominatim and returns address', async () => {
+    const getMock = vi.fn().mockResolvedValue({ data: { display_name: 'Nice place' } });
     vi.doMock('axios', () => ({ default: { get: getMock } }));
-    vi.doMock('../src/config', () => ({ GOOGLE_API_KEY: 'abc' }));
     const { getPlaceByGeoPoint } = await import('../src/utils/geocode');
     const result = await getPlaceByGeoPoint(point);
-    expect(getMock).toHaveBeenCalledWith('https://maps.googleapis.com/maps/api/geocode/json', {
-      params: { latlng: '10,20', key: 'abc' },
+    expect(getMock).toHaveBeenCalledWith('https://nominatim.openstreetmap.org/reverse', {
+      params: { format: 'json', lat: 10, lon: 20 },
+      headers: { 'User-Agent': 'photobank' },
     });
     expect(result).toBe('Nice place');
   });
@@ -22,7 +22,6 @@ describe('getPlaceByGeoPoint', () => {
   it('falls back to coordinates when request fails', async () => {
     const getMock = vi.fn().mockRejectedValue(new Error('fail'));
     vi.doMock('axios', () => ({ default: { get: getMock } }));
-    vi.doMock('../src/config', () => ({ GOOGLE_API_KEY: 'abc' }));
     const { getPlaceByGeoPoint } = await import('../src/utils/geocode');
     const result = await getPlaceByGeoPoint(point);
     expect(result).toBe('10.0000, 20.0000');


### PR DESCRIPTION
## Summary
- update shared geocode util to use Nominatim reverse geocoder
- adjust geocode tests for Nominatim

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_687b5bca25c48328aedf5e3314575c63