### PR TITLE
Refactor telegram bot list commands

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/helpers.ts
+++ b/frontend/packages/telegram-bot/src/commands/helpers.ts
@@ -1,0 +1,81 @@
+import { Context, InlineKeyboard } from "grammy";
+import { prevPageText, nextPageText } from "@photobank/shared/constants";
+
+export const PAGE_SIZE = 10;
+
+export function parsePrefix(text?: string): string {
+  if (!text) return "";
+  const parts = text.split(" ");
+  return parts[1]?.trim() ?? "";
+}
+
+export interface NamedItem { name: string }
+
+export interface SendPageOptions<T extends NamedItem> {
+  ctx: Context;
+  command: string;
+  fetchAll: () => Promise<T[]>;
+  prefix: string;
+  page: number;
+  edit?: boolean;
+  errorMsg: string;
+  filter?: (item: T) => boolean;
+}
+
+export async function sendNamedItemsPage<T extends NamedItem>({
+  ctx,
+  command,
+  fetchAll,
+  prefix,
+  page,
+  edit = false,
+  errorMsg,
+  filter,
+}: SendPageOptions<T>) {
+  let items: T[];
+  try {
+    items = await fetchAll();
+  } catch (err) {
+    console.error(err);
+    await ctx.reply(errorMsg);
+    return;
+  }
+
+  if (filter) items = items.filter(filter);
+
+  const filtered = items
+    .filter((i) => i.name.toLowerCase().startsWith(prefix.toLowerCase()))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const pageIndex = Math.min(Math.max(page, 1), totalPages);
+  const slice = filtered.slice(
+    (pageIndex - 1) * PAGE_SIZE,
+    pageIndex * PAGE_SIZE,
+  );
+
+  const lines = slice.map((i) => `- ${i.name}`);
+  lines.push("", `📄 Страница ${pageIndex} из ${totalPages}`);
+
+  const keyboard = new InlineKeyboard();
+  if (pageIndex > 1)
+    keyboard.text(
+      prevPageText,
+      `${command}:${pageIndex - 1}:${encodeURIComponent(prefix)}`,
+    );
+  if (pageIndex < totalPages)
+    keyboard.text(
+      nextPageText,
+      `${command}:${pageIndex + 1}:${encodeURIComponent(prefix)}`,
+    );
+
+  const text = lines.join("\n");
+
+  if (edit) {
+    await ctx
+      .editMessageText(text, { reply_markup: keyboard })
+      .catch(() => ctx.reply(text, { reply_markup: keyboard }));
+  } else {
+    await ctx.reply(text, { reply_markup: keyboard });
+  }
+}

--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -1,54 +1,27 @@
-import { Context, InlineKeyboard } from "grammy";
+import { Context } from "grammy";
 import { getAllPersons } from "@photobank/shared/api";
-import { prevPageText, nextPageText } from "@photobank/shared/constants";
+import { parsePrefix, sendNamedItemsPage } from "./helpers";
 
-const PAGE_SIZE = 10;
-
-function parsePrefix(text?: string): string {
-    if (!text) return "";
-    const parts = text.split(" ");
-    return parts[1]?.trim() ?? "";
-}
-
-export async function sendPersonsPage(ctx: Context, prefix: string, page: number, edit = false) {
-    let persons;
-    try {
-        persons = await getAllPersons();
-    } catch (err) {
-        console.error(err);
-        await ctx.reply("🚫 Не удалось получить список персон.");
-        return;
-    }
-
-    const filtered = persons
-        .filter(p => p.id >= 1)
-        .filter(p => p.name.toLowerCase().startsWith(prefix.toLowerCase()))
-        .sort((a, b) => a.name.localeCompare(b.name));
-
-    const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
-    const pageIndex = Math.min(Math.max(page, 1), totalPages);
-    const items = filtered.slice((pageIndex - 1) * PAGE_SIZE, pageIndex * PAGE_SIZE);
-
-    const lines = items.map(p => `- ${p.name}`);
-    lines.push("", `📄 Страница ${pageIndex} из ${totalPages}`);
-
-    const keyboard = new InlineKeyboard();
-    if (pageIndex > 1) keyboard.text(prevPageText, `persons:${pageIndex - 1}:${encodeURIComponent(prefix)}`);
-    if (pageIndex < totalPages) keyboard.text(nextPageText, `persons:${pageIndex + 1}:${encodeURIComponent(prefix)}`);
-
-    const text = lines.join("\n");
-
-    if (edit) {
-        await ctx.editMessageText(text, { reply_markup: keyboard }).catch(() =>
-            ctx.reply(text, { reply_markup: keyboard })
-        );
-    } else {
-        await ctx.reply(text, { reply_markup: keyboard });
-    }
+export async function sendPersonsPage(
+  ctx: Context,
+  prefix: string,
+  page: number,
+  edit = false,
+) {
+  await sendNamedItemsPage({
+    ctx,
+    command: "persons",
+    fetchAll: getAllPersons,
+    prefix,
+    page,
+    edit,
+    errorMsg: "🚫 Не удалось получить список персон.",
+    filter: (p) => (p as any).id >= 1,
+  });
 }
 
 export async function personsCommand(ctx: Context) {
-    const prefix = parsePrefix(ctx.message?.text);
-    await sendPersonsPage(ctx, prefix, 1);
+  const prefix = parsePrefix(ctx.message?.text);
+  await sendPersonsPage(ctx, prefix, 1);
 }
 


### PR DESCRIPTION
## Summary
- DRY up telegram-bot commands
- create helpers for paged entity lists

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68852c86e6788328931a4a0e7555ea47