### PR TITLE
Implement OpenAI filter parsing in bot

### DIFF
--- a/frontend/packages/shared/src/dictionaries.ts
+++ b/frontend/packages/shared/src/dictionaries.ts
@@ -1,4 +1,4 @@
-import { PersonsService } from "@photobank/shared/generated";
+import { PersonsService, TagsService } from "@photobank/shared/generated";
 import { unknownPersonLabel } from "@photobank/shared/constants";
 
 let tagMap = new Map<number, string>();
@@ -7,7 +7,7 @@ let storageMap = new Map<number, string>();
 let pathMap = new Map<number, string>();
 
 export async function loadDictionaries() {
-//    tagMap = new Map((await getAllTags()).map(tag => [tag.id, tag.name]));
+    tagMap = new Map((await TagsService.getApiTags()).map(tag => [tag.id, tag.name]));
     personMap = new Map((await PersonsService.getApiPersons()).map(p => [p.id, p.name]));
 //    storageMap = new Map((await getAllStorages()).map(p => [p.id, p.name]));
 //    pathMap = new Map((await getAllPaths()).map(p => [p.storageId, p.path]));
@@ -24,4 +24,44 @@ export function getPersonName(id: number | null | undefined): string {
 
 export function getStorageName(id: number): string {
     return storageMap.get(id) ?? `ID ${id}`;
+}
+
+function similarity(a: string, b: string): number {
+    const dp: number[][] = Array.from({ length: a.length + 1 }, () => new Array(b.length + 1).fill(0));
+    for (let i = 0; i <= a.length; i++) dp[i][0] = i;
+    for (let j = 0; j <= b.length; j++) dp[0][j] = j;
+    for (let i = 1; i <= a.length; i++) {
+        for (let j = 1; j <= b.length; j++) {
+            dp[i][j] = Math.min(
+                dp[i - 1][j] + 1,
+                dp[i][j - 1] + 1,
+                dp[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1)
+            );
+        }
+    }
+    const dist = dp[a.length][b.length];
+    const maxLen = Math.max(a.length, b.length) || 1;
+    return (maxLen - dist) / maxLen;
+}
+
+function findBestId(map: Map<number, string>, name: string): number | undefined {
+    const lower = name.toLowerCase();
+    let bestId: number | undefined;
+    let bestScore = 0;
+    for (const [id, value] of map.entries()) {
+        const score = similarity(lower, value.toLowerCase());
+        if (score > bestScore) {
+            bestScore = score;
+            bestId = id;
+        }
+    }
+    return bestScore >= 0.5 ? bestId : undefined;
+}
+
+export function findBestPersonId(name: string): number | undefined {
+    return findBestId(personMap, name);
+}
+
+export function findBestTagId(name: string): number | undefined {
+    return findBestId(tagMap, name);
 }

--- a/frontend/packages/shared/test/dictionaries.test.ts
+++ b/frontend/packages/shared/test/dictionaries.test.ts
@@ -7,7 +7,11 @@ describe('dictionaries', () => {
 
   it('getPersonName returns loaded name', async () => {
     const getAllPersons = vi.fn().mockResolvedValue([{ id: 1, name: 'John' }]);
-    vi.doMock('../src/generated', () => ({ PersonsService: { getApiPersons: getAllPersons } }));
+    const getAllTags = vi.fn().mockResolvedValue([]);
+    vi.doMock('../src/generated', () => ({
+      PersonsService: { getApiPersons: getAllPersons },
+      TagsService: { getApiTags: getAllTags },
+    }));
     const dict = await import('../src/dictionaries');
     await dict.loadDictionaries();
     expect(dict.getPersonName(1)).toBe('John');
@@ -27,5 +31,24 @@ describe('dictionaries', () => {
     const dict = await import('../src/dictionaries');
     expect(dict.getTagName(5)).toBe('#5');
     expect(dict.getStorageName(7)).toBe('ID 7');
+  });
+
+  it('findBestPersonId and findBestTagId return closest match', async () => {
+    const getAllPersons = vi.fn().mockResolvedValue([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+    const getAllTags = vi.fn().mockResolvedValue([
+      { id: 10, name: 'portrait' },
+      { id: 11, name: 'sea' },
+    ]);
+    vi.doMock('../src/generated', () => ({
+      PersonsService: { getApiPersons: getAllPersons },
+      TagsService: { getApiTags: getAllTags },
+    }));
+    const dict = await import('../src/dictionaries');
+    await dict.loadDictionaries();
+    expect(dict.findBestPersonId('Alic')).toBe(1);
+    expect(dict.findBestTagId('ocean')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- load tags and implement fuzzy ID search helpers
- convert `/ai` command to parse queries with OpenAI
- update unit tests for new behaviour

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_688909a338d8832882b9efd9427c66f2