### PR TITLE
Fix Telegram bot page change behavior

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/thisday.ts
+++ b/frontend/packages/telegram-bot/src/commands/thisday.ts
@@ -29,6 +29,14 @@ export async function handleThisDay(ctx: Context) {
 export const thisDayCommand = handleThisDay;
 
 export async function sendThisDayPage(ctx: Context, page: number, edit = false) {
+    const chatId = ctx.chat?.id;
+    if (chatId) {
+        const prev = currentPagePhotos.get(chatId);
+        if (prev && prev.page !== page) {
+            await deletePhotoMessage(ctx);
+        }
+    }
+
     const skip = (page - 1) * PAGE_SIZE;
     let queryResult;
     try {
@@ -50,14 +58,6 @@ export async function sendThisDayPage(ctx: Context, page: number, edit = false) 
     }
 
     const totalPages = Math.ceil(queryResult.count / PAGE_SIZE);
-
-    const chatId = ctx.chat?.id;
-    if (chatId) {
-        const prev = currentPagePhotos.get(chatId);
-        if (prev && prev.page !== page) {
-            await deletePhotoMessage(ctx);
-        }
-    }
     const byYear = new Map<number, Map<string, typeof queryResult.photos>>();
 
     for (const photo of queryResult.photos) {

--- a/frontend/packages/telegram-bot/test/thisdayPage.test.ts
+++ b/frontend/packages/telegram-bot/test/thisdayPage.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendThisDayPage } from '../src/commands/thisday';
+import * as photosApi from '@photobank/shared/api/photos';
+import * as photo from '../src/photo';
+
+const basePhoto = {
+  id: 1,
+  name: 'test',
+  storageName: 's',
+  relativePath: 'p',
+  takenDate: new Date().toISOString(),
+  persons: [],
+  isAdultContent: false,
+  isRacyContent: false,
+  captions: [],
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  photo.currentPagePhotos.clear();
+});
+
+describe('sendThisDayPage', () => {
+  it('deletes preview message when page changes', async () => {
+    const ctx = {
+      chat: { id: 1 },
+      reply: vi.fn(),
+      editMessageText: vi.fn().mockResolvedValue(undefined),
+    } as any;
+    photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
+    vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
+    vi.spyOn(photosApi, 'searchPhotos').mockResolvedValue({ count: 1, photos: [basePhoto] } as any);
+
+    await sendThisDayPage(ctx, 2, true);
+
+    expect(photo.deletePhotoMessage).toHaveBeenCalled();
+  });
+
+  it('does not delete preview message when same page requested', async () => {
+    const ctx = {
+      chat: { id: 1 },
+      reply: vi.fn(),
+      editMessageText: vi.fn().mockResolvedValue(undefined),
+    } as any;
+    photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
+    vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
+    vi.spyOn(photosApi, 'searchPhotos').mockResolvedValue({ count: 1, photos: [basePhoto] } as any);
+
+    await sendThisDayPage(ctx, 1, true);
+
+    expect(photo.deletePhotoMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure preview photo message is deleted when changing pages
- add unit tests for page change behavior

## Testing
- `pnpm --filter telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_68835805c43c832889191241e6f2f900