### PR TITLE
Add navigation in telegram bot photo viewer

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photoRouter.ts
+++ b/frontend/packages/telegram-bot/src/commands/photoRouter.ts
@@ -33,4 +33,10 @@ export function registerPhotoRoutes(bot: Bot) {
         await ctx.answerCallbackQuery();
         await openPhotoInline(ctx, id);
     });
+
+    bot.callbackQuery(/^photo_nav:(\d+)$/, async (ctx) => {
+        const id = Number(ctx.match[1]);
+        await ctx.answerCallbackQuery();
+        await openPhotoInline(ctx, id);
+    });
 }

--- a/frontend/packages/telegram-bot/src/commands/thisday.ts
+++ b/frontend/packages/telegram-bot/src/commands/thisday.ts
@@ -9,6 +9,7 @@ import {
     prevPageText,
     nextPageText,
 } from "@photobank/shared/constants";
+import { currentPagePhotos, deletePhotoMessage } from "../photo";
 
 export const captionCache = new Map<number, string>();
 
@@ -49,6 +50,14 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
     }
 
     const totalPages = Math.ceil(queryResult.count / PAGE_SIZE);
+
+    const chatId = ctx.chat?.id;
+    if (chatId) {
+        const prev = currentPagePhotos.get(chatId);
+        if (prev && prev.page !== page) {
+            await deletePhotoMessage(ctx);
+        }
+    }
     const byYear = new Map<number, Map<string, typeof queryResult.photos>>();
 
     for (const photo of queryResult.photos) {
@@ -96,6 +105,10 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
         if (index % 5 === 0) keyboard.row();
         keyboard.text(String(index + 1), `photo:${id}`);
     });
+
+    if (chatId) {
+        currentPagePhotos.set(chatId, { page, ids: photoIds });
+    }
 
     keyboard.row();
 

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -1,9 +1,23 @@
-import { Context, InputFile } from "grammy";
+import { Context, InputFile, InlineKeyboard } from "grammy";
 import { getPhotoById } from "@photobank/shared/api/photos";
 import { formatPhotoMessage } from "@photobank/shared/utils/formatPhotoMessage";
-import { photoNotFoundMsg } from "@photobank/shared/constants";
+import { photoNotFoundMsg, prevPageText, nextPageText } from "@photobank/shared/constants";
 
 export const photoMessages = new Map<number, number>();
+export const currentPagePhotos = new Map<number, { page: number; ids: number[] }>();
+
+export async function deletePhotoMessage(ctx: Context) {
+    const chatId = ctx.chat?.id;
+    const messageId = chatId ? photoMessages.get(chatId) : undefined;
+    if (chatId && messageId) {
+        try {
+            await ctx.api.deleteMessage(chatId, messageId);
+        } catch {
+            // ignore
+        }
+        photoMessages.delete(chatId);
+    }
+}
 
 async function fetchPhoto(id: number) {
     try {
@@ -46,12 +60,24 @@ export async function openPhotoInline(ctx: Context, id: number) {
 
     const { caption, image } = formatPhotoMessage(photo);
 
+    let keyboard: InlineKeyboard | undefined;
+    if (chatId) {
+        const list = currentPagePhotos.get(chatId);
+        if (list) {
+            const index = list.ids.indexOf(id);
+            keyboard = new InlineKeyboard();
+            if (index > 0) keyboard.text(prevPageText, `photo_nav:${list.ids[index - 1]}`);
+            if (index < list.ids.length - 1) keyboard.text(nextPageText, `photo_nav:${list.ids[index + 1]}`);
+            if (!keyboard.inline_keyboard.length) keyboard = undefined;
+        }
+    }
+
     if (!chatId) {
         if (image) {
             const file = new InputFile(image, `${photo.name}.jpg`);
-            await ctx.replyWithPhoto(file, { caption, parse_mode: "HTML" });
+            await ctx.replyWithPhoto(file, { caption, parse_mode: "HTML", reply_markup: keyboard });
         } else {
-            await ctx.reply(caption, { parse_mode: "HTML" });
+            await ctx.reply(caption, { parse_mode: "HTML", reply_markup: keyboard });
         }
         return;
     }
@@ -66,11 +92,13 @@ export async function openPhotoInline(ctx: Context, id: number) {
                     media: file,
                     caption,
                     parse_mode: "HTML",
+                    reply_markup: keyboard,
                 });
             } else {
                 await ctx.api.editMessageCaption(chatId, existing, {
                     caption,
                     parse_mode: "HTML",
+                    reply_markup: keyboard,
                 });
             }
             return;
@@ -81,10 +109,10 @@ export async function openPhotoInline(ctx: Context, id: number) {
 
     if (image) {
         const file = new InputFile(image, `${photo.name}.jpg`);
-        const msg = await ctx.replyWithPhoto(file, { caption, parse_mode: "HTML" });
+        const msg = await ctx.replyWithPhoto(file, { caption, parse_mode: "HTML", reply_markup: keyboard });
         photoMessages.set(chatId, msg.message_id);
     } else {
-        const msg = await ctx.reply(caption, { parse_mode: "HTML" });
+        const msg = await ctx.reply(caption, { parse_mode: "HTML", reply_markup: keyboard });
         photoMessages.set(chatId, msg.message_id);
     }
 }

--- a/frontend/packages/telegram-bot/test/photoInline.test.ts
+++ b/frontend/packages/telegram-bot/test/photoInline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { openPhotoInline, photoMessages } from '../src/photo';
+import { openPhotoInline, photoMessages, currentPagePhotos } from '../src/photo';
 import * as photosApi from '@photobank/shared/api/photos';
 
 const basePhoto = {
@@ -15,6 +15,7 @@ const basePhoto = {
 
 beforeEach(() => {
   photoMessages.clear();
+  currentPagePhotos.clear();
   vi.restoreAllMocks();
 });
 
@@ -26,9 +27,11 @@ it('sends new message and stores id', async () => {
     reply: vi.fn(),
     api: { editMessageMedia: vi.fn(), editMessageCaption: vi.fn() },
   } as any;
+  currentPagePhotos.set(1, { page: 1, ids: [1, 2] });
   await openPhotoInline(ctx, 1);
   expect(ctx.replyWithPhoto).toHaveBeenCalled();
   expect(photoMessages.get(1)).toBe(42);
+  expect(ctx.replyWithPhoto.mock.calls[0][1].reply_markup).toBeDefined();
 });
 
 it('edits existing message when available', async () => {
@@ -40,7 +43,24 @@ it('edits existing message when available', async () => {
     replyWithPhoto: vi.fn().mockResolvedValue({ message_id: 43 }),
     reply: vi.fn(),
   } as any;
+  currentPagePhotos.set(1, { page: 1, ids: [1, 2] });
   await openPhotoInline(ctx, 1);
   expect(ctx.api.editMessageMedia).toHaveBeenCalled();
   expect(ctx.replyWithPhoto).not.toHaveBeenCalled();
+  expect(ctx.api.editMessageMedia.mock.calls[0][2].reply_markup).toBeDefined();
+});
+
+it('adds navigation buttons from current page list', async () => {
+  vi.spyOn(photosApi, 'getPhotoById').mockResolvedValue(basePhoto as any);
+  const ctx = {
+    chat: { id: 1 },
+    replyWithPhoto: vi.fn().mockResolvedValue({ message_id: 1 }),
+    reply: vi.fn(),
+    api: { editMessageMedia: vi.fn(), editMessageCaption: vi.fn() },
+  } as any;
+  currentPagePhotos.set(1, { page: 1, ids: [1, 2, 3] });
+  await openPhotoInline(ctx, 2);
+  const kb = ctx.replyWithPhoto.mock.calls[0][1].reply_markup.inline_keyboard;
+  expect(kb[0][0].callback_data).toBe('photo_nav:1');
+  expect(kb[0][1].callback_data).toBe('photo_nav:3');
 });


### PR DESCRIPTION
## Summary
- add state to track current page photos
- add deletePhotoMessage helper
- add prev/next keyboard buttons in photo viewer
- clear open photo when page changes in /thisday
- handle new `photo_nav` callback
- test openPhotoInline navigation

## Testing
- `pnpm -r test` *(fails: FilterFormFields.test.tsx, PhotoDetailsPage.test.tsx)*
- `pnpm --filter telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_6883155ef2f48328a784adfbb7547bfb