### PR TITLE
Fix person list and unknown person handling

### DIFF
--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -24,6 +24,7 @@ export const searchPhotosEmptyMsg = "📭 По вашему запросу фо�
 export const notRegisteredMsg =
   "⚠️ Ваш телеграм не зарегистрирован. Обратитесь к администратору.";
 export const unknownYearLabel = "Неизвестный год";
+export const unknownPersonLabel = "Неизвестный";
 export const prevPageText = "◀ Назад";
 export const nextPageText = "Вперёд ▶";
 export const rolesLabel = "Роли:";

--- a/frontend/packages/shared/src/dictionaries.ts
+++ b/frontend/packages/shared/src/dictionaries.ts
@@ -1,4 +1,5 @@
 import {getAllPersons} from "@photobank/shared/api";
+import { unknownPersonLabel } from "@photobank/shared/constants";
 
 let tagMap = new Map<number, string>();
 let personMap = new Map<number, string>();
@@ -16,7 +17,8 @@ export function getTagName(id: number): string {
     return tagMap.get(id) ?? `#${id}`;
 }
 
-export function getPersonName(id: number): string {
+export function getPersonName(id: number | null | undefined): string {
+    if (id === null || id === undefined) return unknownPersonLabel;
     return personMap.get(id) ?? `ID ${id}`;
 }
 

--- a/frontend/packages/shared/src/utils/formatPhotoMessage.ts
+++ b/frontend/packages/shared/src/utils/formatPhotoMessage.ts
@@ -17,11 +17,8 @@ export function formatPhotoMessage(photo: PhotoDto): { caption: string, hasSpoil
     if (photo.tags?.length) lines.push(`🏷️ ${photo.tags.join(", ")}`);
 
     if (photo.faces?.length) {
-        const people = photo.faces
-            .map(f => f.personId)
-            .filter((id): id is number => id !== undefined)
-            .map(getPersonName);
-        if (people.length) {
+        const people = photo.faces.map(f => getPersonName(f.personId));
+        if (people.some(Boolean)) {
             lines.push(`👤 ${people.join(", ")}`);
         }
     }

--- a/frontend/packages/shared/test/dictionaries.test.ts
+++ b/frontend/packages/shared/test/dictionaries.test.ts
@@ -18,6 +18,11 @@ describe('dictionaries', () => {
     expect(dict.getPersonName(99)).toBe('ID 99');
   });
 
+  it('getPersonName returns unknown label for null', async () => {
+    const dict = await import('../src/dictionaries');
+    expect(dict.getPersonName(null)).toBe('Неизвестный');
+  });
+
   it('getTagName and getStorageName fall back', async () => {
     const dict = await import('../src/dictionaries');
     expect(dict.getTagName(5)).toBe('#5');

--- a/frontend/packages/shared/test/formatPhotoMessage.test.ts
+++ b/frontend/packages/shared/test/formatPhotoMessage.test.ts
@@ -3,7 +3,7 @@ import { formatPhotoMessage } from '../src/utils/formatPhotoMessage';
 import type { PhotoDto } from '../src/generated';
 
 vi.mock('../src/dictionaries', () => ({
-  getPersonName: (id: number) => `Person ${id}`,
+  getPersonName: (id: number | null | undefined) => id == null ? 'Неизвестный' : `Person ${id}`,
 }));
 
 describe('formatPhotoMessage', () => {
@@ -39,5 +39,13 @@ describe('formatPhotoMessage', () => {
     const { image } = formatPhotoMessage({ ...basePhoto, previewImage: base64 });
     expect(image).toBeInstanceOf(Buffer);
     expect(image?.toString()).toBe('img');
+  });
+
+  it('replaces missing person with unknown label', () => {
+    const { caption } = formatPhotoMessage({
+      ...basePhoto,
+      faces: [{ id: 1, personId: null, faceBox: { top:0, left:0, width:1, height:1}, friendlyFaceAttributes: '' }],
+    });
+    expect(caption).toContain('👤 Неизвестный');
   });
 });

--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -21,6 +21,7 @@ export async function sendPersonsPage(ctx: Context, prefix: string, page: number
     }
 
     const filtered = persons
+        .filter(p => p.id >= 1)
         .filter(p => p.name.toLowerCase().startsWith(prefix.toLowerCase()))
         .sort((a, b) => a.name.localeCompare(b.name));
 

--- a/frontend/packages/telegram-bot/test/personsTags.test.ts
+++ b/frontend/packages/telegram-bot/test/personsTags.test.ts
@@ -28,6 +28,19 @@ describe('sendPersonsPage', () => {
     expect(text).toContain('al10');
     expect(text).toContain('Страница 2 из 2');
   });
+
+  it('skips persons with id below 1', async () => {
+    const persons = [
+      { id: 0, name: 'skip' },
+      { id: 1, name: 'al00' },
+    ];
+    vi.spyOn(api, 'getAllPersons').mockResolvedValue(persons as any);
+    const ctx = { reply: vi.fn() } as any;
+    await sendPersonsPage(ctx, 'a', 1);
+    expect(ctx.reply).toHaveBeenCalled();
+    const text = ctx.reply.mock.calls[0][0];
+    expect(text).not.toContain('skip');
+  });
 });
 
 describe('callback regex', () => {


### PR DESCRIPTION
## Summary
- start person listing from id 1
- display `Неизвестный` for unassigned faces
- update tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68852a74e6b083289ddb3c4e3c11f7a7