### PR TITLE
Fix telegram bot paging

### DIFF
--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -5,6 +5,7 @@ import { sendSearchPage, searchCommand } from "./commands/search";
 import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
 import { tagsCommand, sendTagsPage } from "./commands/tags";
 import { personsCommand, sendPersonsPage } from "./commands/persons";
+import { tagsCallbackPattern, personsCallbackPattern } from "./patterns";
 import { loadDictionaries } from "@photobank/shared/dictionaries";
 import { registerPhotoRoutes } from "./commands/photoRouter";
 import { profileCommand } from "./commands/profile";
@@ -58,14 +59,14 @@ bot.callbackQuery(/^caption:(\d+)$/, async (ctx) => {
     await ctx.answerCallbackQuery(caption ?? captionMissingMsg);
 });
 
-bot.callbackQuery(/^tags:(\d+):(.+)$/, async (ctx) => {
+bot.callbackQuery(tagsCallbackPattern, async (ctx) => {
     const page = parseInt(ctx.match[1], 10);
     const prefix = decodeURIComponent(ctx.match[2]);
     await ctx.answerCallbackQuery();
     await sendTagsPage(ctx, prefix, page, true);
 });
 
-bot.callbackQuery(/^persons:(\d+):(.+)$/, async (ctx) => {
+bot.callbackQuery(personsCallbackPattern, async (ctx) => {
     const page = parseInt(ctx.match[1], 10);
     const prefix = decodeURIComponent(ctx.match[2]);
     await ctx.answerCallbackQuery();

--- a/frontend/packages/telegram-bot/src/patterns.ts
+++ b/frontend/packages/telegram-bot/src/patterns.ts
@@ -1,0 +1,2 @@
+export const tagsCallbackPattern = /^tags:(\d+):(.*)$/;
+export const personsCallbackPattern = /^persons:(\d+):(.*)$/;

--- a/frontend/packages/telegram-bot/test/personsTags.test.ts
+++ b/frontend/packages/telegram-bot/test/personsTags.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { sendTagsPage } from '../src/commands/tags';
 import { sendPersonsPage } from '../src/commands/persons';
+import { tagsCallbackPattern, personsCallbackPattern } from '../src/patterns';
 import * as api from '@photobank/shared/api';
 
 describe('sendTagsPage', () => {
@@ -26,5 +27,19 @@ describe('sendPersonsPage', () => {
     const text = ctx.reply.mock.calls[0][0];
     expect(text).toContain('al10');
     expect(text).toContain('Страница 2 из 2');
+  });
+});
+
+describe('callback regex', () => {
+  it('matches empty prefix for tags', () => {
+    const match = 'tags:2:'.match(tagsCallbackPattern);
+    expect(match?.[1]).toBe('2');
+    expect(match?.[2]).toBe('');
+  });
+
+  it('matches empty prefix for persons', () => {
+    const match = 'persons:3:'.match(personsCallbackPattern);
+    expect(match?.[1]).toBe('3');
+    expect(match?.[2]).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- fix paging in /tags and /persons commands when no prefix provided
- expose callback regex patterns for testing
- test callback regex for empty prefix cases

## Testing
- `pnpm -r test` *(fails: FilterFormFields.test.tsx, FilterPage.test.tsx, PhotoDetailsPage.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6884d786895883289006b929afd14226