### PR TITLE
Fix /thisday numbering and keep nav buttons

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/thisday.ts
+++ b/frontend/packages/telegram-bot/src/commands/thisday.ts
@@ -94,7 +94,8 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
                     const metaLine = metaParts.length ? `\n${metaParts.join(" ")}` : "";
 
                     const caption = photo.captions?.join(" ") ?? "";
-                    sections.push(`[-] <b>${title}</b> ${firstNWords(caption, 5)} ${metaLine}`);
+                    const index = photoIds.length + 1;
+                    sections.push(`[${index}] <b>${title}</b> ${firstNWords(caption, 5)} ${metaLine}`);
                     photoIds.push(photo.id);
                 });
             });

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -87,19 +87,22 @@ export async function openPhotoInline(ctx: Context, id: number) {
         try {
             if (image) {
                 const file = new InputFile(image, `${photo.name}.jpg`);
-                await ctx.api.editMessageMedia(chatId, existing, {
-                    type: "photo",
-                    media: file,
-                    caption,
-                    parse_mode: "HTML",
-                    reply_markup: keyboard,
-                });
+                await ctx.api.editMessageMedia(
+                    chatId,
+                    existing,
+                    {
+                        type: "photo",
+                        media: file,
+                        caption,
+                        parse_mode: "HTML",
+                    },
+                    { reply_markup: keyboard }
+                );
             } else {
                 await ctx.api.editMessageCaption(chatId, existing, {
                     caption,
                     parse_mode: "HTML",
-                    reply_markup: keyboard,
-                });
+                }, { reply_markup: keyboard });
             }
             return;
         } catch {

--- a/frontend/packages/telegram-bot/test/photoInline.test.ts
+++ b/frontend/packages/telegram-bot/test/photoInline.test.ts
@@ -47,7 +47,7 @@ it('edits existing message when available', async () => {
   await openPhotoInline(ctx, 1);
   expect(ctx.api.editMessageMedia).toHaveBeenCalled();
   expect(ctx.replyWithPhoto).not.toHaveBeenCalled();
-  expect(ctx.api.editMessageMedia.mock.calls[0][2].reply_markup).toBeDefined();
+  expect(ctx.api.editMessageMedia.mock.calls[0][3].reply_markup).toBeDefined();
 });
 
 it('adds navigation buttons from current page list', async () => {


### PR DESCRIPTION
## Summary
- show photo index numbers in /thisday listing
- preserve inline navigation buttons when browsing photos
- update tests for new editMessageMedia signature

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_68833b0588e48328bd7e528bf0286730