### PR TITLE
Fix Android ExpoModulesPackage path

### DIFF
--- a/frontend/packages/tv/react-native.config.js
+++ b/frontend/packages/tv/react-native.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  dependencies: {
+    expo: {
+      platforms: {
+        android: {
+          packageImportPath: 'import expo.modules.ExpoModulesPackage;',
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- fix Android build by overriding Expo package import

## Testing
- `pnpm -r test` *(fails: PhotoDetailsPage renders photo details)*

------
https://chatgpt.com/codex/tasks/task_e_6883bfbbec088328a206531f18cc4ca8