### PR TITLE
Cache tag/person lists in telegram bot

### DIFF
--- a/frontend/packages/shared/src/dictionaries.ts
+++ b/frontend/packages/shared/src/dictionaries.ts
@@ -1,14 +1,19 @@
-import { PersonsService, TagsService } from "@photobank/shared/generated";
-import { unknownPersonLabel } from "@photobank/shared/constants";
+import { PersonsService, TagsService } from '@photobank/shared/generated';
+import { unknownPersonLabel } from '@photobank/shared/constants';
+import type { PersonDto, TagDto } from '@photobank/shared/generated';
 
 let tagMap = new Map<number, string>();
 let personMap = new Map<number, string>();
+let tagList: TagDto[] = [];
+let personList: PersonDto[] = [];
 let storageMap = new Map<number, string>();
 let pathMap = new Map<number, string>();
 
 export async function loadDictionaries() {
-    tagMap = new Map((await TagsService.getApiTags()).map(tag => [tag.id, tag.name]));
-    personMap = new Map((await PersonsService.getApiPersons()).map(p => [p.id, p.name]));
+    tagList = await TagsService.getApiTags();
+    tagMap = new Map(tagList.map(tag => [tag.id, tag.name]));
+    personList = await PersonsService.getApiPersons();
+    personMap = new Map(personList.map(p => [p.id, p.name]));
 //    storageMap = new Map((await getAllStorages()).map(p => [p.id, p.name]));
 //    pathMap = new Map((await getAllPaths()).map(p => [p.storageId, p.path]));
 }
@@ -17,9 +22,17 @@ export function getTagName(id: number): string {
     return tagMap.get(id) ?? `#${id}`;
 }
 
+export function getAllTags(): TagDto[] {
+    return tagList;
+}
+
 export function getPersonName(id: number | null | undefined): string {
     if (id === null || id === undefined) return unknownPersonLabel;
     return personMap.get(id) ?? `ID ${id}`;
+}
+
+export function getAllPersons(): PersonDto[] {
+    return personList;
 }
 
 export function getStorageName(id: number): string {

--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -1,5 +1,5 @@
 import { Context } from "grammy";
-import { PersonsService } from "@photobank/shared/generated";
+import { getAllPersons } from '@photobank/shared/dictionaries';
 import { parsePrefix, sendNamedItemsPage } from "./helpers";
 
 export async function sendPersonsPage(
@@ -11,7 +11,7 @@ export async function sendPersonsPage(
   await sendNamedItemsPage({
     ctx,
     command: "persons",
-    fetchAll: PersonsService.getApiPersons,
+    fetchAll: async () => getAllPersons(),
     prefix,
     page,
     edit,

--- a/frontend/packages/telegram-bot/src/commands/tags.ts
+++ b/frontend/packages/telegram-bot/src/commands/tags.ts
@@ -1,5 +1,5 @@
 import { Context } from "grammy";
-import { TagsService } from "@photobank/shared/generated";
+import { getAllTags } from '@photobank/shared/dictionaries';
 import { parsePrefix, sendNamedItemsPage } from "./helpers";
 
 export async function sendTagsPage(
@@ -11,7 +11,7 @@ export async function sendTagsPage(
   await sendNamedItemsPage({
     ctx,
     command: "tags",
-    fetchAll: TagsService.getApiTags,
+    fetchAll: async () => getAllTags(),
     prefix,
     page,
     edit,

--- a/frontend/packages/telegram-bot/test/personsTags.test.ts
+++ b/frontend/packages/telegram-bot/test/personsTags.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, vi } from 'vitest';
 import { sendTagsPage } from '../src/commands/tags';
 import { sendPersonsPage } from '../src/commands/persons';
 import { tagsCallbackPattern, personsCallbackPattern } from '../src/patterns';
-import * as api from '@photobank/shared/generated';
+import * as dict from '@photobank/shared/dictionaries';
 
 describe('sendTagsPage', () => {
   it('filters by prefix and paginates', async () => {
     const tags = Array.from({ length: 11 }, (_, i) => ({ id: i + 1, name: `ba${String(i).padStart(2, '0')}` }));
-    vi.spyOn(api.TagsService, 'getApiTags').mockResolvedValue(tags as any);
+    vi.spyOn(dict, 'getAllTags').mockReturnValue(tags as any);
     const ctx = { reply: vi.fn() } as any;
     await sendTagsPage(ctx, 'ba', 2);
     expect(ctx.reply).toHaveBeenCalled();
@@ -20,7 +20,7 @@ describe('sendTagsPage', () => {
 describe('sendPersonsPage', () => {
   it('filters by prefix and paginates', async () => {
     const persons = Array.from({ length: 12 }, (_, i) => ({ id: i + 1, name: `al${String(i).padStart(2, '0')}` }));
-    vi.spyOn(api.PersonsService, 'getApiPersons').mockResolvedValue(persons as any);
+    vi.spyOn(dict, 'getAllPersons').mockReturnValue(persons as any);
     const ctx = { reply: vi.fn() } as any;
     await sendPersonsPage(ctx, 'al', 2);
     expect(ctx.reply).toHaveBeenCalled();
@@ -34,7 +34,7 @@ describe('sendPersonsPage', () => {
       { id: 0, name: 'skip' },
       { id: 1, name: 'al00' },
     ];
-    vi.spyOn(api.PersonsService, 'getApiPersons').mockResolvedValue(persons as any);
+    vi.spyOn(dict, 'getAllPersons').mockReturnValue(persons as any);
     const ctx = { reply: vi.fn() } as any;
     await sendPersonsPage(ctx, 'a', 1);
     expect(ctx.reply).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- keep person and tag lists in memory when loading dictionaries
- reuse cached lists in `/tags` and `/persons` commands
- update tests to stub cached dictionaries

## Testing
- `pnpm -r test` *(fails: PhotoDetailsPage.test.tsx timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68890f5c6eb083288b9e6ce53696cd6f