### PR TITLE
Implement concurrency limits in C# executor

### DIFF
--- a/backend/PhotoBank.Services/DependencyExecutor.cs
+++ b/backend/PhotoBank.Services/DependencyExecutor.cs
@@ -2,6 +2,7 @@
 using PhotoBank.Services.Enrichers;
 using PhotoBank.Services.Models;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,12 +16,19 @@ public interface IDependencyExecutor
 
 public class DependencyExecutor : IDependencyExecutor
 {
+    private readonly int _concurrencyLimit;
+
+    public DependencyExecutor(int concurrencyLimit = 4)
+    {
+        _concurrencyLimit = concurrencyLimit;
+    }
+
     public async Task ExecuteAsync(IEnumerable<IEnricher> enrichers, Photo photo, SourceDataDto sourceData)
     {
         var enricherList = enrichers.ToList();
         var typeToInstance = enricherList.ToDictionary(e => e.GetType());
         var dependencyGraph = new Dictionary<Type, List<Type>>();
-        var incomingEdges = new Dictionary<Type, int>();
+        var incomingEdges = new ConcurrentDictionary<Type, int>();
 
         // Инициализация графа
         foreach (var enricher in enricherList)
@@ -40,52 +48,64 @@ public class DependencyExecutor : IDependencyExecutor
                     throw new InvalidOperationException($"Missing dependency: {dependencyType}");
 
                 dependencyGraph[dependencyType].Add(currentType);
-                incomingEdges[currentType]++;
+                incomingEdges.AddOrUpdate(currentType, 1, (_, v) => v + 1);
             }
         }
 
-        var readyQueue = new Queue<Type>(
+        var readyQueue = new ConcurrentQueue<Type>(
             incomingEdges.Where(kv => kv.Value == 0).Select(kv => kv.Key)
         );
 
-        var completed = new HashSet<Type>();
         var runningTasks = new Dictionary<Type, Task>();
+        var semaphore = new SemaphoreSlim(_concurrencyLimit);
+        var completedCount = 0;
 
-        while (readyQueue.Count > 0 || runningTasks.Count > 0)
+        while (!readyQueue.IsEmpty || runningTasks.Count > 0)
         {
-            while (readyQueue.Count > 0)
+            while (runningTasks.Count < _concurrencyLimit && readyQueue.TryDequeue(out var type))
             {
-                var type = readyQueue.Dequeue();
                 var enricher = typeToInstance[type];
+                await semaphore.WaitAsync();
 
                 var task = Task.Run(async () =>
                 {
-                    await enricher.EnrichAsync(photo, sourceData);
-                    if (photo != null)
-                        photo.EnrichedWithEnricherType |= enricher.EnricherType;
-                    lock (completed)
+                    try
                     {
-                        completed.Add(type);
+                        await enricher.EnrichAsync(photo, sourceData);
+                        if (photo != null)
+                            photo.EnrichedWithEnricherType |= enricher.EnricherType;
+
                         foreach (var dependent in dependencyGraph[type])
                         {
-                            incomingEdges[dependent]--;
-                            if (incomingEdges[dependent] == 0)
-                            {
+                            var newCount = incomingEdges.AddOrUpdate(dependent, 0, (_, v) => v - 1);
+                            if (newCount == 0)
                                 readyQueue.Enqueue(dependent);
-                            }
                         }
+                    }
+                    finally
+                    {
+                        semaphore.Release();
                     }
                 });
 
                 runningTasks[type] = task;
             }
 
-            var finished = await Task.WhenAny(runningTasks.Values);
-            var finishedEntry = runningTasks.First(kvp => kvp.Value == finished);
-            runningTasks.Remove(finishedEntry.Key);
+            if (runningTasks.Count > 0)
+            {
+                var finished = await Task.WhenAny(runningTasks.Values);
+                var finishedEntry = runningTasks.First(kvp => kvp.Value == finished);
+                runningTasks.Remove(finishedEntry.Key);
+                await finished;
+                completedCount++;
+            }
+            else if (readyQueue.IsEmpty)
+            {
+                break;
+            }
         }
 
-        if (completed.Count < enricherList.Count)
+        if (completedCount < enricherList.Count)
             throw new InvalidOperationException("Cycle detected in dependencies");
     }
 }


### PR DESCRIPTION
## Summary
- revert the previous frontend changes
- add concurrency limit and use thread-safe collections for `DependencyExecutor`

## Testing
- `pnpm -r test`
- `dotnet test backend/PhotoBank.sln` *(fails: The current .NET SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687c0117d6488328a74df54448bfcc9e