### PR TITLE
Fix missing using for SemaphoreSlim

### DIFF
--- a/backend/PhotoBank.Services/DependencyExecutor.cs
+++ b/backend/PhotoBank.Services/DependencyExecutor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PhotoBank.Services;


### PR DESCRIPTION
## Summary
- add missing `System.Threading` import so SemaphoreSlim is recognized

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_687d2283cfc083289356c3d91d30ac87