### PR TITLE
Optimize PhotoService

### DIFF
--- a/backend/PhotoBank.Services/Api/PhotoService.cs
+++ b/backend/PhotoBank.Services/Api/PhotoService.cs
@@ -1,179 +1,178 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Repositories;
 using PhotoBank.ViewModel.Dto;
 
-namespace PhotoBank.Services.Api
+namespace PhotoBank.Services.Api;
+
+public interface IPhotoService
 {
-    public interface IPhotoService
+    Task<QueryResult> GetAllPhotosAsync(FilterDto filter);
+    Task<PhotoDto> GetPhotoAsync(int id);
+    Task<IEnumerable<PersonDto>> GetAllPersonsAsync();
+    Task<IEnumerable<StorageDto>> GetAllStoragesAsync();
+    Task<IEnumerable<TagDto>> GetAllTagsAsync();
+    Task<IEnumerable<PathDto>> GetAllPathsAsync();
+    Task UpdateFaceAsync(int faceId, int personId);
+}
+
+public class PhotoService : IPhotoService
+{
+    private readonly IRepository<Photo> _photoRepository;
+    private readonly IRepository<Face> _faceRepository;
+    private readonly IMapper _mapper;
+    private readonly IMemoryCache _cache;
+    private readonly Lazy<Task<IReadOnlyList<PersonDto>>> _persons;
+    private readonly Lazy<Task<IReadOnlyList<StorageDto>>> _storages;
+    private readonly Lazy<Task<IReadOnlyList<TagDto>>> _tags;
+    private readonly Lazy<Task<IReadOnlyList<PathDto>>> _paths;
+
+    private static readonly MemoryCacheEntryOptions CacheOptions = new()
+        { AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5) };
+
+    public PhotoService(
+        IRepository<Photo> photoRepository,
+        IRepository<Person> personRepository,
+        IRepository<Face> faceRepository,
+        IRepository<Storage> storageRepository,
+        IRepository<Tag> tagRepository,
+        IMapper mapper,
+        IMemoryCache cache)
     {
-        Task<QueryResult> GetAllPhotosAsync(FilterDto filter);
-        Task<PhotoDto> GetPhotoAsync(int id);
-        Task<IEnumerable<PersonDto>> GetAllPersonsAsync();
-        Task<IEnumerable<StorageDto>> GetAllStoragesAsync();
-        Task<IEnumerable<TagDto>> GetAllTagsAsync();
-        Task<IEnumerable<PathDto>> GetAllPathsAsync();
-        Task UpdateFaceAsync(int faceId, int personId);
+        _photoRepository = photoRepository;
+        _faceRepository = faceRepository;
+        _mapper = mapper;
+        _cache = cache;
+        _persons = new Lazy<Task<IReadOnlyList<PersonDto>>>(() =>
+            GetCachedAsync("persons", () => personRepository.GetAll()
+                .OrderBy(p => p.Name)
+                .ProjectTo<PersonDto>(_mapper.ConfigurationProvider)
+                .ToListAsync()));
+        _storages = new Lazy<Task<IReadOnlyList<StorageDto>>>(() =>
+            GetCachedAsync("storages", () => storageRepository.GetAll()
+                .OrderBy(p => p.Name)
+                .ProjectTo<StorageDto>(_mapper.ConfigurationProvider)
+                .ToListAsync()));
+        _tags = new Lazy<Task<IReadOnlyList<TagDto>>>(() =>
+            GetCachedAsync("tags", () => tagRepository.GetAll()
+                .OrderBy(p => p.Name)
+                .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
+                .ToListAsync()));
+        _paths = new Lazy<Task<IReadOnlyList<PathDto>>>(() =>
+            GetCachedAsync("paths", () => photoRepository.GetAll()
+                .ProjectTo<PathDto>(_mapper.ConfigurationProvider)
+                .Distinct()
+                .OrderBy(p => p.Path)
+                .ToListAsync()));
     }
 
-    public class PhotoService : IPhotoService
+    private async Task<IReadOnlyList<T>> GetCachedAsync<T>(string key, Func<Task<IReadOnlyList<T>>> factory)
     {
-        private readonly IRepository<Photo> _photoRepository;
-        private readonly IRepository<Face> _faceRepository;
-        private readonly IMapper _mapper;
-        private readonly Lazy<Task<List<PersonDto>>> _persons;
-        private readonly Lazy<Task<List<StorageDto>>> _storages;
-        private readonly Lazy<Task<List<TagDto>>> _tags;
-        private readonly Lazy<Task<List<PathDto>>> _paths;
-
-        public PhotoService(
-            IRepository<Photo> photoRepository,
-            IRepository<Person> personRepository,
-            IRepository<Face> faceRepository,
-            IRepository<Storage> storageRepository,
-            IRepository<Tag> tagRepository,
-            IMapper mapper)
+        if (!_cache.TryGetValue(key, out IReadOnlyList<T> values))
         {
-            _photoRepository = photoRepository;
-            _faceRepository = faceRepository;
-            _mapper = mapper;
-            _persons = new Lazy<Task<List<PersonDto>>>(() => personRepository.GetAll().OrderBy(p => p.Name).ProjectTo<PersonDto>(_mapper.ConfigurationProvider).ToListAsync());
-            _storages = new Lazy<Task<List<StorageDto>>>(() => storageRepository.GetAll().OrderBy(p => p.Name).ProjectTo<StorageDto>(_mapper.ConfigurationProvider).ToListAsync());
-            _tags = new Lazy<Task<List<TagDto>>>(() => tagRepository.GetAll().OrderBy(p => p.Name).ProjectTo<TagDto>(_mapper.ConfigurationProvider).ToListAsync());
-            _paths = new Lazy<Task<List<PathDto>>>(() => photoRepository.GetAll()
-                .ProjectTo<PathDto>(_mapper.ConfigurationProvider).Distinct().OrderBy(p=>p.Path).ToListAsync());
+            values = await factory();
+            _cache.Set(key, values, CacheOptions);
         }
 
-        public async Task<QueryResult> GetAllPhotosAsync(FilterDto filter)
+        return values;
+    }
+
+    private static IQueryable<Photo> ApplyFilter(IQueryable<Photo> query, FilterDto filter)
+    {
+        if (filter.IsBW is true) query = query.Where(p => p.IsBW);
+        if (filter.IsAdultContent is true) query = query.Where(p => p.IsAdultContent);
+        if (filter.IsRacyContent is true) query = query.Where(p => p.IsRacyContent);
+        if (filter.TakenDateFrom.HasValue)
+            query = query.Where(p => p.TakenDate.HasValue && p.TakenDate >= filter.TakenDateFrom.Value);
+        if (filter.TakenDateTo.HasValue)
+            query = query.Where(p => p.TakenDate.HasValue && p.TakenDate <= filter.TakenDateTo.Value);
+        if (filter.ThisDay is true)
+            query = query.Where(p => p.TakenDate.HasValue &&
+                                     p.TakenDate.Value.Day == DateTime.Today.Day &&
+                                     p.TakenDate.Value.Month == DateTime.Today.Month);
+        if (filter.Storages?.Any() == true)
         {
-            var query = _photoRepository
-                .GetAll()
-                .AsNoTrackingWithIdentityResolution()
-                .AsSplitQuery();
+            var storages = filter.Storages.ToList();
+            query = query.Where(p => storages.Contains(p.StorageId));
 
-            if (filter.IsBW is true)
-            {
-                query = query.Where(p => p.IsBW);
-            }
-
-            if (filter.IsAdultContent is true)
-            {
-                query = query.Where(p => p.IsAdultContent);
-            }
-
-            if (filter.IsRacyContent is true)
-            {
-                query = query.Where(p => p.IsRacyContent);
-            }
-
-            if (filter.TakenDateFrom.HasValue)
-            {
-                query = query.Where(p => p.TakenDate.HasValue && p.TakenDate >= filter.TakenDateFrom.Value);
-            }
-
-            if (filter.TakenDateTo.HasValue)
-            {
-                query = query.Where(p => p.TakenDate.HasValue && p.TakenDate <= filter.TakenDateTo.Value);
-            }
-
-            if (filter.ThisDay is true)
-            {
-                query = query.Where(p =>
-                    p.TakenDate.HasValue && p.TakenDate.Value.Day == DateTime.Today.Day &&
-                    p.TakenDate.Value.Month == DateTime.Today.Month);
-            }
-
-            if (filter.Storages != null && filter.Storages.Any())
-            {
-                var storages = filter.Storages.ToList();
-                query = query.Where(p => storages.Contains(p.StorageId));
-
-                if (!string.IsNullOrEmpty(filter.RelativePath))
-                {
-                    query = query.Where(p => p.RelativePath == filter.RelativePath);
-                }
-            }
-
-            if (!string.IsNullOrEmpty(filter.Caption))
-            {
-                query = query.Where(p => p.Captions.Any(c => EF.Functions.FreeText(c.Text, filter.Caption!)));
-            }
-
-            if (filter.Persons != null && filter.Persons.Any())
-            {
-                var ids = filter.Persons.ToList();
-                query = query.Where(p => ids.All(id => p.Faces.Any(f => f.PersonId == id)));
-            }
-
-            if (filter.Tags != null && filter.Tags.Any())
-            {
-                var ids = filter.Tags.ToList();
-                query = query.Where(p => ids.All(id => p.PhotoTags.Any(t => t.TagId == id)));
-            }
-
-            var result = new QueryResult
-            {
-                Count = await query.CountAsync(),
-                Photos = await query
-                    .OrderByDescending(p => p.TakenDate)
-                    .Skip(filter.Skip ?? 0)
-                    .Take(filter.Top ?? int.MaxValue)
-                    .ProjectTo<PhotoItemDto>(_mapper.ConfigurationProvider)
-                    .ToListAsync()
-            };
-
-            return result;
+            if (!string.IsNullOrEmpty(filter.RelativePath))
+                query = query.Where(p => p.RelativePath == filter.RelativePath);
         }
 
-        public async Task<PhotoDto> GetPhotoAsync(int id)
+        if (!string.IsNullOrEmpty(filter.Caption))
+            query = query.Where(p => p.Captions.Any(c => EF.Functions.FreeText(c.Text, filter.Caption!)));
+
+        if (filter.Persons?.Any() == true)
         {
-            var photo = await _photoRepository.GetAsync(id,
-                p => p
-                    .Include(p1 => p1.Faces)
-                    .ThenInclude(f => f.Person)
-                    .Include(p1 => p1.Captions)
-                    .Include(p1 => p1.PhotoTags)
-                    .ThenInclude(t => t.Tag)
-            );
-            return _mapper.Map<Photo, PhotoDto>(photo);
+            var ids = filter.Persons.ToList();
+            query = query.Where(p => ids.All(id => p.Faces.Any(f => f.PersonId == id)));
         }
 
-        public async Task<IEnumerable<PersonDto>> GetAllPersonsAsync()
+        if (filter.Tags?.Any() == true)
         {
-            return await _persons.Value;
+            var ids = filter.Tags.ToList();
+            query = query.Where(p => ids.All(id => p.PhotoTags.Any(t => t.TagId == id)));
         }
 
-        public async Task<IEnumerable<PathDto>> GetAllPathsAsync()
-        {
-            return await _paths.Value;
-        }
+        return query;
+    }
 
-        public async Task<IEnumerable<StorageDto>> GetAllStoragesAsync()
-        {
-            return await _storages.Value;
-        }
+    public async Task<QueryResult> GetAllPhotosAsync(FilterDto filter)
+    {
+        var query = ApplyFilter(_photoRepository.GetAll().AsNoTracking().AsSplitQuery(), filter);
 
-        public async Task<IEnumerable<TagDto>> GetAllTagsAsync()
-        {
-            return await _tags.Value;
-        }
+        var countTask = query.CountAsync();
+        var photosTask = query
+            .OrderByDescending(p => p.TakenDate)
+            .Skip(filter.Skip ?? 0)
+            .Take(filter.Top ?? int.MaxValue)
+            .ProjectTo<PhotoItemDto>(_mapper.ConfigurationProvider)
+            .ToListAsync();
 
-        public async Task UpdateFaceAsync(int faceId, int personId)
+        await Task.WhenAll(countTask, photosTask);
+
+        return new QueryResult
         {
-            var face = new Face
-            {
-                Id = faceId,
-                IdentifiedWithConfidence = personId == -1 ? 0 : 1,
-                IdentityStatus = personId == -1 ? IdentityStatus.StopProcessing : IdentityStatus.Identified,
-                PersonId = personId == -1 ? (int?)null : personId
-            };
-            await _faceRepository.UpdateAsync(face, f => f.PersonId, f => f.IdentifiedWithConfidence, f => f.IdentityStatus);
-        }
+            Count = countTask.Result,
+            Photos = photosTask.Result
+        };
+    }
+
+    public async Task<PhotoDto> GetPhotoAsync(int id)
+    {
+        var photo = await _photoRepository.GetAsync(id,
+            q => q.Include(p => p.Faces).ThenInclude(f => f.Person)
+                   .Include(p => p.Captions)
+                   .Include(p => p.PhotoTags).ThenInclude(t => t.Tag));
+
+        return _mapper.Map<Photo, PhotoDto>(photo);
+    }
+
+    public async Task<IEnumerable<PersonDto>> GetAllPersonsAsync() => await _persons.Value;
+
+    public async Task<IEnumerable<PathDto>> GetAllPathsAsync() => await _paths.Value;
+
+    public async Task<IEnumerable<StorageDto>> GetAllStoragesAsync() => await _storages.Value;
+
+    public async Task<IEnumerable<TagDto>> GetAllTagsAsync() => await _tags.Value;
+
+    public async Task UpdateFaceAsync(int faceId, int personId)
+    {
+        var face = new Face
+        {
+            Id = faceId,
+            IdentifiedWithConfidence = personId == -1 ? 0 : 1,
+            IdentityStatus = personId == -1 ? IdentityStatus.StopProcessing : IdentityStatus.Identified,
+            PersonId = personId == -1 ? (int?)null : personId
+        };
+        await _faceRepository.UpdateAsync(face, f => f.PersonId, f => f.IdentifiedWithConfidence, f => f.IdentityStatus);
     }
 }
+

--- a/backend/PhotoBank.Services/PhotoBank.Services.csproj
+++ b/backend/PhotoBank.Services/PhotoBank.Services.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.7" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/PhotoBank.Services/RegisterServicesForApi.cs
+++ b/backend/PhotoBank.Services/RegisterServicesForApi.cs
@@ -8,6 +8,7 @@ namespace PhotoBank.Services
     {
         public static void Configure(IServiceCollection services)
         {
+            services.AddMemoryCache();
             services.AddTransient(typeof(IRepository<>), typeof(Repository<>));
             services.AddTransient<IPhotoService, PhotoService>();
             services.AddTransient<ITokenService, TokenService>();

--- a/backend/PhotoBank.Services/RegisterServicesForConsole.cs
+++ b/backend/PhotoBank.Services/RegisterServicesForConsole.cs
@@ -22,6 +22,7 @@ namespace PhotoBank.Services
 
         public static void Configure(IServiceCollection services, IConfiguration configuration)
         {
+            services.AddMemoryCache();
             services.AddSingleton<IComputerVisionClient, ComputerVisionClient>(provider =>
             {
                 var key = configuration.GetSection(ComputerVision)["Key"];


### PR DESCRIPTION
## Summary
- add memory cache dependency
- cache person, storage, tag, and path lists
- refactor PhotoService to use caching and a helper for building queries
- run queries for count and data concurrently
- add memory cache registration for API and console

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688219ec9b6c832890c8a9aa5f300200