### PR TITLE
Add persons/tags commands

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -1,0 +1,53 @@
+import { Context, InlineKeyboard } from "grammy";
+import { getAllPersons } from "@photobank/shared/api";
+import { prevPageText, nextPageText } from "@photobank/shared/constants";
+
+const PAGE_SIZE = 10;
+
+function parsePrefix(text?: string): string {
+    if (!text) return "";
+    const parts = text.split(" ");
+    return parts[1]?.trim() ?? "";
+}
+
+export async function sendPersonsPage(ctx: Context, prefix: string, page: number, edit = false) {
+    let persons;
+    try {
+        persons = await getAllPersons();
+    } catch (err) {
+        console.error(err);
+        await ctx.reply("🚫 Не удалось получить список персон.");
+        return;
+    }
+
+    const filtered = persons
+        .filter(p => p.name.toLowerCase().startsWith(prefix.toLowerCase()))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+    const pageIndex = Math.min(Math.max(page, 1), totalPages);
+    const items = filtered.slice((pageIndex - 1) * PAGE_SIZE, pageIndex * PAGE_SIZE);
+
+    const lines = items.map(p => `- ${p.name}`);
+    lines.push("", `📄 Страница ${pageIndex} из ${totalPages}`);
+
+    const keyboard = new InlineKeyboard();
+    if (pageIndex > 1) keyboard.text(prevPageText, `persons:${pageIndex - 1}:${encodeURIComponent(prefix)}`);
+    if (pageIndex < totalPages) keyboard.text(nextPageText, `persons:${pageIndex + 1}:${encodeURIComponent(prefix)}`);
+
+    const text = lines.join("\n");
+
+    if (edit) {
+        await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() =>
+            ctx.reply(text, { reply_markup: keyboard })
+        );
+    } else {
+        await ctx.reply(text, { reply_markup: keyboard });
+    }
+}
+
+export async function personsCommand(ctx: Context) {
+    const prefix = parsePrefix(ctx.message?.text);
+    await sendPersonsPage(ctx, prefix, 1);
+}
+

--- a/frontend/packages/telegram-bot/src/commands/tags.ts
+++ b/frontend/packages/telegram-bot/src/commands/tags.ts
@@ -1,0 +1,53 @@
+import { Context, InlineKeyboard } from "grammy";
+import { getAllTags } from "@photobank/shared/api";
+import { prevPageText, nextPageText } from "@photobank/shared/constants";
+
+const PAGE_SIZE = 10;
+
+function parsePrefix(text?: string): string {
+    if (!text) return "";
+    const parts = text.split(" ");
+    return parts[1]?.trim() ?? "";
+}
+
+export async function sendTagsPage(ctx: Context, prefix: string, page: number, edit = false) {
+    let tags;
+    try {
+        tags = await getAllTags();
+    } catch (err) {
+        console.error(err);
+        await ctx.reply("🚫 Не удалось получить список тегов.");
+        return;
+    }
+
+    const filtered = tags
+        .filter(t => t.name.toLowerCase().startsWith(prefix.toLowerCase()))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+    const pageIndex = Math.min(Math.max(page, 1), totalPages);
+    const items = filtered.slice((pageIndex - 1) * PAGE_SIZE, pageIndex * PAGE_SIZE);
+
+    const lines = items.map(t => `- ${t.name}`);
+    lines.push("", `📄 Страница ${pageIndex} из ${totalPages}`);
+
+    const keyboard = new InlineKeyboard();
+    if (pageIndex > 1) keyboard.text(prevPageText, `tags:${pageIndex - 1}:${encodeURIComponent(prefix)}`);
+    if (pageIndex < totalPages) keyboard.text(nextPageText, `tags:${pageIndex + 1}:${encodeURIComponent(prefix)}`);
+
+    const text = lines.join("\n");
+
+    if (edit) {
+        await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() =>
+            ctx.reply(text, { reply_markup: keyboard })
+        );
+    } else {
+        await ctx.reply(text, { reply_markup: keyboard });
+    }
+}
+
+export async function tagsCommand(ctx: Context) {
+    const prefix = parsePrefix(ctx.message?.text);
+    await sendTagsPage(ctx, prefix, 1);
+}
+

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -2,6 +2,8 @@ import {Bot} from "grammy";
 import {BOT_TOKEN, API_EMAIL, API_PASSWORD} from "./config";
 import {sendThisDayPage, thisDayCommand, captionCache} from "./commands/thisday";
 import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
+import { tagsCommand, sendTagsPage } from "./commands/tags";
+import { personsCommand, sendPersonsPage } from "./commands/persons";
 import { loadDictionaries } from "@photobank/shared/dictionaries";
 import { registerPhotoRoutes } from "./commands/photoRouter";
 import { profileCommand } from "./commands/profile";
@@ -39,6 +41,9 @@ bot.command("profile", profileCommand);
 
 bot.command("subscribe", subscribeCommand);
 
+bot.command("tags", tagsCommand);
+bot.command("persons", personsCommand);
+
 bot.callbackQuery(/^thisday:(\d+)$/, async (ctx) => {
     const page = parseInt(ctx.match[1], 10);
     await ctx.answerCallbackQuery();
@@ -49,6 +54,20 @@ bot.callbackQuery(/^caption:(\d+)$/, async (ctx) => {
     const id = parseInt(ctx.match[1], 10);
     const caption = captionCache.get(id);
     await ctx.answerCallbackQuery(caption ?? captionMissingMsg);
+});
+
+bot.callbackQuery(/^tags:(\d+):(.+)$/, async (ctx) => {
+    const page = parseInt(ctx.match[1], 10);
+    const prefix = decodeURIComponent(ctx.match[2]);
+    await ctx.answerCallbackQuery();
+    await sendTagsPage(ctx, prefix, page, true);
+});
+
+bot.callbackQuery(/^persons:(\d+):(.+)$/, async (ctx) => {
+    const page = parseInt(ctx.match[1], 10);
+    const prefix = decodeURIComponent(ctx.match[2]);
+    await ctx.answerCallbackQuery();
+    await sendPersonsPage(ctx, prefix, page, true);
 });
 
 bot.start();

--- a/frontend/packages/telegram-bot/test/personsTags.test.ts
+++ b/frontend/packages/telegram-bot/test/personsTags.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sendTagsPage } from '../src/commands/tags';
+import { sendPersonsPage } from '../src/commands/persons';
+import * as api from '@photobank/shared/api';
+
+describe('sendTagsPage', () => {
+  it('filters by prefix and paginates', async () => {
+    const tags = Array.from({ length: 11 }, (_, i) => ({ id: i + 1, name: `ba${String(i).padStart(2, '0')}` }));
+    vi.spyOn(api, 'getAllTags').mockResolvedValue(tags as any);
+    const ctx = { reply: vi.fn() } as any;
+    await sendTagsPage(ctx, 'ba', 2);
+    expect(ctx.reply).toHaveBeenCalled();
+    const text = ctx.reply.mock.calls[0][0];
+    expect(text).toContain('ba10');
+    expect(text).toContain('Страница 2 из 2');
+  });
+});
+
+describe('sendPersonsPage', () => {
+  it('filters by prefix and paginates', async () => {
+    const persons = Array.from({ length: 12 }, (_, i) => ({ id: i + 1, name: `al${String(i).padStart(2, '0')}` }));
+    vi.spyOn(api, 'getAllPersons').mockResolvedValue(persons as any);
+    const ctx = { reply: vi.fn() } as any;
+    await sendPersonsPage(ctx, 'al', 2);
+    expect(ctx.reply).toHaveBeenCalled();
+    const text = ctx.reply.mock.calls[0][0];
+    expect(text).toContain('al10');
+    expect(text).toContain('Страница 2 из 2');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `/persons` and `/tags` bot commands
- show paginated results filtered by prefix
- handle callbacks for navigation
- test list commands

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6884943690a0832886896e5948a6fc0e