### PR TITLE
Fix telegram bot startup error

### DIFF
--- a/frontend/packages/shared/src/config.ts
+++ b/frontend/packages/shared/src/config.ts
@@ -16,8 +16,8 @@ export async function loadResources(): Promise<void> {
       }
     } else {
       const fs = await import('fs/promises');
-      const path = await import('path');
-      const file = await fs.readFile(path.resolve(__dirname, '../Resources.json'), 'utf-8');
+      const url = new URL('../Resources.json', import.meta.url);
+      const file = await fs.readFile(url, 'utf-8');
       data = JSON.parse(file);
     }
     if (data?.API_BASE_URL) {


### PR DESCRIPTION
## Summary
- load resources using URL instead of `__dirname` to support ESM modules

## Testing
- `npx pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6881e5fdebe48328a7f21a7e5848577a