### PR TITLE
Add perceptual hashing and duplicate API

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PhotosController.cs
+++ b/backend/PhotoBank.Api/Controllers/PhotosController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
 using System.Diagnostics.Metrics;
+using System.Collections.Generic;
 
 namespace PhotoBank.Api.Controllers
 {
@@ -32,6 +33,14 @@ namespace PhotoBank.Api.Controllers
                 return NotFound();
 
             return Ok(photo);
+        }
+
+        [HttpGet("duplicates")]
+        [ProducesResponseType(typeof(IEnumerable<PhotoItemDto>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IEnumerable<PhotoItemDto>>> GetDuplicates([FromQuery] int? id, [FromQuery] string? hash, [FromQuery] int threshold = 5)
+        {
+            var result = await photoService.FindDuplicatesAsync(id, hash, threshold);
+            return Ok(result);
         }
     }
 }

--- a/backend/PhotoBank.DbContext/Migrations/20250701121000_AddImageHash.cs
+++ b/backend/PhotoBank.DbContext/Migrations/20250701121000_AddImageHash.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PhotoBank.DbContext.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageHash : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ImageHash",
+                table: "Photos",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ImageHash",
+                table: "Photos");
+        }
+    }
+}

--- a/backend/PhotoBank.DbContext/Migrations/PhotoBankDbContextModelSnapshot.cs
+++ b/backend/PhotoBank.DbContext/Migrations/PhotoBankDbContextModelSnapshot.cs
@@ -545,6 +545,10 @@ namespace PhotoBank.DbContext.Migrations
                     b.Property<double>("RacyScore")
                         .HasColumnType("float");
 
+                    b.Property<string>("ImageHash")
+                        .HasMaxLength(64)
+                        .HasColumnType("nvarchar(64)");
+
                     b.Property<string>("RelativePath")
                         .HasMaxLength(255)
                         .HasColumnType("nvarchar(255)");

--- a/backend/PhotoBank.DbContext/Models/Photo.cs
+++ b/backend/PhotoBank.DbContext/Models/Photo.cs
@@ -43,6 +43,8 @@ namespace PhotoBank.DbContext.Models
         public double AdultScore { get; set; }
         public bool IsRacyContent { get; set; }
         public double RacyScore { get; set; }
+        [MaxLength(64)]
+        public string ImageHash { get; set; }
         [MaxLength(255)]
         public string RelativePath { get; set; }
         public List<File> Files { get; set; }

--- a/backend/PhotoBank.Services/ImageHashHelper.cs
+++ b/backend/PhotoBank.Services/ImageHashHelper.cs
@@ -1,0 +1,55 @@
+using System;
+using ImageMagick;
+
+namespace PhotoBank.Services;
+
+public static class ImageHashHelper
+{
+    public static string ComputeHash(byte[] data)
+    {
+        using var image = new MagickImage(data);
+        image.Resize(8, 8);
+        image.ColorSpace = ColorSpace.Gray;
+
+        var pixels = image.GetPixels();
+        ulong total = 0;
+        for (int y = 0; y < 8; y++)
+        {
+            for (int x = 0; x < 8; x++)
+            {
+                total += pixels.GetPixel(x, y).GetChannel(0);
+            }
+        }
+
+        ulong avg = total / 64;
+        ulong hash = 0;
+        for (int y = 0; y < 8; y++)
+        {
+            for (int x = 0; x < 8; x++)
+            {
+                if (pixels.GetPixel(x, y).GetChannel(0) >= avg)
+                {
+                    hash |= 1UL << (y * 8 + x);
+                }
+            }
+        }
+
+        return hash.ToString("X16");
+    }
+
+    public static int HammingDistance(string hash1, string hash2)
+    {
+        if (string.IsNullOrEmpty(hash1) || string.IsNullOrEmpty(hash2))
+            return int.MaxValue;
+        ulong h1 = Convert.ToUInt64(hash1, 16);
+        ulong h2 = Convert.ToUInt64(hash2, 16);
+        ulong x = h1 ^ h2;
+        int setBits = 0;
+        while (x != 0)
+        {
+            setBits += (int)(x & 1);
+            x >>= 1;
+        }
+        return setBits;
+    }
+}

--- a/backend/PhotoBank.Services/PhotoProcessor.cs
+++ b/backend/PhotoBank.Services/PhotoProcessor.cs
@@ -75,6 +75,11 @@ namespace PhotoBank.Services
 
             await _dependencyExecutor.ExecuteAsync(_enrichers, photo, sourceData);
 
+            if (photo.PreviewImage != null)
+            {
+                photo.ImageHash = ImageHashHelper.ComputeHash(photo.PreviewImage);
+            }
+
             try
             {
                 await _photoRepository.InsertAsync(photo);

--- a/frontend/packages/shared/src/generated/services/PhotosService.ts
+++ b/frontend/packages/shared/src/generated/services/PhotosService.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 import type { FilterDto } from '../models/FilterDto';
 import type { PhotoDto } from '../models/PhotoDto';
+import type { PhotoItemDto } from '../models/PhotoItemDto';
 import type { QueryResult } from '../models/QueryResult';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
@@ -24,6 +25,28 @@ export class PhotosService {
             mediaType: 'application/json',
             errors: {
                 400: `Bad Request`,
+            },
+        });
+    }
+    /**
+     * @param id
+     * @param hash
+     * @param threshold
+     * @returns PhotoItemDto OK
+     * @throws ApiError
+     */
+    public static getApiPhotosDuplicates(
+        id?: number,
+        hash?: string,
+        threshold: number = 5,
+    ): CancelablePromise<Array<PhotoItemDto>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/photos/duplicates',
+            query: {
+                'id': id,
+                'hash': hash,
+                'threshold': threshold,
             },
         });
     }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -269,6 +269,38 @@ paths:
             text/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  /api/photos/duplicates:
+    get:
+      tags:
+        - Photos
+      parameters:
+        - name: id
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: hash
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: threshold
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 5
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PhotoItemDto'
   '/api/photos/{id}':
     get:
       tags:


### PR DESCRIPTION
## Summary
- compute perceptual hash for each photo on upload
- store hash in the new `ImageHash` column
- expose duplicates lookup in service and API
- update OpenAPI schema and generated client
- switch to ImageMagick for hash generation

## Testing
- `dotnet build backend/PhotoBank.Backend.sln -v q` *(fails: NETSDK1045 due to missing .NET 9 SDK)*
- `dotnet test backend/PhotoBank.Backend.sln --no-build` *(skipped: build failed)*
- `pnpm --dir frontend test` *(fails: 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6885c77f0398832883bbd53a8a2bef75