### PR TITLE
Replace manual api with generated OpenAPI client

### DIFF
--- a/frontend/packages/frontend/src/components/FaceOverlay.tsx
+++ b/frontend/packages/frontend/src/components/FaceOverlay.tsx
@@ -1,6 +1,6 @@
 import {getGenderText} from '@photobank/shared';
 
-import type { FaceDto } from '@photobank/shared/types';
+import type { FaceDto } from '@photobank/shared/generated';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover.tsx';
 import { Label } from '@/components/ui/label.tsx';
 import {

--- a/frontend/packages/frontend/src/components/FacePersonSelector.tsx
+++ b/frontend/packages/frontend/src/components/FacePersonSelector.tsx
@@ -13,7 +13,7 @@ import {
     CommandGroup,
     CommandItem,
 } from "@/components/ui/command";
-import type { PersonDto } from '@photobank/shared/types';
+import type { PersonDto } from '@photobank/shared/generated';
 import {
     unassignedLabel,
     facePrefix,

--- a/frontend/packages/frontend/src/entities/photo/api.ts
+++ b/frontend/packages/frontend/src/entities/photo/api.ts
@@ -4,9 +4,9 @@ import {
   getPhotoById as getPhotoByIdApi,
   updateFace as updateFaceApi,
 } from '@photobank/shared/api';
-import type { UpdateFaceDto } from '@photobank/shared/types';
+import type { UpdateFaceDto } from '@photobank/shared/generated';
 
-import type { FilterDto, PhotoDto, QueryResult } from '@photobank/shared/types';
+import type { FilterDto, PhotoDto, QueryResult } from '@photobank/shared/generated';
 
 export const api = createApi({
   reducerPath: 'photobankApi',

--- a/frontend/packages/frontend/src/features/auth/model/authSlice.ts
+++ b/frontend/packages/frontend/src/features/auth/model/authSlice.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import type { LoginRequestDto } from '@photobank/shared/types';
+import type { LoginRequestDto } from '@photobank/shared/generated';
 import { login } from '@photobank/shared/api';
 import { invalidCredentialsMsg } from '@photobank/shared/constants';
 

--- a/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
+++ b/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
@@ -1,6 +1,6 @@
 import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { getAllPaths, getAllPersons, getAllStorages, getAllTags } from '@photobank/shared/api';
-import type { PathDto, PersonDto, StorageDto, TagDto } from '@photobank/shared/types';
+import type { PathDto, PersonDto, StorageDto, TagDto } from '@photobank/shared/generated';
 
 import {
   METADATA_CACHE_KEY,

--- a/frontend/packages/frontend/src/features/photo/model/photoSlice.ts
+++ b/frontend/packages/frontend/src/features/photo/model/photoSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import type { FilterDto, PhotoItemDto } from '@photobank/shared/types';
+import type { FilterDto, PhotoItemDto } from '@photobank/shared/generated';
 import { DEFAULT_PHOTO_FILTER } from '@photobank/shared/constants.ts';
 
 interface PhotoState {

--- a/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getAllUsers, updateUserById, setUserClaims } from '@photobank/shared/api';
-import type { UserWithClaimsDto } from '@photobank/shared/types';
+import type { UserWithClaimsDto } from '@photobank/shared/generated';
 import { Button } from '@/components/ui/button';
 import {
   Form,

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -10,7 +10,7 @@ import {Input} from '@/components/ui/input';
 import {Textarea} from '@/components/ui/textarea';
 import {ScrollArea} from '@/components/ui/scroll-area';
 import {Checkbox} from '@/components/ui/checkbox';
-import type { FaceBoxDto } from '@photobank/shared/types';
+import type { FaceBoxDto } from '@photobank/shared/generated';
 import {useGetPhotoByIdQuery, useUpdateFaceMutation} from "@/entities/photo/api.ts";
 import {ScoreBar} from '@/components/ScoreBar';
 import {FaceOverlay} from "@/components/FaceOverlay.tsx";

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { formatDate, firstNWords } from '@photobank/shared';
-import type { PhotoItemDto } from '@photobank/shared/types';
+import type { PhotoItemDto } from '@photobank/shared/generated';
 
 import { useSearchPhotosMutation } from '@/entities/photo/api.ts';
 import { Badge } from '@/components/ui/badge';

--- a/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
+++ b/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
@@ -14,7 +14,7 @@ import {
 import {Button} from '@/components/ui/button';
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
 import {Input} from '@/components/ui/input';
-import type {UserDto, RoleDto, ClaimDto} from '@photobank/shared/types';
+import type { UserDto, RoleDto, ClaimDto } from '@photobank/shared/generated';
 import {
   myProfileTitle,
   emailPrefix,

--- a/frontend/packages/shared/src/api/auth.ts
+++ b/frontend/packages/shared/src/api/auth.ts
@@ -6,8 +6,8 @@ import type {
   UpdateUserDto,
   ClaimDto,
   RoleDto,
-} from '../types';
-import { apiClient } from './client';
+} from '../generated';
+import { AuthService } from '../generated';
 
 const AUTH_TOKEN_KEY = 'photobank_token';
 let authToken: string | null = null;
@@ -53,39 +53,33 @@ loadAuthToken();
 export const login = async (
   data: LoginRequestDto,
 ): Promise<LoginResponseDto> => {
-  const response = await apiClient.post<LoginResponseDto>(
-    '/auth/login',
-    data,
-  );
-  setAuthToken(response.data.token, data.rememberMe ?? true);
-  return response.data;
+  const response = await AuthService.postApiAuthLogin(data);
+  setAuthToken(response.token!, data.rememberMe ?? true);
+  return response;
 };
 
 export const register = async (
   data: RegisterRequestDto,
 ): Promise<void> => {
-  await apiClient.post('/auth/register', data);
+  await AuthService.postApiAuthRegister(data);
 };
 
 export const getCurrentUser = async (): Promise<UserDto> => {
-  const response = await apiClient.get<UserDto>('/auth/user');
-  return response.data;
+  return AuthService.getApiAuthUser();
 };
 
 export const updateUser = async (
   data: UpdateUserDto,
 ): Promise<void> => {
-  await apiClient.put('/auth/user', data);
+  await AuthService.putApiAuthUser(data);
 };
 
 export const getUserClaims = async (): Promise<ClaimDto[]> => {
-  const response = await apiClient.get<ClaimDto[]>('/auth/claims');
-  return response.data;
+  return AuthService.getApiAuthClaims();
 };
 
 export const getUserRoles = async (): Promise<RoleDto[]> => {
-  const response = await apiClient.get<RoleDto[]>('/auth/roles');
-  return response.data;
+  return AuthService.getApiAuthRoles();
 };
 
 export const logout = () => {

--- a/frontend/packages/shared/src/api/faces.ts
+++ b/frontend/packages/shared/src/api/faces.ts
@@ -1,6 +1,6 @@
-import { apiClient } from './client';
-import type { UpdateFaceDto } from '../types';
+import type { UpdateFaceDto } from '../generated';
+import { FacesService } from '../generated';
 
 export const updateFace = async (dto: UpdateFaceDto): Promise<void> => {
-  await apiClient.put('/faces', dto);
+  await FacesService.putApiFaces(dto);
 };

--- a/frontend/packages/shared/src/api/paths.ts
+++ b/frontend/packages/shared/src/api/paths.ts
@@ -1,7 +1,6 @@
-import type { PathDto } from '../types';
-import { apiClient } from './client';
+import type { PathDto } from '../generated';
+import { PathsService } from '../generated';
 
 export const getAllPaths = async (): Promise<PathDto[]> => {
-  const response = await apiClient.get<PathDto[]>('/paths');
-  return response.data;
+  return PathsService.getApiPaths();
 };

--- a/frontend/packages/shared/src/api/persons.ts
+++ b/frontend/packages/shared/src/api/persons.ts
@@ -1,7 +1,6 @@
-import type { PersonDto } from '../types';
-import { apiClient } from './client';
+import type { PersonDto } from '../generated';
+import { PersonsService } from '../generated';
 
 export const getAllPersons = async (): Promise<PersonDto[]> => {
-  const response = await apiClient.get<PersonDto[]>('/persons');
-  return response.data;
+  return PersonsService.getApiPersons();
 };

--- a/frontend/packages/shared/src/api/photos.ts
+++ b/frontend/packages/shared/src/api/photos.ts
@@ -1,5 +1,5 @@
-import type { FilterDto, PhotoDto, QueryResult } from '../types';
-import { apiClient } from './client';
+import type { FilterDto, PhotoDto, QueryResult } from '../generated';
+import { PhotosService } from '../generated';
 import { isBrowser } from '../config';
 import { cachePhoto, getCachedPhoto } from '../cache/photosCache';
 import { cacheFilterResult, getCachedFilterResult } from '../cache/filterResultsCache';
@@ -15,11 +15,11 @@ export const searchPhotos = async (filter: FilterDto): Promise<QueryResult> => {
     }
   }
 
-  const response = await apiClient.post<QueryResult>('/photos/search', filter);
-  if (response.data.photos) {
-    void cacheFilterResult(hash, { count: response.data.count, photos: response.data.photos });
+  const result = await PhotosService.postApiPhotosSearch(filter);
+  if (result.photos) {
+    void cacheFilterResult(hash, { count: result.count, photos: result.photos });
   }
-  return response.data;
+  return result;
 };
 
 export const getPhotoById = async (id: number): Promise<PhotoDto> => {
@@ -27,9 +27,9 @@ export const getPhotoById = async (id: number): Promise<PhotoDto> => {
     const cached = await getCachedPhoto(id);
     if (cached) return cached;
   }
-  const response = await apiClient.get<PhotoDto>(`/photos/${id}`);
+  const result = await PhotosService.getApiPhotos(id);
   if (isBrowser()) {
-    void cachePhoto(response.data);
+    void cachePhoto(result);
   }
-  return response.data;
+  return result;
 };

--- a/frontend/packages/shared/src/api/storages.ts
+++ b/frontend/packages/shared/src/api/storages.ts
@@ -1,7 +1,6 @@
-import type { StorageDto } from '../types';
-import { apiClient } from './client';
+import type { StorageDto } from '../generated';
+import { StoragesService } from '../generated';
 
 export const getAllStorages = async (): Promise<StorageDto[]> => {
-  const response = await apiClient.get<StorageDto[]>('/storages');
-  return response.data;
+  return StoragesService.getApiStorages();
 };

--- a/frontend/packages/shared/src/api/tags.ts
+++ b/frontend/packages/shared/src/api/tags.ts
@@ -1,7 +1,6 @@
-import type { TagDto } from '../types';
-import { apiClient } from './client';
+import type { TagDto } from '../generated';
+import { TagsService } from '../generated';
 
 export const getAllTags = async (): Promise<TagDto[]> => {
-  const response = await apiClient.get<TagDto[]>('/tags');
-  return response.data;
+  return TagsService.getApiTags();
 };

--- a/frontend/packages/shared/src/api/users.ts
+++ b/frontend/packages/shared/src/api/users.ts
@@ -1,21 +1,20 @@
-import type { UserWithClaimsDto, UpdateUserDto, ClaimDto } from '../types';
-import { apiClient } from './client';
+import type { UserWithClaimsDto, UpdateUserDto, ClaimDto } from '../generated';
+import { UsersService } from '../generated';
 
 export const getAllUsers = async (): Promise<UserWithClaimsDto[]> => {
-  const res = await apiClient.get<UserWithClaimsDto[]>('/admin/users');
-  return res.data;
+  return UsersService.getApiAdminUsers();
 };
 
 export const updateUserById = async (
   id: string,
   data: UpdateUserDto,
 ): Promise<void> => {
-  await apiClient.put(`/admin/users/${id}`, data);
+  await UsersService.putApiAdminUsers(id, data);
 };
 
 export const setUserClaims = async (
   id: string,
   claims: ClaimDto[],
 ): Promise<void> => {
-  await apiClient.put(`/admin/users/${id}/claims`, claims);
+  await UsersService.putApiAdminUsersClaims(id, claims);
 };

--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -1,4 +1,4 @@
-import type {FilterDto} from "@photobank/shared/types";
+import type { FilterDto } from '@photobank/shared/generated';
 
 export const DEFAULT_PHOTO_FILTER: FilterDto = {
     thisDay: true,

--- a/frontend/packages/shared/src/utils/formatPhotoMessage.ts
+++ b/frontend/packages/shared/src/utils/formatPhotoMessage.ts
@@ -1,4 +1,4 @@
-import { PhotoDto } from "@photobank/shared/types";
+import { PhotoDto } from "@photobank/shared/generated";
 import { getPersonName } from "@photobank/shared/dictionaries";
 import { formatDate } from "@photobank/shared/index";
 import { Buffer } from "buffer";

--- a/frontend/packages/shared/test/api.test.ts
+++ b/frontend/packages/shared/test/api.test.ts
@@ -6,11 +6,11 @@ describe('api helpers', () => {
   });
 
   it('searchPhotos posts filter', async () => {
-    const postMock = vi.fn().mockResolvedValue({ data: { count: 1 } });
-    vi.doMock('../src/api/client', () => ({ apiClient: { post: postMock } }));
+    const postMock = vi.fn().mockResolvedValue({ count: 1 });
+    vi.doMock('../src/generated', () => ({ PhotosService: { postApiPhotosSearch: postMock } }));
     const { searchPhotos } = await import('../src/api/photos');
     const res = await searchPhotos({ thisDay: true } as any);
-    expect(postMock).toHaveBeenCalledWith('/photos/search', { thisDay: true });
+    expect(postMock).toHaveBeenCalledWith({ thisDay: true } as any);
     expect(res).toEqual({ count: 1 });
   });
 
@@ -20,7 +20,7 @@ describe('api helpers', () => {
     // simulate browser environment
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).window = { crypto: {} };
-    vi.doMock('../src/api/client', () => ({ apiClient: { post: postMock } }));
+    vi.doMock('../src/generated', () => ({ PhotosService: { postApiPhotosSearch: postMock } }));
     vi.doMock('../src/cache/filterResultsCache', () => ({
       cacheFilterResult: vi.fn(),
       getCachedFilterResult: vi.fn().mockResolvedValue({ hash: 'h', count: 1, photos: [cachedItem] }),
@@ -37,55 +37,55 @@ describe('api helpers', () => {
   });
 
   it('getPhotoById requests by id', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: { id: 5 } });
-    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const getMock = vi.fn().mockResolvedValue({ id: 5 });
+    vi.doMock('../src/generated', () => ({ PhotosService: { getApiPhotos: getMock } }));
     const { getPhotoById } = await import('../src/api/photos');
     const res = await getPhotoById(5);
-    expect(getMock).toHaveBeenCalledWith('/photos/5');
+    expect(getMock).toHaveBeenCalledWith(5);
     expect(res).toEqual({ id: 5 });
   });
 
   it('getAllPersons fetches persons', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: [{ id: 1 }] });
-    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const getMock = vi.fn().mockResolvedValue([{ id: 1 }]);
+    vi.doMock('../src/generated', () => ({ PersonsService: { getApiPersons: getMock } }));
     const { getAllPersons } = await import('../src/api/persons');
     const res = await getAllPersons();
-    expect(getMock).toHaveBeenCalledWith('/persons');
+    expect(getMock).toHaveBeenCalled();
     expect(res).toEqual([{ id: 1 }]);
   });
 
   it('getAllPaths fetches paths', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: [{ storageId: 1 }] });
-    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const getMock = vi.fn().mockResolvedValue([{ storageId: 1 }]);
+    vi.doMock('../src/generated', () => ({ PathsService: { getApiPaths: getMock } }));
     const { getAllPaths } = await import('../src/api/paths');
     const res = await getAllPaths();
-    expect(getMock).toHaveBeenCalledWith('/paths');
+    expect(getMock).toHaveBeenCalled();
     expect(res).toEqual([{ storageId: 1 }]);
   });
 
   it('getAllStorages fetches storages', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: [{ id: 2 }] });
-    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const getMock = vi.fn().mockResolvedValue([{ id: 2 }]);
+    vi.doMock('../src/generated', () => ({ StoragesService: { getApiStorages: getMock } }));
     const { getAllStorages } = await import('../src/api/storages');
     const res = await getAllStorages();
-    expect(getMock).toHaveBeenCalledWith('/storages');
+    expect(getMock).toHaveBeenCalled();
     expect(res).toEqual([{ id: 2 }]);
   });
 
   it('getAllTags fetches tags', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: [{ id: 3 }] });
-    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const getMock = vi.fn().mockResolvedValue([{ id: 3 }]);
+    vi.doMock('../src/generated', () => ({ TagsService: { getApiTags: getMock } }));
     const { getAllTags } = await import('../src/api/tags');
     const res = await getAllTags();
-    expect(getMock).toHaveBeenCalledWith('/tags');
+    expect(getMock).toHaveBeenCalled();
     expect(res).toEqual([{ id: 3 }]);
   });
 
   it('updateFace sends data', async () => {
     const putMock = vi.fn().mockResolvedValue({});
-    vi.doMock('../src/api/client', () => ({ apiClient: { put: putMock } }));
+    vi.doMock('../src/generated', () => ({ FacesService: { putApiFaces: putMock } }));
     const { updateFace } = await import('../src/api/faces');
     await updateFace({ faceId: 5, personId: 2 });
-    expect(putMock).toHaveBeenCalledWith('/faces', { faceId: 5, personId: 2 });
+    expect(putMock).toHaveBeenCalledWith({ faceId: 5, personId: 2 });
   });
 });

--- a/frontend/packages/shared/test/auth.test.ts
+++ b/frontend/packages/shared/test/auth.test.ts
@@ -69,55 +69,55 @@ describe('auth utilities', () => {
   });
 
   it('login posts credentials and saves token', async () => {
-    const postMock = vi.fn().mockResolvedValue({ data: { token: 'res' } });
-    vi.doMock('../src/api/client', () => ({ apiClient: { post: postMock } }));
+    const postMock = vi.fn().mockResolvedValue({ token: 'res' });
+    vi.doMock('../src/generated', () => ({ AuthService: { postApiAuthLogin: postMock } }));
     const auth = await import('../src/api/auth');
     const result = await auth.login({ email: 'e', password: 'p' });
-    expect(postMock).toHaveBeenCalledWith('/auth/login', { email: 'e', password: 'p' });
+    expect(postMock).toHaveBeenCalledWith({ email: 'e', password: 'p' });
     expect(result).toEqual({ token: 'res' });
     expect(auth.getAuthToken()).toBe('res');
   });
 
   it('register posts user info', async () => {
     const postMock = vi.fn().mockResolvedValue({});
-    vi.doMock('../src/api/client', () => ({ apiClient: { post: postMock } }));
+    vi.doMock('../src/generated', () => ({ AuthService: { postApiAuthRegister: postMock } }));
     const auth = await import('../src/api/auth');
     await auth.register({ email: 'e', password: 'p' });
-    expect(postMock).toHaveBeenCalledWith('/auth/register', { email: 'e', password: 'p' });
+    expect(postMock).toHaveBeenCalledWith({ email: 'e', password: 'p' });
   });
 
   it('getCurrentUser fetches user', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: { email: 'a@b.c' } });
-    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const getMock = vi.fn().mockResolvedValue({ email: 'a@b.c' });
+    vi.doMock('../src/generated', () => ({ AuthService: { getApiAuthUser: getMock } }));
     const auth = await import('../src/api/auth');
     const user = await auth.getCurrentUser();
-    expect(getMock).toHaveBeenCalledWith('/auth/user');
+    expect(getMock).toHaveBeenCalled();
     expect(user).toEqual({ email: 'a@b.c' });
   });
 
   it('updateUser sends data', async () => {
     const putMock = vi.fn().mockResolvedValue({});
-    vi.doMock('../src/api/client', () => ({ apiClient: { put: putMock } }));
+    vi.doMock('../src/generated', () => ({ AuthService: { putApiAuthUser: putMock } }));
     const auth = await import('../src/api/auth');
     await auth.updateUser({ phoneNumber: '123' });
-    expect(putMock).toHaveBeenCalledWith('/auth/user', { phoneNumber: '123' });
+    expect(putMock).toHaveBeenCalledWith({ phoneNumber: '123' });
   });
 
   it('getUserClaims fetches claims', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: [{ type: 't', value: 'v' }] });
-    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const getMock = vi.fn().mockResolvedValue([{ type: 't', value: 'v' }]);
+    vi.doMock('../src/generated', () => ({ AuthService: { getApiAuthClaims: getMock } }));
     const auth = await import('../src/api/auth');
     const claims = await auth.getUserClaims();
-    expect(getMock).toHaveBeenCalledWith('/auth/claims');
+    expect(getMock).toHaveBeenCalled();
     expect(claims).toEqual([{ type: 't', value: 'v' }]);
   });
 
   it('getUserRoles fetches roles with claims', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: [{ name: 'admin', claims: [] }] });
-    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const getMock = vi.fn().mockResolvedValue([{ name: 'admin', claims: [] }]);
+    vi.doMock('../src/generated', () => ({ AuthService: { getApiAuthRoles: getMock } }));
     const auth = await import('../src/api/auth');
     const roles = await auth.getUserRoles();
-    expect(getMock).toHaveBeenCalledWith('/auth/roles');
+    expect(getMock).toHaveBeenCalled();
     expect(roles).toEqual([{ name: 'admin', claims: [] }]);
   });
 });

--- a/frontend/packages/shared/test/users.test.ts
+++ b/frontend/packages/shared/test/users.test.ts
@@ -6,29 +6,27 @@ describe('admin users api', () => {
   });
 
   it('getAllUsers fetches users', async () => {
-    const getMock = vi.fn().mockResolvedValue({ data: [{ id: '1' }] });
-    vi.doMock('../src/api/client', () => ({ apiClient: { get: getMock } }));
+    const getMock = vi.fn().mockResolvedValue([{ id: '1' }]);
+    vi.doMock('../src/generated', () => ({ UsersService: { getApiAdminUsers: getMock } }));
     const { getAllUsers } = await import('../src/api/users');
     const res = await getAllUsers();
-    expect(getMock).toHaveBeenCalledWith('/admin/users');
+    expect(getMock).toHaveBeenCalled();
     expect(res).toEqual([{ id: '1' }]);
   });
 
   it('updateUserById sends data', async () => {
     const putMock = vi.fn().mockResolvedValue({});
-    vi.doMock('../src/api/client', () => ({ apiClient: { put: putMock } }));
+    vi.doMock('../src/generated', () => ({ UsersService: { putApiAdminUsers: putMock } }));
     const { updateUserById } = await import('../src/api/users');
     await updateUserById('5', { phoneNumber: '1' });
-    expect(putMock).toHaveBeenCalledWith('/admin/users/5', { phoneNumber: '1' });
+    expect(putMock).toHaveBeenCalledWith('5', { phoneNumber: '1' });
   });
 
   it('setUserClaims posts claims', async () => {
     const putMock = vi.fn().mockResolvedValue({});
-    vi.doMock('../src/api/client', () => ({ apiClient: { put: putMock } }));
+    vi.doMock('../src/generated', () => ({ UsersService: { putApiAdminUsersClaims: putMock } }));
     const { setUserClaims } = await import('../src/api/users');
     await setUserClaims('3', [{ type: 't', value: 'v' }]);
-    expect(putMock).toHaveBeenCalledWith('/admin/users/3/claims', [
-      { type: 't', value: 'v' },
-    ]);
+    expect(putMock).toHaveBeenCalledWith('3', [{ type: 't', value: 'v' }]);
   });
 });

--- a/frontend/packages/tv/components/PhotoCard.tsx
+++ b/frontend/packages/tv/components/PhotoCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TouchableOpacity, Image, StyleSheet, Text, View } from 'react-native';
-import { PhotoItemDto } from '@photobank/shared/types';
+import { PhotoItemDto } from '@photobank/shared/generated';
 
 export const PhotoCard = ({ photo, onPress }: { photo: PhotoItemDto; onPress: () => void }) => (
     <TouchableOpacity style={styles.card} onPress={onPress}>

--- a/frontend/packages/tv/components/PhotoRow.tsx
+++ b/frontend/packages/tv/components/PhotoRow.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import { PhotoItemDto } from '@photobank/shared/types';
+import { PhotoItemDto } from '@photobank/shared/generated';
 
 import { PhotoCard } from './PhotoCard';
 

--- a/frontend/packages/tv/hooks/usePhotoApi.ts
+++ b/frontend/packages/tv/hooks/usePhotoApi.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import {PhotoItemDto, FilterDto, PhotoDto} from "@photobank/shared/types";
+import { PhotoItemDto, FilterDto, PhotoDto } from '@photobank/shared/generated';
 import {getPhotoById, searchPhotos} from "@photobank/shared/api";
 
 export const usePhotos = (filter: FilterDto | null) => {


### PR DESCRIPTION
## Summary
- switch shared api modules to use generated OpenAPI services
- update redux slices and components to use generated DTOs
- adjust tests to mock OpenAPI services

## Testing
- `pnpm -r test` *(fails: Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6884d9afe68c8328b3a6cad910f19dcd