### PR TITLE
Add image tags to compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   api:
     build:
       context: ./backend
+    image: makhin/photobank-api:latest
     ports:
       - "5066:5066"
 
@@ -9,6 +10,7 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile.frontend
+    image: makhin/photobank-frontend:latest
     ports:
       - "5173:5173"
     depends_on:
@@ -18,6 +20,7 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile.bot
+    image: makhin/photobank-bot:latest
     environment:
       - BOT_TOKEN=${BOT_TOKEN}
       - API_EMAIL=${API_EMAIL}


### PR DESCRIPTION
## Summary
- update docker-compose to include image names for each service

## Testing
- `pnpm -r test` in `frontend`
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: current .NET SDK does not support .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687e907a56f08328a60272228b2bf185