### PR TITLE
Fix pnpm lockfile

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -264,6 +264,9 @@ importers:
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
+      form-data:
+        specifier: ^4.0.4
+        version: 4.0.4
       lru-cache:
         specifier: ^11.1.0
         version: 11.1.0


### PR DESCRIPTION
## Summary
- update `pnpm-lock.yaml` to include `form-data` dependency for `@photobank/shared`

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm -r test` *(fails: PhotoDetailsPage.test.tsx timeout)*

------
https://chatgpt.com/codex/tasks/task_e_688503f688548328bc7f43760df32ea3