### PR TITLE
Update search command parsing

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/search.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.ts
@@ -18,7 +18,14 @@ const PAGE_SIZE = 10;
 function parseCaption(text?: string): string {
   if (!text) return "";
   const match = text.match(/^\/search\s+(.+)/);
-  return match ? match[1] : "";
+  let caption = match ? match[1].trim() : "";
+  if (
+    (caption.startsWith('"') && caption.endsWith('"')) ||
+    (caption.startsWith("'") && caption.endsWith("'"))
+  ) {
+    caption = caption.slice(1, -1);
+  }
+  return caption;
 }
 
 export async function handleSearch(ctx: Context) {

--- a/frontend/packages/telegram-bot/test/searchCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/searchCommand.test.ts
@@ -1,19 +1,32 @@
 import { describe, it, expect, vi } from 'vitest';
-import { handleSearch } from '../src/commands/search';
+import * as searchCommands from '../src/commands/search';
 import * as photosApi from '@photobank/shared/api/photos';
 import { sorryTryToRequestLaterMsg, searchCommandUsageMsg } from '@photobank/shared/constants';
 
 describe('handleSearch', () => {
   it('replies with usage when caption missing', async () => {
     const ctx = { reply: vi.fn(), message: { text: '/search' } } as any;
-    await handleSearch(ctx);
+    await searchCommands.handleSearch(ctx);
     expect(ctx.reply).toHaveBeenCalledWith(searchCommandUsageMsg);
   });
 
   it('replies with fallback message on API failure', async () => {
     const ctx = { reply: vi.fn(), message: { text: '/search cats' } } as any;
     vi.spyOn(photosApi, 'searchPhotos').mockRejectedValue(new Error('fail'));
-    await handleSearch(ctx);
+    await searchCommands.handleSearch(ctx);
     expect(ctx.reply).toHaveBeenCalledWith(sorryTryToRequestLaterMsg);
+  });
+
+  it('strips quotes around caption', async () => {
+    const ctx = { reply: vi.fn(), message: { text: '/search "dog cat"' } } as any;
+    const searchSpy = vi
+      .spyOn(photosApi, 'searchPhotos')
+      .mockResolvedValue({ count: 0, photos: [] } as any);
+
+    await searchCommands.handleSearch(ctx);
+
+    expect(searchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ caption: 'dog cat' }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- trim quotes when parsing telegram search command
- test quoted caption handling

## Testing
- `pnpm -r test` *(fails: Test timed out in packages/frontend)*

------
https://chatgpt.com/codex/tasks/task_e_6884aa54b35483289c241908b5c74e09