### PR TITLE
Fix env loading for frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,11 @@ DB_CONNECTION="Server=server;Database=Photobank;User Id=user;Password=pass;Encry
 
 # Telegram bot credentials
 BOT_TOKEN=your_token
+VITE_BOT_TOKEN=your_token
 API_EMAIL=admin@example.com
+VITE_API_EMAIL=admin@example.com
 API_PASSWORD=secret
+VITE_API_PASSWORD=secret
 
 # API endpoint
 VITE_API_BASE_URL=http://localhost:5066

--- a/frontend/packages/frontend/package.json
+++ b/frontend/packages/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "HOST=0.0.0.0 react-scripts start",
-    "dev": "dotenv -e ../../../.env -- vite",
+    "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss,html,json}\"",
@@ -60,7 +60,6 @@
     "@typescript-eslint/parser": "^8.38.0",
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/ui": "^3.2.4",
-    "dotenv-cli": "^9.0.0",
     "eslint": "^9.31.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/frontend/packages/frontend/src/config.ts
+++ b/frontend/packages/frontend/src/config.ts
@@ -1,8 +1,16 @@
-export const API_BASE_URL: string = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5066';
-export const BOT_TOKEN: string = import.meta.env.VITE_BOT_TOKEN || '';
-export const API_EMAIL: string = import.meta.env.VITE_API_EMAIL || '';
-export const API_PASSWORD: string = import.meta.env.VITE_API_PASSWORD || '';
-export const AZURE_OPENAI_ENDPOINT: string = import.meta.env.VITE_AZURE_OPENAI_ENDPOINT || '';
-export const AZURE_OPENAI_KEY: string = import.meta.env.VITE_AZURE_OPENAI_KEY || '';
-export const AZURE_OPENAI_DEPLOYMENT: string = import.meta.env.VITE_AZURE_OPENAI_DEPLOYMENT || '';
-export const AZURE_OPENAI_API_VERSION: string = import.meta.env.VITE_AZURE_OPENAI_API_VERSION || '';
+export const API_BASE_URL: string =
+  import.meta.env.VITE_API_BASE_URL || import.meta.env.API_BASE_URL || 'http://localhost:5066';
+export const BOT_TOKEN: string =
+  import.meta.env.VITE_BOT_TOKEN || import.meta.env.BOT_TOKEN || '';
+export const API_EMAIL: string =
+  import.meta.env.VITE_API_EMAIL || import.meta.env.API_EMAIL || '';
+export const API_PASSWORD: string =
+  import.meta.env.VITE_API_PASSWORD || import.meta.env.API_PASSWORD || '';
+export const AZURE_OPENAI_ENDPOINT: string =
+  import.meta.env.VITE_AZURE_OPENAI_ENDPOINT || import.meta.env.AZURE_OPENAI_ENDPOINT || '';
+export const AZURE_OPENAI_KEY: string =
+  import.meta.env.VITE_AZURE_OPENAI_KEY || import.meta.env.AZURE_OPENAI_KEY || '';
+export const AZURE_OPENAI_DEPLOYMENT: string =
+  import.meta.env.VITE_AZURE_OPENAI_DEPLOYMENT || import.meta.env.AZURE_OPENAI_DEPLOYMENT || '';
+export const AZURE_OPENAI_API_VERSION: string =
+  import.meta.env.VITE_AZURE_OPENAI_API_VERSION || import.meta.env.AZURE_OPENAI_API_VERSION || '';

--- a/frontend/packages/frontend/tsconfig.app.json
+++ b/frontend/packages/frontend/tsconfig.app.json
@@ -23,7 +23,7 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "types": ["node", "react"],
+    "types": ["node", "react", "vite/client"],
     "noUncheckedSideEffectImports": true,
     "baseUrl": ".",
     "paths": {

--- a/frontend/packages/frontend/vite.config.ts
+++ b/frontend/packages/frontend/vite.config.ts
@@ -7,6 +7,8 @@ import tailwindcss from '@tailwindcss/vite'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
+  envDir: path.resolve(__dirname, '../../../'),
+  envPrefix: ['VITE_', 'BOT_', 'API_'],
   plugins: [react(), tailwindcss()],
   server: {
     host: '0.0.0.0',

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
-      dotenv-cli:
-        specifier: ^9.0.0
-        version: 9.0.0
       eslint:
         specifier: ^9.31.0
         version: 9.31.0(jiti@2.5.1)
@@ -3092,14 +3089,6 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
-
-  dotenv-cli@9.0.0:
-    resolution: {integrity: sha512-NhGrQum/u1VTBxnSnlNwVkTP3gojYO8T6Fntyru93wbR1hPo8aFhDFJiBPmkT0771i7f5Rd7EQDaOreS8jY8gA==}
-    hasBin: true
-
-  dotenv-expand@10.0.0:
-    resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
-    engines: {node: '>=12'}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -9075,15 +9064,6 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
-
-  dotenv-cli@9.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      dotenv: 17.2.1
-      dotenv-expand: 10.0.0
-      minimist: 1.2.8
-
-  dotenv-expand@10.0.0: {}
 
   dotenv-expand@11.0.7:
     dependencies:


### PR DESCRIPTION
## Summary
- load `.env` from repo root with `envDir`
- accept BOT_/API_ prefixed variables via `envPrefix`
- support both prefixed and unprefixed vars in `config.ts`
- update example `.env`

## Testing
- `pnpm -r test` *(fails: Test timed out)*
- `pnpm --filter frontend run dev`

------
https://chatgpt.com/codex/tasks/task_e_6888a8047610832897a92bebdfefcc50