### PR TITLE
Add Azure OpenAI API version env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ DB_CONNECTION=Server=server;Database=Photobank;User Id=user;Password=pass;Encryp
 BOT_TOKEN=your_token
 API_EMAIL=admin@example.com
 API_PASSWORD=secret
+
+# Azure OpenAI settings
+VITE_AZURE_OPENAI_API_VERSION=2024-02-15-preview

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ pnpm dev
 ```bash
 VITE_API_BASE_URL=http://localhost:5066
 ```
+При необходимости можно задать версию Azure OpenAI через переменную
+`VITE_AZURE_OPENAI_API_VERSION` (по умолчанию `2024-02-15-preview`).
 
 ### Телеграм‑бот
 
@@ -161,6 +163,9 @@ Before running set `VITE_API_BASE_URL` (or put it into `.env`) – the API addre
 ```bash
 VITE_API_BASE_URL=http://localhost:5066
 ```
+
+If needed, you can specify the Azure OpenAI version via
+`VITE_AZURE_OPENAI_API_VERSION` (default is `2024-02-15-preview`).
 
 ### Telegram bot
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,3 +5,6 @@ DB_CONNECTION=Server=server;Database=Photobank;User Id=user;Password=pass;Encryp
 BOT_TOKEN=your_token
 API_EMAIL=admin@example.com
 API_PASSWORD=secret
+
+# Azure OpenAI settings
+VITE_AZURE_OPENAI_API_VERSION=2024-02-15-preview

--- a/frontend/packages/frontend/src/pages/openai/OpenAIPage.tsx
+++ b/frontend/packages/frontend/src/pages/openai/OpenAIPage.tsx
@@ -25,6 +25,7 @@ export default function OpenAIPage() {
       endpoint: import.meta.env.VITE_AZURE_OPENAI_ENDPOINT,
       apiKey: import.meta.env.VITE_AZURE_OPENAI_KEY,
       deployment: import.meta.env.VITE_AZURE_OPENAI_DEPLOYMENT,
+      apiVersion: import.meta.env.VITE_AZURE_OPENAI_API_VERSION,
     });
   }, []);
 

--- a/frontend/packages/frontend/src/vite-env.d.ts
+++ b/frontend/packages/frontend/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_AZURE_OPENAI_ENDPOINT?: string;
   readonly VITE_AZURE_OPENAI_KEY?: string;
   readonly VITE_AZURE_OPENAI_DEPLOYMENT?: string;
+  readonly VITE_AZURE_OPENAI_API_VERSION?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- allow specifying `VITE_AZURE_OPENAI_API_VERSION`
- pass the api version to Azure OpenAI configuration
- document the new variable in README and example env files

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_688610285dec832888e3ded617a26bcf