### PR TITLE
Add Azure OpenAI service to shared package

### DIFF
--- a/frontend/packages/shared/src/api/index.ts
+++ b/frontend/packages/shared/src/api/index.ts
@@ -7,3 +7,4 @@ export * from './storages';
 export * from './auth';
 export * from './users';
 export * from './faces';
+export * from './openai';

--- a/frontend/packages/shared/src/api/openai.ts
+++ b/frontend/packages/shared/src/api/openai.ts
@@ -1,0 +1,50 @@
+import axios from 'axios';
+
+export interface AzureOpenAIConfig {
+  endpoint: string; // e.g. https://my-resource.openai.azure.com
+  apiKey: string;
+  deployment: string;
+  apiVersion?: string;
+}
+
+const DEFAULT_API_VERSION = '2024-02-15-preview';
+
+let config: AzureOpenAIConfig | null = null;
+
+export function configureAzureOpenAI(cfg: AzureOpenAIConfig): void {
+  config = { ...cfg, apiVersion: cfg.apiVersion ?? DEFAULT_API_VERSION };
+}
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatCompletionRequest {
+  messages: ChatMessage[];
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  choices: Array<{ message: ChatMessage }>;
+  [key: string]: unknown;
+}
+
+export async function createChatCompletion(
+  request: ChatCompletionRequest,
+): Promise<ChatCompletionResponse> {
+  if (!config) {
+    throw new Error('Azure OpenAI is not configured');
+  }
+  const { endpoint, deployment, apiKey, apiVersion = DEFAULT_API_VERSION } = config;
+  const url = `${endpoint}/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`;
+  const res = await axios.post(url, request, {
+    headers: {
+      'api-key': apiKey,
+    },
+  });
+  return res.data as ChatCompletionResponse;
+}
+

--- a/frontend/packages/shared/test/openai.test.ts
+++ b/frontend/packages/shared/test/openai.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const cfg = {
+  endpoint: 'https://example.openai.azure.com',
+  apiKey: 'key',
+  deployment: 'gpt-4',
+  apiVersion: '2024-02-15-preview',
+};
+
+describe('azure openai service', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('posts chat completion request', async () => {
+    const postMock = vi.fn().mockResolvedValue({ data: { id: '1', choices: [] } });
+    vi.doMock('axios', () => ({ default: { post: postMock } }));
+    const { configureAzureOpenAI, createChatCompletion } = await import('../src/api/openai');
+    configureAzureOpenAI(cfg);
+    const req = { messages: [{ role: 'user', content: 'hi' }] };
+    const res = await createChatCompletion(req);
+    expect(postMock).toHaveBeenCalledWith(
+      `${cfg.endpoint}/openai/deployments/${cfg.deployment}/chat/completions?api-version=${cfg.apiVersion}`,
+      req,
+      { headers: { 'api-key': cfg.apiKey } },
+    );
+    expect(res).toEqual({ id: '1', choices: [] });
+  });
+
+  it('throws when not configured', async () => {
+    const { createChatCompletion } = await import('../src/api/openai');
+    await expect(createChatCompletion({ messages: [] })).rejects.toThrow('Azure OpenAI is not configured');
+  });
+});


### PR DESCRIPTION
## Summary
- add Azure OpenAI REST client in `@photobank/shared`
- expose new service from API index
- test OpenAI service with vitest

## Testing
- `pnpm --filter @photobank/shared test`

------
https://chatgpt.com/codex/tasks/task_e_6886065144348328b02cb8aeb5ca6b44