### PR TITLE
Add backend-only solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - **PhotoBank.Console** – консольные утилиты.
 - **PhotoBank.DbContext**, **PhotoBank.Repositories**, **PhotoBank.Services**, **PhotoBank.ViewModel.Dto** – общие слои приложения.
 - **PhotoBank.UnitTests**, **PhotoBank.IntegrationTests** – проекты с тестами.
+- **PhotoBank.Backend.sln** – решение со всеми бэкенд‑проектами без MAUI.
 
 ## Сборка и запуск
 
@@ -84,6 +85,8 @@ dotnet run --project PhotoBank.MAUI.Blazor
 
 ```bash
 dotnet test PhotoBank.sln
+# либо
+dotnet test PhotoBank.Backend.sln
 ```
 
 Для пакетов Node.js:
@@ -117,6 +120,7 @@ The project is composed of several modules:
 - **PhotoBank.Console** – command-line utilities.
 - **PhotoBank.DbContext**, **PhotoBank.Repositories**, **PhotoBank.Services**, **PhotoBank.ViewModel.Dto** – common layers.
 - **PhotoBank.UnitTests**, **PhotoBank.IntegrationTests** – test projects.
+- **PhotoBank.Backend.sln** – solution containing all backend projects without the MAUI client.
 
 ## Build and run
 
@@ -188,6 +192,8 @@ For .NET projects:
 
 ```bash
 dotnet test PhotoBank.sln
+# or
+dotnet test PhotoBank.Backend.sln
 ```
 
 For Node.js packages:

--- a/backend/PhotoBank.Backend.sln
+++ b/backend/PhotoBank.Backend.sln
@@ -1,0 +1,111 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31808.319
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.Console", "PhotoBank.Console\PhotoBank.Console.csproj", "{3D391550-A562-4E89-BE78-0FAD842150C7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.DbContext", "PhotoBank.DbContext\PhotoBank.DbContext.csproj", "{0B58F0BB-872E-4644-ADFD-2F52312B95B4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.Repositories", "PhotoBank.Repositories\PhotoBank.Repositories.csproj", "{BB03B6F7-5A40-4D48-97E2-75CFC99191D1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.Services", "PhotoBank.Services\PhotoBank.Services.csproj", "{01B72FEE-BD48-43D8-B155-9E2B2D953C55}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.UnitTests", "PhotoBank.UnitTests\PhotoBank.UnitTests.csproj", "{8D6228B3-00A6-4D7F-97F8-80BA25278155}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.IntegrationTests", "PhotoBank.IntegrationTests\PhotoBank.IntegrationTests.csproj", "{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.ServerBlazorApp", "Photobank.ServerBlazorApp\PhotoBank.ServerBlazorApp.csproj", "{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoBank.Api", "PhotoBank.Api\PhotoBank.Api.csproj", "{3267B5DA-F866-471C-B496-2510EAED53E4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoBank.ViewModel.Dto", "PhotoBank.ViewModel.Dto\PhotoBank.ViewModel.Dto.csproj", "{84FA7787-892C-45A8-8988-B21CBA3FE2AC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3D391550-A562-4E89-BE78-0FAD842150C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D391550-A562-4E89-BE78-0FAD842150C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D391550-A562-4E89-BE78-0FAD842150C7}.Debug|x64.ActiveCfg = Debug|x64
+		{3D391550-A562-4E89-BE78-0FAD842150C7}.Debug|x64.Build.0 = Debug|x64
+		{3D391550-A562-4E89-BE78-0FAD842150C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D391550-A562-4E89-BE78-0FAD842150C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D391550-A562-4E89-BE78-0FAD842150C7}.Release|x64.ActiveCfg = Release|x64
+		{3D391550-A562-4E89-BE78-0FAD842150C7}.Release|x64.Build.0 = Release|x64
+		{0B58F0BB-872E-4644-ADFD-2F52312B95B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B58F0BB-872E-4644-ADFD-2F52312B95B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B58F0BB-872E-4644-ADFD-2F52312B95B4}.Debug|x64.ActiveCfg = Debug|x64
+		{0B58F0BB-872E-4644-ADFD-2F52312B95B4}.Debug|x64.Build.0 = Debug|x64
+		{0B58F0BB-872E-4644-ADFD-2F52312B95B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B58F0BB-872E-4644-ADFD-2F52312B95B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B58F0BB-872E-4644-ADFD-2F52312B95B4}.Release|x64.ActiveCfg = Release|x64
+		{0B58F0BB-872E-4644-ADFD-2F52312B95B4}.Release|x64.Build.0 = Release|x64
+		{BB03B6F7-5A40-4D48-97E2-75CFC99191D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB03B6F7-5A40-4D48-97E2-75CFC99191D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB03B6F7-5A40-4D48-97E2-75CFC99191D1}.Debug|x64.ActiveCfg = Debug|x64
+		{BB03B6F7-5A40-4D48-97E2-75CFC99191D1}.Debug|x64.Build.0 = Debug|x64
+		{BB03B6F7-5A40-4D48-97E2-75CFC99191D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB03B6F7-5A40-4D48-97E2-75CFC99191D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB03B6F7-5A40-4D48-97E2-75CFC99191D1}.Release|x64.ActiveCfg = Release|x64
+		{BB03B6F7-5A40-4D48-97E2-75CFC99191D1}.Release|x64.Build.0 = Release|x64
+		{01B72FEE-BD48-43D8-B155-9E2B2D953C55}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01B72FEE-BD48-43D8-B155-9E2B2D953C55}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01B72FEE-BD48-43D8-B155-9E2B2D953C55}.Debug|x64.ActiveCfg = Debug|x64
+		{01B72FEE-BD48-43D8-B155-9E2B2D953C55}.Debug|x64.Build.0 = Debug|x64
+		{01B72FEE-BD48-43D8-B155-9E2B2D953C55}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01B72FEE-BD48-43D8-B155-9E2B2D953C55}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01B72FEE-BD48-43D8-B155-9E2B2D953C55}.Release|x64.ActiveCfg = Release|x64
+		{01B72FEE-BD48-43D8-B155-9E2B2D953C55}.Release|x64.Build.0 = Release|x64
+		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Debug|x64.ActiveCfg = Debug|x64
+		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Debug|x64.Build.0 = Debug|x64
+		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|x64.ActiveCfg = Release|x64
+		{8D6228B3-00A6-4D7F-97F8-80BA25278155}.Release|x64.Build.0 = Release|x64
+		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Debug|x64.ActiveCfg = Debug|x64
+		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Debug|x64.Build.0 = Debug|x64
+		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|x64.ActiveCfg = Release|x64
+		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|x64.Build.0 = Release|x64
+		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|x64.Build.0 = Debug|Any CPU
+		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|x64.ActiveCfg = Release|Any CPU
+		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|x64.Build.0 = Release|Any CPU
+		{3267B5DA-F866-471C-B496-2510EAED53E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3267B5DA-F866-471C-B496-2510EAED53E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3267B5DA-F866-471C-B496-2510EAED53E4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3267B5DA-F866-471C-B496-2510EAED53E4}.Debug|x64.Build.0 = Debug|Any CPU
+		{3267B5DA-F866-471C-B496-2510EAED53E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3267B5DA-F866-471C-B496-2510EAED53E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3267B5DA-F866-471C-B496-2510EAED53E4}.Release|x64.ActiveCfg = Release|Any CPU
+		{3267B5DA-F866-471C-B496-2510EAED53E4}.Release|x64.Build.0 = Release|Any CPU
+		{84FA7787-892C-45A8-8988-B21CBA3FE2AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84FA7787-892C-45A8-8988-B21CBA3FE2AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84FA7787-892C-45A8-8988-B21CBA3FE2AC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{84FA7787-892C-45A8-8988-B21CBA3FE2AC}.Debug|x64.Build.0 = Debug|Any CPU
+		{84FA7787-892C-45A8-8988-B21CBA3FE2AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84FA7787-892C-45A8-8988-B21CBA3FE2AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84FA7787-892C-45A8-8988-B21CBA3FE2AC}.Release|x64.ActiveCfg = Release|Any CPU
+		{84FA7787-892C-45A8-8988-B21CBA3FE2AC}.Release|x64.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2A884144-2694-464F-9578-96F68C48D53E}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add `PhotoBank.Backend.sln` for building backend projects without the MAUI client
- update README with a note about this solution and the test commands

## Testing
- `pnpm -r test`
- `dotnet test PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687d1ecba3e483288c607653709afa6c