### PR TITLE
Fix woodpecker pipeline event filter

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,3 +1,7 @@
+when:
+  event:
+    - push
+    - pull_request
 steps:
   - name: backend-build
     image: mcr.microsoft.com/dotnet/sdk:9.0


### PR DESCRIPTION
## Summary
- add global `when` event filter for push and pull_request

## Testing
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6883b8f47320832889fb42812adcef04