### PR TITLE
Implement AI search results in Telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/ai.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.ts
@@ -1,17 +1,157 @@
-import { Context } from 'grammy';
+import { Context, InlineKeyboard } from 'grammy';
 import {
   aiCommandUsageMsg,
   sorryTryToRequestLaterMsg,
+  searchPhotosEmptyMsg,
+  apiErrorMsg,
+  unknownYearLabel,
+  prevPageText,
+  nextPageText,
 } from '@photobank/shared/constants';
 import { parseQueryWithOpenAI } from '@photobank/shared/ai/openai';
 import { findBestPersonId, findBestTagId } from '@photobank/shared/dictionaries';
 import type { FilterDto } from '@photobank/shared/generated';
+import { PhotosService } from '@photobank/shared/generated';
+import { firstNWords, getFilterHash } from '@photobank/shared/index';
+import { currentPagePhotos, deletePhotoMessage } from '../photo';
+import { captionCache } from './thisday';
+
+export const aiFilters = new Map<string, FilterDto>();
+
+const PAGE_SIZE = 10;
 
 export function parseAiPrompt(text?: string): string | null {
-    if (!text) return null;
-    const match = text.match(/^\/ai\s+([\s\S]+)/); // capture anything after /ai
-    if (!match) return null;
-    return match[1].trim();
+  if (!text) return null;
+  const match = text.match(/^\/ai\s+([\s\S]+)/); // capture anything after /ai
+  if (!match) return null;
+  return match[1].trim();
+}
+
+export async function sendAiPage(
+  ctx: Context,
+  hash: string,
+  page: number,
+  edit = false,
+) {
+  const filter = aiFilters.get(hash);
+  if (!filter) {
+    await ctx.reply(sorryTryToRequestLaterMsg);
+    return;
+  }
+
+  const chatId = ctx.chat?.id;
+  if (chatId) {
+    const prev = currentPagePhotos.get(chatId);
+    if (prev && prev.page !== page) {
+      await deletePhotoMessage(ctx);
+    }
+  }
+
+  const skip = (page - 1) * PAGE_SIZE;
+  let queryResult;
+  try {
+    queryResult = await PhotosService.postApiPhotosSearch({
+      ...filter,
+      top: PAGE_SIZE,
+      skip,
+    });
+  } catch (err) {
+    console.error(apiErrorMsg, err);
+    await ctx.reply(sorryTryToRequestLaterMsg);
+    return;
+  }
+
+  if (!queryResult.count || !queryResult.photos?.length) {
+    const fallback = searchPhotosEmptyMsg;
+    if (edit) {
+      await ctx.editMessageText(fallback).catch(() => ctx.reply(fallback));
+    } else {
+      await ctx.reply(fallback);
+    }
+    return;
+  }
+
+  const totalPages = Math.ceil(queryResult.count / PAGE_SIZE);
+  const byYear = new Map<number, Map<string, typeof queryResult.photos>>();
+
+  for (const photo of queryResult.photos) {
+    const year = photo.takenDate ? new Date(photo.takenDate).getFullYear() : 0;
+    if (!byYear.has(year)) byYear.set(year, new Map());
+    const yearMap = byYear.get(year)!;
+    const storage = photo.storageName;
+    const path = photo.relativePath;
+    const key = `${storage} / ${path}`;
+    if (!yearMap.has(key)) yearMap.set(key, []);
+    yearMap.get(key)!.push(photo);
+  }
+
+  const sections: string[] = [];
+  const keyboard = new InlineKeyboard();
+  const photoIds: number[] = [];
+
+  [...byYear.entries()]
+    .sort(([a], [b]) => b - a)
+    .forEach(([year, folders]) => {
+      sections.push(`\n📅 <b>${year || unknownYearLabel}</b>`);
+      [...folders.entries()].forEach(([folder, photos]) => {
+        sections.push(`📁 ${folder}`);
+        photos.forEach((photo) => {
+          const title = photo.name.slice(0, 10) || 'Без названия';
+          const peopleCount = photo.persons?.length ?? 0;
+          const isAdult = photo.isAdultContent ? '🔞' : '';
+          const isRacy = photo.isRacyContent ? '⚠️' : '';
+
+          const metaParts: string[] = [];
+          if (peopleCount > 0) metaParts.push(`👥 ${peopleCount} чел.`);
+          if (isAdult) metaParts.push(isAdult);
+          if (isRacy) metaParts.push(isRacy);
+          const metaLine = metaParts.length ? `\n${metaParts.join(' ')}` : '';
+
+          const cap = photo.captions?.join(' ') ?? '';
+          const index = photoIds.length + 1;
+          sections.push(`[${index}] <b>${title}</b>\n${firstNWords(cap, 5)} ${metaLine}`);
+          captionCache.set(photo.id, cap);
+          photoIds.push(photo.id);
+        });
+      });
+    });
+
+  photoIds.forEach((id, index) => {
+    if (index % 5 === 0) keyboard.row();
+    keyboard.text(String(index + 1), `photo:${id}`);
+  });
+
+  if (chatId) {
+    currentPagePhotos.set(chatId, { page, ids: photoIds });
+  }
+
+  keyboard.row();
+
+  sections.push(`\n📄 Страница ${page} из ${totalPages}`);
+
+  if (page > 1) keyboard.text(prevPageText, `ai:${page - 1}:${hash}`);
+  if (page < totalPages) keyboard.text(nextPageText, `ai:${page + 1}:${hash}`);
+
+  const text = sections.join('\n');
+
+  if (edit) {
+    await ctx
+      .editMessageText(text, {
+        parse_mode: 'HTML',
+        reply_markup: keyboard,
+      })
+      .catch(() =>
+        ctx.reply(text, {
+          parse_mode: 'HTML',
+          reply_markup: keyboard,
+        }),
+      );
+  } else {
+    await ctx.reply(text, {
+      parse_mode: 'HTML',
+      reply_markup: keyboard,
+    });
+  }
 }
 
 export async function aiCommand(ctx: Context) {
@@ -36,7 +176,10 @@ export async function aiCommand(ctx: Context) {
     if (filter.dateFrom) dto.takenDateFrom = filter.dateFrom.toISOString();
     if (filter.dateTo) dto.takenDateTo = filter.dateTo.toISOString();
 
-    await ctx.reply(JSON.stringify(dto, null, 2));
+    const hash = await getFilterHash(dto);
+    aiFilters.set(hash, dto);
+
+    await sendAiPage(ctx, hash, 1);
   } catch (err) {
     console.error(err);
     await ctx.reply(sorryTryToRequestLaterMsg);

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -21,7 +21,7 @@ import {
 } from "./config";
 import { sendThisDayPage, thisDayCommand, captionCache } from "./commands/thisday";
 import { sendSearchPage, searchCommand } from "./commands/search";
-import { aiCommand } from "./commands/ai";
+import { aiCommand, sendAiPage } from "./commands/ai";
 import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
 import { tagsCommand, sendTagsPage } from "./commands/tags";
 import { personsCommand, sendPersonsPage } from "./commands/persons";
@@ -65,7 +65,7 @@ bot.command(
 
 bot.command("thisday", withRegistered(thisDayCommand));
 bot.command("search", withRegistered(searchCommand));
-bot.command("ai", aiCommand);
+bot.command("ai", withRegistered(aiCommand));
 
 bot.command("profile", profileCommand);
 
@@ -120,6 +120,16 @@ bot.callbackQuery(/^search:(\d+):(.+)$/, withRegistered(async (ctx) => {
   const caption = decodeURIComponent(ctx.match[2]);
   await ctx.answerCallbackQuery();
   await sendSearchPage(ctx, caption, page, true);
+}));
+
+bot.callbackQuery(/^ai:(\d+):([\w-]+)$/, withRegistered(async (ctx) => {
+  if (!ctx.match) {
+    throw new Error("Callback query match is undefined.");
+  }
+  const page = parseInt(ctx.match[1], 10);
+  const hash = ctx.match[2];
+  await ctx.answerCallbackQuery();
+  await sendAiPage(ctx, hash, page, true);
 }));
 
 bot.start();

--- a/frontend/packages/telegram-bot/test/aiCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/aiCommand.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { aiCommand, parseAiPrompt } from '../src/commands/ai';
+import { aiCommand, parseAiPrompt, aiFilters } from '../src/commands/ai';
 import * as openai from '@photobank/shared/ai/openai';
 import * as dict from '@photobank/shared/dictionaries';
-import { aiCommandUsageMsg, sorryTryToRequestLaterMsg } from '@photobank/shared/constants';
+import * as photosApi from '@photobank/shared/generated';
+import * as utils from '@photobank/shared/index';
+import { aiCommandUsageMsg, sorryTryToRequestLaterMsg, searchPhotosEmptyMsg } from '@photobank/shared/constants';
 
 describe('parseAiPrompt', () => {
   it('parses prompt from command', () => {
@@ -28,7 +30,7 @@ describe('aiCommand', () => {
     expect(ctx.reply).toHaveBeenCalledWith(sorryTryToRequestLaterMsg);
   });
 
-  it('sends filter dto string on success', async () => {
+  it('requests photos with parsed filter', async () => {
     const ctx = { reply: vi.fn(), message: { text: '/ai test' } } as any;
     vi.spyOn(openai, 'parseQueryWithOpenAI').mockResolvedValue({
       persons: ['Alice'],
@@ -38,9 +40,24 @@ describe('aiCommand', () => {
     });
     vi.spyOn(dict, 'findBestPersonId').mockReturnValue(1);
     vi.spyOn(dict, 'findBestTagId').mockReturnValue(10);
+    vi.spyOn(utils, 'getFilterHash').mockResolvedValue('hash');
+    const searchSpy = vi
+      .spyOn(photosApi.PhotosService, 'postApiPhotosSearch')
+      .mockResolvedValue({ count: 0, photos: [] } as any);
+    aiFilters.clear();
+
     await aiCommand(ctx);
-    expect(ctx.reply).toHaveBeenCalledWith(
-      JSON.stringify({ persons: [1], tags: [10], takenDateFrom: '2020-01-01T00:00:00.000Z' }, null, 2)
+
+    expect(aiFilters.has('hash')).toBe(true);
+    expect(searchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        persons: [1],
+        tags: [10],
+        takenDateFrom: '2020-01-01T00:00:00.000Z',
+        top: 10,
+        skip: 0,
+      })
     );
+    expect(ctx.reply).toHaveBeenCalledWith(searchPhotosEmptyMsg);
   });
 });

--- a/frontend/packages/telegram-bot/test/aiPage.test.ts
+++ b/frontend/packages/telegram-bot/test/aiPage.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendAiPage, aiFilters } from '../src/commands/ai';
+import * as photosApi from '@photobank/shared/generated';
+import * as photo from '../src/photo';
+
+const basePhoto = {
+  id: 1,
+  name: 'test',
+  storageName: 's',
+  relativePath: 'p',
+  takenDate: new Date().toISOString(),
+  persons: [],
+  isAdultContent: false,
+  isRacyContent: false,
+  captions: [],
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  photo.currentPagePhotos.clear();
+  aiFilters.clear();
+});
+
+describe('sendAiPage', () => {
+  it('deletes preview message when page changes', async () => {
+    const ctx = {
+      chat: { id: 1 },
+      reply: vi.fn(),
+      editMessageText: vi.fn().mockResolvedValue(undefined),
+    } as any;
+    aiFilters.set('hash', {} as any);
+    photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
+    vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
+    vi.spyOn(photosApi.PhotosService, 'postApiPhotosSearch').mockResolvedValue({
+      count: 1,
+      photos: [basePhoto],
+    } as any);
+
+    await sendAiPage(ctx, 'hash', 2, true);
+
+    expect(photo.deletePhotoMessage).toHaveBeenCalled();
+  });
+
+  it('does not delete preview message when same page requested', async () => {
+    const ctx = {
+      chat: { id: 1 },
+      reply: vi.fn(),
+      editMessageText: vi.fn().mockResolvedValue(undefined),
+    } as any;
+    aiFilters.set('hash', {} as any);
+    photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
+    vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
+    vi.spyOn(photosApi.PhotosService, 'postApiPhotosSearch').mockResolvedValue({
+      count: 1,
+      photos: [basePhoto],
+    } as any);
+
+    await sendAiPage(ctx, 'hash', 1, true);
+
+    expect(photo.deletePhotoMessage).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- enable AI search pagination in the Telegram bot
- store AI filters for callback navigation
- add `/ai` pagination callbacks and require registration
- update unit tests and add tests for AI pages

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6889c2e354a883288609bb59c688da94