### PR TITLE
Load API base URL from Resources.json

### DIFF
--- a/frontend/packages/frontend/public/Resources.json
+++ b/frontend/packages/frontend/public/Resources.json
@@ -1,0 +1,3 @@
+{
+  "API_BASE_URL": "http://localhost:5066"
+}

--- a/frontend/packages/frontend/src/main.tsx
+++ b/frontend/packages/frontend/src/main.tsx
@@ -1,6 +1,8 @@
 import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
+import { loadResources, getApiBaseUrl } from '@photobank/shared/config';
+import { setApiBaseUrl } from '@photobank/shared/api';
 
 import { store } from '@/app/store';
 
@@ -8,11 +10,18 @@ import App from './app/App.tsx';
 
 import './index.css';
 
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <Provider store={store}>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </Provider>
-);
+async function start() {
+  await loadResources();
+  setApiBaseUrl(getApiBaseUrl());
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>,
+  );
+}
+
+start();

--- a/frontend/packages/shared/Resources.json
+++ b/frontend/packages/shared/Resources.json
@@ -1,0 +1,3 @@
+{
+  "API_BASE_URL": "http://localhost:5066"
+}

--- a/frontend/packages/shared/src/api/client.ts
+++ b/frontend/packages/shared/src/api/client.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import {API_BASE_URL, isBrowser} from "@photobank/shared/config";
+import { getApiBaseUrl, isBrowser } from "@photobank/shared/config";
 import {getAuthToken} from './auth';
 
 let impersonateUser: string | null = null;
@@ -8,13 +8,17 @@ export const setImpersonateUser = (username: string | null | undefined) => {
 };
 
 export const apiClient = axios.create({
-  baseURL: `${API_BASE_URL}/api/`,
+  baseURL: '',
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
   },
   withCredentials: true,
 });
+
+export function setApiBaseUrl(url: string) {
+  apiClient.defaults.baseURL = `${url}/api/`;
+}
 
 apiClient.interceptors.request.use((config) => {
   const token = getAuthToken();

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -6,7 +6,8 @@ import { loadDictionaries } from "@photobank/shared/dictionaries";
 import { photoByIdCommand } from "./commands/photoById";
 import { registerPhotoRoutes } from "./commands/photoRouter";
 import { profileCommand } from "./commands/profile";
-import { login, setImpersonateUser } from "@photobank/shared/api";
+import { login, setImpersonateUser, setApiBaseUrl } from "@photobank/shared/api";
+import { loadResources, getApiBaseUrl } from "@photobank/shared/config";
 import {
     captionMissingMsg,
     unknownMessageReplyMsg,
@@ -22,6 +23,9 @@ bot.use(async (ctx, next) => {
 });
 
 registerPhotoRoutes(bot);
+
+await loadResources();
+setApiBaseUrl(getApiBaseUrl());
 
 await login({ email: API_EMAIL, password: API_PASSWORD });
 await loadDictionaries();


### PR DESCRIPTION
## Summary
- move API_BASE_URL definition to Resources.json
- load Resources.json on startup for bot and frontend
- allow api client base URL to be set after loading
- update bot and frontend entrypoints to read Resources.json

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6881b9e809f083288f987de739d2046f