### PR TITLE
Limit number of people in face selector

### DIFF
--- a/frontend/packages/frontend/src/components/FacePersonSelector.tsx
+++ b/frontend/packages/frontend/src/components/FacePersonSelector.tsx
@@ -72,7 +72,7 @@ export const FacePersonSelector = ({
                                 <CommandItem onSelect={() => { handleSelect(undefined); }}>
                                     {noneLabel}
                                 </CommandItem>
-                                {persons.map((person) => (
+                                {persons.slice(0, 10).map((person) => (
                                     <CommandItem
                                         key={person.id}
                                         value={person.name}


### PR DESCRIPTION
## Summary
- limit the number of people displayed in the face selector dropdown

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6883a88957e08328a0c4874407519dbc