### PR TITLE
Add OpenAI /ai command to bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ API_PASSWORD=secret
 
 # Azure OpenAI settings
 VITE_AZURE_OPENAI_API_VERSION=2024-02-15-preview
+VITE_AZURE_OPENAI_ENDPOINT=https://example.openai.azure.com
+VITE_AZURE_OPENAI_KEY=your_key
+VITE_AZURE_OPENAI_DEPLOYMENT=gpt-4

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ BOT_TOKEN=ваш_токен
 API_EMAIL=admin@example.com
 API_PASSWORD=secret
 API_BASE_URL=http://localhost:5066
+VITE_AZURE_OPENAI_ENDPOINT=https://example.openai.azure.com
+VITE_AZURE_OPENAI_KEY=your_key
+VITE_AZURE_OPENAI_DEPLOYMENT=gpt-4
 ```
 
 ### MAUI/Blazor клиент
@@ -182,6 +185,9 @@ BOT_TOKEN=your_token
 API_EMAIL=admin@example.com
 API_PASSWORD=secret
 API_BASE_URL=http://localhost:5066
+VITE_AZURE_OPENAI_ENDPOINT=https://example.openai.azure.com
+VITE_AZURE_OPENAI_KEY=your_key
+VITE_AZURE_OPENAI_DEPLOYMENT=gpt-4
 ```
 
 ### MAUI/Blazor client

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,3 +8,6 @@ API_PASSWORD=secret
 
 # Azure OpenAI settings
 VITE_AZURE_OPENAI_API_VERSION=2024-02-15-preview
+VITE_AZURE_OPENAI_ENDPOINT=https://example.openai.azure.com
+VITE_AZURE_OPENAI_KEY=your_key
+VITE_AZURE_OPENAI_DEPLOYMENT=gpt-4

--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -19,6 +19,7 @@ export const photoCommandUsageMsg = "❗ Используй: /photo <id>";
 export const photoNotFoundMsg = "❌ Фото не найдено.";
 export const subscribeCommandUsageMsg = "❗ Используй: /subscribe HH:MM";
 export const searchCommandUsageMsg = "❗ Используй: /search <caption>";
+export const aiCommandUsageMsg = "❗ Используй: /ai <prompt>";
 export const todaysPhotosEmptyMsg = "📭 Сегодняшних фото пока нет.";
 export const searchPhotosEmptyMsg = "📭 По вашему запросу фото не найдены.";
 export const notRegisteredMsg =

--- a/frontend/packages/telegram-bot/src/commands/ai.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.ts
@@ -1,0 +1,26 @@
+import { Context } from "grammy";
+import { createChatCompletion } from "@photobank/shared/api";
+import { aiCommandUsageMsg, sorryTryToRequestLaterMsg } from "@photobank/shared/constants";
+
+export function parseAiPrompt(text?: string): string | null {
+    if (!text) return null;
+    const match = text.match(/^\/ai\s+([\s\S]+)/); // capture anything after /ai
+    if (!match) return null;
+    return match[1].trim();
+}
+
+export async function aiCommand(ctx: Context) {
+    const prompt = parseAiPrompt(ctx.message?.text);
+    if (!prompt) {
+        await ctx.reply(aiCommandUsageMsg);
+        return;
+    }
+    try {
+        const res = await createChatCompletion({ messages: [{ role: 'user', content: prompt }] });
+        const reply = res.choices[0]?.message?.content;
+        await ctx.reply(reply ?? sorryTryToRequestLaterMsg);
+    } catch (err) {
+        console.error(err);
+        await ctx.reply(sorryTryToRequestLaterMsg);
+    }
+}

--- a/frontend/packages/telegram-bot/src/config.ts
+++ b/frontend/packages/telegram-bot/src/config.ts
@@ -15,3 +15,8 @@ if (!API_EMAIL || !API_PASSWORD) {
   throw new Error(apiCredentialsNotDefinedError);
 }
 
+export const AZURE_OPENAI_ENDPOINT: string = process.env.VITE_AZURE_OPENAI_ENDPOINT || '';
+export const AZURE_OPENAI_KEY: string = process.env.VITE_AZURE_OPENAI_KEY || '';
+export const AZURE_OPENAI_DEPLOYMENT: string = process.env.VITE_AZURE_OPENAI_DEPLOYMENT || '';
+export const AZURE_OPENAI_API_VERSION: string | undefined = process.env.VITE_AZURE_OPENAI_API_VERSION;
+

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -1,7 +1,16 @@
 import {Bot} from "grammy";
-import {BOT_TOKEN, API_EMAIL, API_PASSWORD} from "./config";
+import {
+    BOT_TOKEN,
+    API_EMAIL,
+    API_PASSWORD,
+    AZURE_OPENAI_ENDPOINT,
+    AZURE_OPENAI_KEY,
+    AZURE_OPENAI_DEPLOYMENT,
+    AZURE_OPENAI_API_VERSION,
+} from "./config";
 import {sendThisDayPage, thisDayCommand, captionCache} from "./commands/thisday";
 import { sendSearchPage, searchCommand } from "./commands/search";
+import { aiCommand } from "./commands/ai";
 import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
 import { tagsCommand, sendTagsPage } from "./commands/tags";
 import { personsCommand, sendPersonsPage } from "./commands/persons";
@@ -10,7 +19,12 @@ import { loadDictionaries } from "@photobank/shared/dictionaries";
 import { registerPhotoRoutes } from "./commands/photoRouter";
 import { profileCommand } from "./commands/profile";
 import { withRegistered } from './registration';
-import { login, setImpersonateUser, setApiBaseUrl } from "@photobank/shared/api";
+import {
+    login,
+    setImpersonateUser,
+    setApiBaseUrl,
+    configureAzureOpenAI,
+} from "@photobank/shared/api";
 import { loadResources, getApiBaseUrl } from "@photobank/shared/config";
 import {
     captionMissingMsg,
@@ -33,6 +47,13 @@ setApiBaseUrl(getApiBaseUrl());
 await login({ email: API_EMAIL, password: API_PASSWORD });
 await loadDictionaries();
 
+configureAzureOpenAI({
+    endpoint: AZURE_OPENAI_ENDPOINT,
+    apiKey: AZURE_OPENAI_KEY,
+    deployment: AZURE_OPENAI_DEPLOYMENT,
+    apiVersion: AZURE_OPENAI_API_VERSION,
+});
+
 bot.command(
     "start",
     (ctx) => ctx.reply(welcomeBotMsg),
@@ -40,6 +61,7 @@ bot.command(
 
 bot.command("thisday", withRegistered(thisDayCommand));
 bot.command("search", withRegistered(searchCommand));
+bot.command("ai", aiCommand);
 
 bot.command("profile", profileCommand);
 

--- a/frontend/packages/telegram-bot/test/aiCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/aiCommand.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { aiCommand, parseAiPrompt } from '../src/commands/ai';
+import * as openai from '@photobank/shared/api/openai';
+import { aiCommandUsageMsg, sorryTryToRequestLaterMsg } from '@photobank/shared/constants';
+
+describe('parseAiPrompt', () => {
+  it('parses prompt from command', () => {
+    expect(parseAiPrompt('/ai hello')).toBe('hello');
+  });
+
+  it('returns null without prompt', () => {
+    expect(parseAiPrompt('/ai')).toBeNull();
+  });
+});
+
+describe('aiCommand', () => {
+  it('replies with usage on empty prompt', async () => {
+    const ctx = { reply: vi.fn(), message: { text: '/ai' } } as any;
+    await aiCommand(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith(aiCommandUsageMsg);
+  });
+
+  it('replies with fallback when API fails', async () => {
+    const ctx = { reply: vi.fn(), message: { text: '/ai test' } } as any;
+    vi.spyOn(openai, 'createChatCompletion').mockRejectedValue(new Error('fail'));
+    await aiCommand(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith(sorryTryToRequestLaterMsg);
+  });
+
+  it('sends assistant message on success', async () => {
+    const ctx = { reply: vi.fn(), message: { text: '/ai test' } } as any;
+    vi.spyOn(openai, 'createChatCompletion').mockResolvedValue({
+      choices: [{ message: { role: 'assistant', content: 'hi' } }],
+    } as any);
+    await aiCommand(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith('hi');
+  });
+});


### PR DESCRIPTION
## Summary
- support `/ai` command in the Telegram bot
- connect bot to Azure OpenAI using env vars
- document new OpenAI env variables in README and `.env.example`
- cover AI command logic with unit tests

## Testing
- `pnpm -r test` *(fails: FilterFormFields, PhotoDetailsPage)*
- `pnpm --filter ./packages/telegram-bot test`
- `pnpm --filter @photobank/telegram-bot lint` *(fails: numerous lint errors)*
- `npx tsc -p frontend/packages/telegram-bot/tsconfig.json --noEmit` *(fails: shared package not built)*

------
https://chatgpt.com/codex/tasks/task_e_68861e92fab08328941ea55643d218d7