### PR TITLE
Add service info page to frontend

### DIFF
--- a/frontend/packages/frontend/src/pages/service/ServiceInfoPage.tsx
+++ b/frontend/packages/frontend/src/pages/service/ServiceInfoPage.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { StatusCard } from '@/components/StatusCard';
+import { API_BASE_URL } from '@photobank/shared/config';
+import { serviceInfoTitle } from '@photobank/shared/constants';
+
+export default function ServiceInfoPage() {
+  const info = {
+    appVersion: import.meta.env.VITE_APP_VERSION ?? 'unknown',
+    mode: import.meta.env.MODE,
+    apiBaseUrl: API_BASE_URL,
+    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : 'N/A',
+    platform: typeof navigator !== 'undefined' ? navigator.platform : 'N/A',
+  } as const;
+
+  return (
+    <div className="p-4 space-y-4">
+      <Card className="w-full max-w-md mx-auto">
+        <CardHeader>
+          <CardTitle>{serviceInfoTitle}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="list-disc list-inside space-y-1">
+            {Object.entries(info).map(([key, value]) => (
+              <li key={key}>
+                <span className="font-medium">{key}: </span>
+                <span className="break-all">{String(value)}</span>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+      <StatusCard />
+    </div>
+  );
+}

--- a/frontend/packages/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/packages/frontend/src/routes/AppRoutes.tsx
@@ -10,11 +10,13 @@ import RegisterPage from '@/pages/auth/RegisterPage.tsx';
 import LogoutPage from '@/pages/auth/LogoutPage.tsx';
 import MyProfilePage from '@/pages/profile/MyProfilePage.tsx';
 import UsersPage from '@/pages/admin/UsersPage.tsx';
+import ServiceInfoPage from '@/pages/service/ServiceInfoPage.tsx';
 
 export const AppRoutes = () => (
   <Routes>
     <Route path="/login" element={<LoginPage />} />
     <Route path="/register" element={<RegisterPage />} />
+    <Route path="/service" element={<ServiceInfoPage />} />
     <Route element={<RequireAuth />}>
       <Route path="/" element={<Navigate to="/filter" />} />
       <Route path="/logout" element={<LogoutPage />} />

--- a/frontend/packages/frontend/test/ServiceInfoPage.test.tsx
+++ b/frontend/packages/frontend/test/ServiceInfoPage.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import botReducer from '../src/features/bot/model/botSlice';
+import ServiceInfoPage from '../src/pages/service/ServiceInfoPage';
+import { serviceInfoTitle } from '@photobank/shared/constants';
+
+describe('ServiceInfoPage', () => {
+  it('renders technical information title', () => {
+    const store = configureStore({ reducer: { bot: botReducer } });
+    render(
+      <Provider store={store}>
+        <ServiceInfoPage />
+      </Provider>
+    );
+    expect(screen.getByText(serviceInfoTitle)).toBeTruthy();
+  });
+});

--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -170,3 +170,6 @@ export const colDetailsLabel = 'Details';
 // Admin pages
 export const manageUsersTitle = 'Manage Users';
 export const saveUserButtonText = 'Save User';
+
+// Service page
+export const serviceInfoTitle = 'Technical Information';


### PR DESCRIPTION
## Summary
- add ServiceInfoPage component displaying env information and StatusCard
- expose service page route in AppRoutes accessible without authentication
- provide `serviceInfoTitle` constant in shared package
- test new ServiceInfoPage with vitest

## Testing
- `pnpm --filter @photobank/frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68812ba453608328a2d742684b422919