### PR TITLE
Fix ESM dirname in telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/src/config.ts
+++ b/frontend/packages/telegram-bot/src/config.ts
@@ -1,6 +1,10 @@
 // packages/telegram-bot/src/config.ts
 import * as dotenv from 'dotenv';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Node.js ESM does not provide __dirname, recreate it from import.meta.url
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 import {
   apiCredentialsNotDefinedError,
   botTokenNotDefinedError,


### PR DESCRIPTION
## Summary
- use `fileURLToPath` to recreate `__dirname` in `config.ts`
- load env vars correctly when running as ESM

## Testing
- `pnpm test`
- `pnpm --filter telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_6888d33625a88328ac1674a3369d38ae