### PR TITLE
Implement inline photo editing

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photoRouter.ts
+++ b/frontend/packages/telegram-bot/src/commands/photoRouter.ts
@@ -1,5 +1,5 @@
 import { Bot, Context } from "grammy";
-import { sendPhotoById } from "../photo";
+import { sendPhotoById, openPhotoInline } from "../photo";
 import { photoCommandUsageMsg } from "@photobank/shared/constants";
 
 // Основная команда
@@ -31,6 +31,6 @@ export function registerPhotoRoutes(bot: Bot) {
     bot.callbackQuery(/^photo:(\d+)$/, async (ctx) => {
         const id = Number(ctx.match[1]);
         await ctx.answerCallbackQuery();
-        await sendPhotoById(ctx, id);
+        await openPhotoInline(ctx, id);
     });
 }

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -3,6 +3,16 @@ import { getPhotoById } from "@photobank/shared/api/photos";
 import { formatPhotoMessage } from "@photobank/shared/utils/formatPhotoMessage";
 import { photoNotFoundMsg } from "@photobank/shared/constants";
 
+export const photoMessages = new Map<number, number>();
+
+async function fetchPhoto(id: number) {
+    try {
+        return await getPhotoById(id);
+    } catch {
+        return null;
+    }
+}
+
 export async function sendPhotoById(ctx: Context, id: number) {
     let photo;
 
@@ -23,5 +33,58 @@ export async function sendPhotoById(ctx: Context, id: number) {
         });
     } else {
         await ctx.reply(caption, { parse_mode: "HTML" });
+    }
+}
+
+export async function openPhotoInline(ctx: Context, id: number) {
+    const chatId = ctx.chat?.id;
+    const photo = await fetchPhoto(id);
+    if (!photo) {
+        await ctx.reply(photoNotFoundMsg);
+        return;
+    }
+
+    const { caption, image } = formatPhotoMessage(photo);
+
+    if (!chatId) {
+        if (image) {
+            const file = new InputFile(image, `${photo.name}.jpg`);
+            await ctx.replyWithPhoto(file, { caption, parse_mode: "HTML" });
+        } else {
+            await ctx.reply(caption, { parse_mode: "HTML" });
+        }
+        return;
+    }
+
+    const existing = photoMessages.get(chatId);
+    if (existing) {
+        try {
+            if (image) {
+                const file = new InputFile(image, `${photo.name}.jpg`);
+                await ctx.api.editMessageMedia(chatId, existing, {
+                    type: "photo",
+                    media: file,
+                    caption,
+                    parse_mode: "HTML",
+                });
+            } else {
+                await ctx.api.editMessageCaption(chatId, existing, {
+                    caption,
+                    parse_mode: "HTML",
+                });
+            }
+            return;
+        } catch {
+            photoMessages.delete(chatId);
+        }
+    }
+
+    if (image) {
+        const file = new InputFile(image, `${photo.name}.jpg`);
+        const msg = await ctx.replyWithPhoto(file, { caption, parse_mode: "HTML" });
+        photoMessages.set(chatId, msg.message_id);
+    } else {
+        const msg = await ctx.reply(caption, { parse_mode: "HTML" });
+        photoMessages.set(chatId, msg.message_id);
     }
 }

--- a/frontend/packages/telegram-bot/test/photoInline.test.ts
+++ b/frontend/packages/telegram-bot/test/photoInline.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { openPhotoInline, photoMessages } from '../src/photo';
+import * as photosApi from '@photobank/shared/api/photos';
+
+const basePhoto = {
+  id: 1,
+  name: 'test',
+  scale: 1,
+  previewImage: Buffer.from('img').toString('base64'),
+  adultScore: 0,
+  racyScore: 0,
+  height: 100,
+  width: 100,
+};
+
+beforeEach(() => {
+  photoMessages.clear();
+  vi.restoreAllMocks();
+});
+
+it('sends new message and stores id', async () => {
+  vi.spyOn(photosApi, 'getPhotoById').mockResolvedValue(basePhoto as any);
+  const ctx = {
+    chat: { id: 1 },
+    replyWithPhoto: vi.fn().mockResolvedValue({ message_id: 42 }),
+    reply: vi.fn(),
+    api: { editMessageMedia: vi.fn(), editMessageCaption: vi.fn() },
+  } as any;
+  await openPhotoInline(ctx, 1);
+  expect(ctx.replyWithPhoto).toHaveBeenCalled();
+  expect(photoMessages.get(1)).toBe(42);
+});
+
+it('edits existing message when available', async () => {
+  vi.spyOn(photosApi, 'getPhotoById').mockResolvedValue(basePhoto as any);
+  photoMessages.set(1, 42);
+  const ctx = {
+    chat: { id: 1 },
+    api: { editMessageMedia: vi.fn(), editMessageCaption: vi.fn() },
+    replyWithPhoto: vi.fn().mockResolvedValue({ message_id: 43 }),
+    reply: vi.fn(),
+  } as any;
+  await openPhotoInline(ctx, 1);
+  expect(ctx.api.editMessageMedia).toHaveBeenCalled();
+  expect(ctx.replyWithPhoto).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- reuse the same message when opening photos from inline buttons
- add tests for editing inline photo messages

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68830f3408d48328bb0f0b9cac0fc53c