### PR TITLE
Fix frontend type mismatches

### DIFF
--- a/frontend/packages/frontend/src/components/ScoreBar.tsx
+++ b/frontend/packages/frontend/src/components/ScoreBar.tsx
@@ -2,12 +2,12 @@ import { Label } from "@/components/ui/label";
 
 interface ScoreBarProps {
     label: string;
-    score: number;
+    score?: number;
     colorClass: string;
 }
 
 export const ScoreBar = ({ label, score, colorClass }: ScoreBarProps) => {
-    const percent = (score * 100).toFixed(1);
+    const percent = ((score ?? 0) * 100).toFixed(1);
 
     return (
         <div>

--- a/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
@@ -34,7 +34,7 @@ function UserEditor({ user, onSave }: UserEditorProps) {
   const defaultValues = {
     phoneNumber: user.phoneNumber ?? '',
     telegram: user.telegram ?? '',
-    claims: user.claims.map((c) => `${c.type}:${c.value}`).join('\n'),
+    claims: user.claims?.map((c) => `${c.type}:${c.value}`).join('\n') ?? '',
   };
   const form = useForm<FormData>({ resolver: zodResolver(schema), defaultValues });
   return (
@@ -42,7 +42,7 @@ function UserEditor({ user, onSave }: UserEditorProps) {
       <h2 className="font-semibold">{user.email}</h2>
       <Form {...form}>
         {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
-        <form onSubmit={form.handleSubmit((d) => onSave(user.id, d))} className="space-y-4">
+        <form onSubmit={form.handleSubmit((d) => onSave(user.id!, d))} className="space-y-4">
           <FormField
             control={form.control}
             name="phoneNumber"

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -74,7 +74,9 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
     const photoId = propPhotoId ?? (id ? +id : 0);
     const {data: photo, error} = useGetPhotoByIdQuery(photoId, { skip: photoId === 0 });
 
-    const formattedTakenDate = useMemo(() => photo?.takenDate && formatDate(photo.takenDate), [photo?.takenDate]);
+    const formattedTakenDate = useMemo(() =>
+        photo?.takenDate ? formatDate(photo.takenDate) : '',
+    [photo?.takenDate]);
 
     const previewImageSrc = photo?.previewImage && `data:image/jpeg;base64,${photo.previewImage}`;
 
@@ -258,7 +260,7 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                     {photo.orientation && (
                                         <div>
                                             <Label className="text-muted-foreground text-xs">{orientationLabel}</Label>
-                                            <Input value={getOrientation(photo.orientation)} readOnly
+                                            <Input value={getOrientation(photo.orientation ?? undefined)} readOnly
                                                    className="mt-1 bg-muted"/>
                                         </div>
                                     )}

--- a/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -35,16 +35,16 @@ function FilterPage() {
 
   const useCurrentFilter = (location.state as { useCurrentFilter?: boolean } | null)?.useCurrentFilter;
 
-  const savedDefaults = {
-    caption: savedFilter.caption,
+  const savedDefaults: FormData = {
+    caption: savedFilter.caption ?? undefined,
     storages: savedFilter.storages?.map(String) ?? [],
     paths: savedFilter.paths?.map(String) ?? [],
     persons: savedFilter.persons?.map(String) ?? [],
     tags: savedFilter.tags?.map(String) ?? [],
-    isBW: savedFilter.isBW,
-    isAdultContent: savedFilter.isAdultContent,
-    isRacyContent: savedFilter.isRacyContent,
-    thisDay: savedFilter.thisDay,
+    isBW: savedFilter.isBW ?? undefined,
+    isAdultContent: savedFilter.isAdultContent ?? undefined,
+    isRacyContent: savedFilter.isRacyContent ?? undefined,
+    thisDay: savedFilter.thisDay ?? undefined,
     dateFrom: savedFilter.takenDateFrom ? new Date(savedFilter.takenDateFrom) : undefined,
     dateTo: savedFilter.takenDateTo ? new Date(savedFilter.takenDateTo) : undefined,
   };

--- a/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
+++ b/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
@@ -113,9 +113,9 @@ export default function MyProfilePage() {
                 {roles.map((r) => (
                   <li key={r.name}>
                     <span className="font-semibold">{r.name}</span>
-                    {r.claims.length > 0 && (
+                    {r.claims && r.claims.length > 0 && (
                       <ul className="list-disc list-inside ml-4">
-                        {r.claims.map((c, idx) => (
+                        {r.claims?.map((c, idx) => (
                           <li key={idx}>{c.type}: {c.value}</li>
                         ))}
                       </ul>

--- a/frontend/packages/shared/src/api/client.ts
+++ b/frontend/packages/shared/src/api/client.ts
@@ -16,8 +16,8 @@ export function setApiBaseUrl(url: string) {
   axios.defaults.baseURL = url;
 }
 
-OpenAPI.TOKEN = () => getAuthToken() ?? '';
-OpenAPI.HEADERS = () =>
+OpenAPI.TOKEN = async () => getAuthToken() ?? '';
+OpenAPI.HEADERS = async () =>
   impersonateUser ? { 'X-Impersonate-User': impersonateUser } : {};
 
 axios.interceptors.response.use(undefined, (error) => {

--- a/frontend/packages/shared/src/cache/filterResultsCache.ts
+++ b/frontend/packages/shared/src/cache/filterResultsCache.ts
@@ -1,7 +1,7 @@
 import Dexie, { type Table } from 'dexie';
 import { LRUCache } from 'lru-cache';
 import { isBrowser } from '../config';
-import type { PhotoItemDto } from '../types';
+import type { PhotoItemDto } from '../generated';
 
 export interface CachedFilterResult {
   hash: string;

--- a/frontend/packages/shared/src/cache/photosCache.ts
+++ b/frontend/packages/shared/src/cache/photosCache.ts
@@ -1,7 +1,7 @@
 import Dexie, { type Table } from 'dexie';
 import { LRUCache } from 'lru-cache';
 import { isBrowser } from '../config';
-import type { PhotoDto } from '../types';
+import type { PhotoDto } from '../generated';
 
 export interface CachedPhoto extends PhotoDto {
   added: number;

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -9,8 +9,8 @@ export const formatDate = (dateString?: string) => {
   }
 };
 
-export const getGenderText = (gender?: boolean) => {
-  if (gender === undefined) return 'не указан пол';
+export const getGenderText = (gender?: boolean | null) => {
+  if (gender === undefined || gender === null) return 'не указан пол';
   return gender ? 'Муж' : 'Жен';
 };
 

--- a/frontend/packages/shared/src/utils/geocode.ts
+++ b/frontend/packages/shared/src/utils/geocode.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { GeoPointDto } from '../types';
+import type { GeoPointDto } from '../generated';
 
 /**
  * Returns a human friendly place name for the given coordinates using

--- a/frontend/packages/shared/src/utils/getFilterHash.ts
+++ b/frontend/packages/shared/src/utils/getFilterHash.ts
@@ -1,4 +1,4 @@
-import type {FilterDto} from '../types';
+import type {FilterDto} from '../generated';
 import objectHash from 'object-hash';
 
 /**

--- a/frontend/packages/shared/test/formatPhotoMessage.test.ts
+++ b/frontend/packages/shared/test/formatPhotoMessage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { formatPhotoMessage } from '../src/utils/formatPhotoMessage';
-import type { PhotoDto } from '../src/types';
+import type { PhotoDto } from '../src/generated';
 
 vi.mock('../src/dictionaries', () => ({
   getPersonName: (id: number) => `Person ${id}`,

--- a/frontend/packages/shared/test/getFilterHash.test.ts
+++ b/frontend/packages/shared/test/getFilterHash.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getFilterHash } from '../src';
-import type { FilterDto } from '../src/types';
+import type { FilterDto } from '../src/generated';
 
 describe('getFilterHash', () => {
   it('returns stable hash for identical filters', async () => {


### PR DESCRIPTION
## Summary
- fix type mismatches between generated and custom DTOs
- update gender text util for nullable values
- update caches and helpers to use generated DTOs
- adjust client OpenAPI hooks to async style
- tweak components and pages to handle optional values
- update tests to import generated DTOs

## Testing
- `pnpm -r test` *(fails: AggregateError from jsdom network calls)*

------
https://chatgpt.com/codex/tasks/task_e_6885086002d8832887f3848a9d62ff95