### PR TITLE
Implement /filter wizard command

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/filter.ts
+++ b/frontend/packages/telegram-bot/src/commands/filter.ts
@@ -1,0 +1,107 @@
+import { Context, InlineKeyboard } from "grammy";
+import { searchPhotos } from "@photobank/shared/api/photos";
+import type { FilterDto } from "@photobank/shared/types";
+import {
+    prevPageText,
+    nextPageText,
+    sorryTryToRequestLaterMsg,
+    photoNotFoundMsg,
+    apiErrorMsg,
+} from "@photobank/shared/constants";
+import { sendPhotoById } from "../photo";
+
+interface WizardState {
+    step: number;
+    filter: FilterDto;
+}
+
+const wizards = new Map<number, WizardState>();
+
+interface ResultState {
+    ids: number[];
+    index: number;
+}
+
+const results = new Map<number, ResultState>();
+
+export async function filterCommand(ctx: Context) {
+    wizards.set(ctx.chat.id, { step: 1, filter: {} });
+    await ctx.reply("Введите ID хранилища:");
+}
+
+export async function handleFilterWizard(ctx: Context) {
+    const state = wizards.get(ctx.chat.id);
+    if (!state || !ctx.message?.text) return false;
+    const text = ctx.message.text.trim();
+
+    switch (state.step) {
+        case 1:
+            state.filter.storages = text ? [Number(text)] : undefined;
+            state.step = 2;
+            await ctx.reply("Введите дату YYYY-MM-DD:");
+            break;
+        case 2:
+            state.filter.takenDateFrom = text || undefined;
+            state.filter.takenDateTo = text || undefined;
+            state.step = 3;
+            await ctx.reply("Введите ID персоны:");
+            break;
+        case 3:
+            state.filter.persons = text ? [Number(text)] : undefined;
+            state.step = 4;
+            await ctx.reply("Введите ID тега:");
+            break;
+        case 4:
+            state.filter.tags = text ? [Number(text)] : undefined;
+            state.step = 5;
+            await ctx.reply("Контент для взрослых? (yes/no)");
+            break;
+        case 5:
+            state.filter.isAdultContent = /^y(es)?|1|да$/i.test(text);
+            wizards.delete(ctx.chat.id);
+            await executeFilter(ctx, state.filter);
+            break;
+    }
+    return true;
+}
+
+async function executeFilter(ctx: Context, filter: FilterDto) {
+    let queryResult;
+    try {
+        queryResult = await searchPhotos(filter);
+    } catch (err) {
+        console.error(apiErrorMsg, err);
+        await ctx.reply(sorryTryToRequestLaterMsg);
+        return;
+    }
+
+    if (!queryResult.photos?.length) {
+        await ctx.reply(photoNotFoundMsg);
+        return;
+    }
+
+    const ids = queryResult.photos.map(p => p.id);
+    results.set(ctx.chat.id, { ids, index: 0 });
+    await sendFilteredPhoto(ctx, ctx.chat.id, 0);
+}
+
+async function sendFilteredPhoto(ctx: Context, chatId: number, index: number) {
+    const state = results.get(chatId);
+    if (!state) return;
+    state.index = index;
+    const id = state.ids[index];
+    await sendPhotoById(ctx, id);
+    const keyboard = new InlineKeyboard();
+    if (index > 0) keyboard.text(prevPageText, `filter_prev:${index - 1}`);
+    if (index < state.ids.length - 1) keyboard.text(nextPageText, `filter_next:${index + 1}`);
+    await ctx.reply("Переключайте фото:", { reply_markup: keyboard });
+}
+
+export async function handleFilterNavigation(ctx: Context) {
+    const match = ctx.callbackQuery?.data?.match(/^filter_(next|prev):(\d+)$/);
+    if (!match) return false;
+    const index = Number(match[2]);
+    await ctx.answerCallbackQuery();
+    await sendFilteredPhoto(ctx, ctx.chat.id, index);
+    return true;
+}

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -2,6 +2,7 @@ import { Bot } from "grammy";
 import {BOT_TOKEN, API_EMAIL, API_PASSWORD} from "./config";
 import {sendThisDayPage, thisDayCommand, captionCache} from "./commands/thisday";
 import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
+import { filterCommand, handleFilterWizard, handleFilterNavigation } from "./commands/filter";
 import { loadDictionaries } from "@photobank/shared/dictionaries";
 import { photoByIdCommand } from "./commands/photoById";
 import { registerPhotoRoutes } from "./commands/photoRouter";
@@ -43,6 +44,8 @@ bot.command("profile", profileCommand);
 
 bot.command("subscribe", subscribeCommand);
 
+bot.command("filter", filterCommand);
+
 bot.callbackQuery(/^thisday:(\d+)$/, async (ctx) => {
     const page = parseInt(ctx.match[1], 10);
     await ctx.answerCallbackQuery();
@@ -54,6 +57,10 @@ bot.callbackQuery(/^caption:(\d+)$/, async (ctx) => {
     const caption = captionCache.get(id);
     await ctx.answerCallbackQuery(caption ?? captionMissingMsg, { show_alert: true });
 });
+
+bot.callbackQuery(/^filter_(next|prev):(\d+)$/, handleFilterNavigation);
+
+bot.on("message:text", handleFilterWizard);
 
 bot.on("message", (ctx) => ctx.reply(unknownMessageReplyMsg));
 

--- a/frontend/packages/telegram-bot/test/filter.test.ts
+++ b/frontend/packages/telegram-bot/test/filter.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { filterCommand, handleFilterWizard } from '../src/commands/filter';
+
+describe('filterCommand wizard', () => {
+  it('starts wizard and asks for storage', async () => {
+    const ctx = { chat: { id: 1 }, reply: vi.fn() } as any;
+    await filterCommand(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith('Введите ID хранилища:');
+  });
+
+  it('handles first step and asks for date', async () => {
+    const ctxStart = { chat: { id: 2 }, reply: vi.fn() } as any;
+    await filterCommand(ctxStart);
+    const ctx = { chat: { id: 2 }, message: { text: '1' }, reply: vi.fn() } as any;
+    await handleFilterWizard(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith('Введите дату YYYY-MM-DD:');
+  });
+});


### PR DESCRIPTION
## Summary
- create new Telegram bot command `/filter`
- implement wizard to gather filter parameters and request photos
- navigate photos with inline keyboard
- register the command and handlers
- add basic unit tests for the wizard logic

## Testing
- `pnpm test` in telegram-bot package
- `pnpm --recursive test`

------
https://chatgpt.com/codex/tasks/task_e_68825f415008832895001d9c36fd9f58