### PR TITLE
Add OpenAI chat page

### DIFF
--- a/frontend/packages/frontend/src/components/NavBar.tsx
+++ b/frontend/packages/frontend/src/components/NavBar.tsx
@@ -10,6 +10,7 @@ import {
   navbarLogoutLabel,
   navbarRegisterLabel,
   navbarUsersLabel,
+  navbarOpenAiLabel,
 } from '@photobank/shared/constants';
 
 export default function NavBar() {
@@ -36,6 +37,11 @@ export default function NavBar() {
         <li>
           <Button variant="link" className={linkClass} asChild>
             <NavLink to="/profile">{navbarProfileLabel}</NavLink>
+          </Button>
+        </li>
+        <li>
+          <Button variant="link" className={linkClass} asChild>
+            <NavLink to="/openai">{navbarOpenAiLabel}</NavLink>
           </Button>
         </li>
         {isAdmin && (

--- a/frontend/packages/frontend/src/pages/openai/OpenAIPage.tsx
+++ b/frontend/packages/frontend/src/pages/openai/OpenAIPage.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import {
+  configureAzureOpenAI,
+  createChatCompletion,
+  type ChatMessage,
+} from '@photobank/shared/api';
+import {
+  openAiPageTitle,
+  openAiSendButton,
+  openAiPromptPlaceholder,
+} from '@photobank/shared/constants';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+export default function OpenAIPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    configureAzureOpenAI({
+      endpoint: import.meta.env.VITE_AZURE_OPENAI_ENDPOINT,
+      apiKey: import.meta.env.VITE_AZURE_OPENAI_KEY,
+      deployment: import.meta.env.VITE_AZURE_OPENAI_DEPLOYMENT,
+    });
+  }, []);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMsg: ChatMessage = { role: 'user', content: input };
+    const newMessages = [...messages, userMsg];
+    setMessages(newMessages);
+    setInput('');
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await createChatCompletion({ messages: newMessages });
+      const assistant = res.choices[0]?.message;
+      if (assistant) {
+        setMessages([...newMessages, assistant]);
+      }
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <Card className="w-full max-w-2xl mx-auto space-y-4">
+        <CardHeader>
+          <CardTitle>{openAiPageTitle}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            {messages.map((m, i) => (
+              <div key={i} className="whitespace-pre-wrap">
+                <span className="font-bold mr-1">
+                  {m.role === 'user' ? 'You:' : 'AI:'}
+                </span>
+                {m.content}
+              </div>
+            ))}
+            {error && <p className="text-destructive text-sm">{error}</p>}
+          </div>
+          <div className="flex items-start gap-2">
+            <Textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder={openAiPromptPlaceholder}
+              className="flex-1"
+            />
+            <Button onClick={sendMessage} disabled={loading}>
+              {loading ? '...' : openAiSendButton}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/packages/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/packages/frontend/src/routes/AppRoutes.tsx
@@ -11,12 +11,14 @@ import LogoutPage from '@/pages/auth/LogoutPage.tsx';
 import MyProfilePage from '@/pages/profile/MyProfilePage.tsx';
 import UsersPage from '@/pages/admin/UsersPage.tsx';
 import ServiceInfoPage from '@/pages/service/ServiceInfoPage.tsx';
+import OpenAIPage from '@/pages/openai/OpenAIPage.tsx';
 
 export const AppRoutes = () => (
   <Routes>
     <Route path="/login" element={<LoginPage />} />
     <Route path="/register" element={<RegisterPage />} />
     <Route path="/service" element={<ServiceInfoPage />} />
+    <Route path="/openai" element={<OpenAIPage />} />
     <Route element={<RequireAuth />}>
       <Route path="/" element={<Navigate to="/filter" />} />
       <Route path="/logout" element={<LogoutPage />} />

--- a/frontend/packages/frontend/src/vite-env.d.ts
+++ b/frontend/packages/frontend/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_AZURE_OPENAI_ENDPOINT?: string;
+  readonly VITE_AZURE_OPENAI_KEY?: string;
+  readonly VITE_AZURE_OPENAI_DEPLOYMENT?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -178,3 +178,9 @@ export const saveUserButtonText = 'Save User';
 
 // Service page
 export const serviceInfoTitle = 'Technical Information';
+
+// OpenAI page
+export const openAiPageTitle = 'OpenAI Chat';
+export const openAiSendButton = 'Send';
+export const openAiPromptPlaceholder = 'Enter your request...';
+export const navbarOpenAiLabel = 'OpenAI';


### PR DESCRIPTION
## Summary
- implement OpenAI chat page using shared OpenAI service
- expose new labels for the OpenAI page
- link the page in routes and navbar
- type new environment variables

## Testing
- `pnpm -r test` *(fails: FilterFormFields.test.tsx, PhotoDetailsPage.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688608c0b0008328bfa7c0bf42814a8f