### PR TITLE
Refactor telegram-bot photo commands

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/ai.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.ts
@@ -1,24 +1,16 @@
-import { Context, InlineKeyboard } from 'grammy';
+import { Context } from 'grammy';
 import {
   aiCommandUsageMsg,
   sorryTryToRequestLaterMsg,
   searchPhotosEmptyMsg,
-  apiErrorMsg,
-  unknownYearLabel,
-  prevPageText,
-  nextPageText,
 } from '@photobank/shared/constants';
 import { parseQueryWithOpenAI } from '@photobank/shared/ai/openai';
 import { findBestPersonId, findBestTagId } from '@photobank/shared/dictionaries';
 import type { FilterDto } from '@photobank/shared/generated';
-import { PhotosService } from '@photobank/shared/generated';
-import { firstNWords, getFilterHash } from '@photobank/shared/index';
-import { currentPagePhotos, deletePhotoMessage } from '../photo';
-import { captionCache } from './thisday';
+import { getFilterHash } from '@photobank/shared/index';
+import { sendPhotosPage } from './photosPage';
 
 export const aiFilters = new Map<string, FilterDto>();
-
-const PAGE_SIZE = 10;
 
 export function parseAiPrompt(text?: string): string | null {
   if (!text) return null;
@@ -38,120 +30,14 @@ export async function sendAiPage(
     await ctx.reply(sorryTryToRequestLaterMsg);
     return;
   }
-
-  const chatId = ctx.chat?.id;
-  if (chatId) {
-    const prev = currentPagePhotos.get(chatId);
-    if (prev && prev.page !== page) {
-      await deletePhotoMessage(ctx);
-    }
-  }
-
-  const skip = (page - 1) * PAGE_SIZE;
-  let queryResult;
-  try {
-    queryResult = await PhotosService.postApiPhotosSearch({
-      ...filter,
-      top: PAGE_SIZE,
-      skip,
-    });
-  } catch (err) {
-    console.error(apiErrorMsg, err);
-    await ctx.reply(sorryTryToRequestLaterMsg);
-    return;
-  }
-
-  if (!queryResult.count || !queryResult.photos?.length) {
-    const fallback = searchPhotosEmptyMsg;
-    if (edit) {
-      await ctx.editMessageText(fallback).catch(() => ctx.reply(fallback));
-    } else {
-      await ctx.reply(fallback);
-    }
-    return;
-  }
-
-  const totalPages = Math.ceil(queryResult.count / PAGE_SIZE);
-  const byYear = new Map<number, Map<string, typeof queryResult.photos>>();
-
-  for (const photo of queryResult.photos) {
-    const year = photo.takenDate ? new Date(photo.takenDate).getFullYear() : 0;
-    if (!byYear.has(year)) byYear.set(year, new Map());
-    const yearMap = byYear.get(year)!;
-    const storage = photo.storageName;
-    const path = photo.relativePath;
-    const key = `${storage} / ${path}`;
-    if (!yearMap.has(key)) yearMap.set(key, []);
-    yearMap.get(key)!.push(photo);
-  }
-
-  const sections: string[] = [];
-  const keyboard = new InlineKeyboard();
-  const photoIds: number[] = [];
-
-  [...byYear.entries()]
-    .sort(([a], [b]) => b - a)
-    .forEach(([year, folders]) => {
-      sections.push(`\n📅 <b>${year || unknownYearLabel}</b>`);
-      [...folders.entries()].forEach(([folder, photos]) => {
-        sections.push(`📁 ${folder}`);
-        photos.forEach((photo) => {
-          const title = photo.name.slice(0, 10) || 'Без названия';
-          const peopleCount = photo.persons?.length ?? 0;
-          const isAdult = photo.isAdultContent ? '🔞' : '';
-          const isRacy = photo.isRacyContent ? '⚠️' : '';
-
-          const metaParts: string[] = [];
-          if (peopleCount > 0) metaParts.push(`👥 ${peopleCount} чел.`);
-          if (isAdult) metaParts.push(isAdult);
-          if (isRacy) metaParts.push(isRacy);
-          const metaLine = metaParts.length ? `\n${metaParts.join(' ')}` : '';
-
-          const cap = photo.captions?.join(' ') ?? '';
-          const index = photoIds.length + 1;
-          sections.push(`[${index}] <b>${title}</b>\n${firstNWords(cap, 5)} ${metaLine}`);
-          captionCache.set(photo.id, cap);
-          photoIds.push(photo.id);
-        });
-      });
-    });
-
-  photoIds.forEach((id, index) => {
-    if (index % 5 === 0) keyboard.row();
-    keyboard.text(String(index + 1), `photo:${id}`);
+  await sendPhotosPage({
+    ctx,
+    filter,
+    page,
+    edit,
+    fallbackMessage: searchPhotosEmptyMsg,
+    buildCallbackData: (p) => `ai:${p}:${hash}`,
   });
-
-  if (chatId) {
-    currentPagePhotos.set(chatId, { page, ids: photoIds });
-  }
-
-  keyboard.row();
-
-  sections.push(`\n📄 Страница ${page} из ${totalPages}`);
-
-  if (page > 1) keyboard.text(prevPageText, `ai:${page - 1}:${hash}`);
-  if (page < totalPages) keyboard.text(nextPageText, `ai:${page + 1}:${hash}`);
-
-  const text = sections.join('\n');
-
-  if (edit) {
-    await ctx
-      .editMessageText(text, {
-        parse_mode: 'HTML',
-        reply_markup: keyboard,
-      })
-      .catch(() =>
-        ctx.reply(text, {
-          parse_mode: 'HTML',
-          reply_markup: keyboard,
-        }),
-      );
-  } else {
-    await ctx.reply(text, {
-      parse_mode: 'HTML',
-      reply_markup: keyboard,
-    });
-  }
 }
 
 export async function aiCommand(ctx: Context) {

--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -1,0 +1,143 @@
+import { Context, InlineKeyboard } from 'grammy';
+import {
+  apiErrorMsg,
+  sorryTryToRequestLaterMsg,
+  unknownYearLabel,
+  prevPageText,
+  nextPageText,
+} from '@photobank/shared/constants';
+import type { FilterDto } from '@photobank/shared/generated';
+import { PhotosService } from '@photobank/shared/generated';
+import { firstNWords } from '@photobank/shared/index';
+import { captionCache, currentPagePhotos, deletePhotoMessage } from '../photo';
+
+export const PHOTOS_PAGE_SIZE = 10;
+
+export interface SendPhotosPageOptions {
+  ctx: Context;
+  filter: FilterDto;
+  page: number;
+  edit?: boolean;
+  fallbackMessage: string;
+  buildCallbackData: (page: number) => string;
+}
+
+export async function sendPhotosPage({
+  ctx,
+  filter,
+  page,
+  edit = false,
+  fallbackMessage,
+  buildCallbackData,
+}: SendPhotosPageOptions) {
+  const chatId = ctx.chat?.id;
+  if (chatId) {
+    const prev = currentPagePhotos.get(chatId);
+    if (prev && prev.page !== page) {
+      await deletePhotoMessage(ctx);
+    }
+  }
+
+  const skip = (page - 1) * PHOTOS_PAGE_SIZE;
+  let queryResult;
+  try {
+    queryResult = await PhotosService.postApiPhotosSearch({
+      ...filter,
+      top: PHOTOS_PAGE_SIZE,
+      skip,
+    });
+  } catch (err) {
+    console.error(apiErrorMsg, err);
+    await ctx.reply(sorryTryToRequestLaterMsg);
+    return;
+  }
+
+  if (!queryResult.count || !queryResult.photos?.length) {
+    if (edit) {
+      await ctx.editMessageText(fallbackMessage).catch(() => ctx.reply(fallbackMessage));
+    } else {
+      await ctx.reply(fallbackMessage);
+    }
+    return;
+  }
+
+  const totalPages = Math.ceil(queryResult.count / PHOTOS_PAGE_SIZE);
+  const byYear = new Map<number, Map<string, typeof queryResult.photos>>();
+
+  for (const photo of queryResult.photos) {
+    const year = photo.takenDate ? new Date(photo.takenDate).getFullYear() : 0;
+    if (!byYear.has(year)) byYear.set(year, new Map());
+    const yearMap = byYear.get(year)!;
+    const key = `${photo.storageName} / ${photo.relativePath}`;
+    if (!yearMap.has(key)) yearMap.set(key, []);
+    yearMap.get(key)!.push(photo);
+  }
+
+  const sections: string[] = [];
+  const keyboard = new InlineKeyboard();
+  const photoIds: number[] = [];
+
+  [...byYear.entries()]
+    .sort(([a], [b]) => b - a)
+    .forEach(([year, folders]) => {
+      sections.push(`\n📅 <b>${year || unknownYearLabel}</b>`);
+      [...folders.entries()].forEach(([folder, photos]) => {
+        sections.push(`📁 ${folder}`);
+        photos.forEach((photo) => {
+          const title = photo.name.slice(0, 10) || 'Без названия';
+          const peopleCount = photo.persons?.length ?? 0;
+          const isAdult = photo.isAdultContent ? '🔞' : '';
+          const isRacy = photo.isRacyContent ? '⚠️' : '';
+
+          const metaParts: string[] = [];
+          if (peopleCount > 0) metaParts.push(`👥 ${peopleCount} чел.`);
+          if (isAdult) metaParts.push(isAdult);
+          if (isRacy) metaParts.push(isRacy);
+          const metaLine = metaParts.length ? `\n${metaParts.join(' ')}` : '';
+
+          const cap = photo.captions?.join(' ') ?? '';
+          const index = photoIds.length + 1;
+          sections.push(`[${index}] <b>${title}</b>\n${firstNWords(cap, 5)} ${metaLine}`);
+          captionCache.set(photo.id, cap);
+          photoIds.push(photo.id);
+        });
+      });
+    });
+
+  photoIds.forEach((id, index) => {
+    if (index % 5 === 0) keyboard.row();
+    keyboard.text(String(index + 1), `photo:${id}`);
+  });
+
+  if (chatId) {
+    currentPagePhotos.set(chatId, { page, ids: photoIds });
+  }
+
+  keyboard.row();
+
+  sections.push(`\n📄 Страница ${page} из ${totalPages}`);
+
+  if (page > 1) keyboard.text(prevPageText, buildCallbackData(page - 1));
+  if (page < totalPages) keyboard.text(nextPageText, buildCallbackData(page + 1));
+
+  const text = sections.join('\n');
+
+  if (edit) {
+    await ctx
+      .editMessageText(text, {
+        parse_mode: 'HTML',
+        reply_markup: keyboard,
+      })
+      .catch(() =>
+        ctx.reply(text, {
+          parse_mode: 'HTML',
+          reply_markup: keyboard,
+        }),
+      );
+  } else {
+    await ctx.reply(text, {
+      parse_mode: 'HTML',
+      reply_markup: keyboard,
+    });
+  }
+}

--- a/frontend/packages/telegram-bot/src/commands/search.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.ts
@@ -1,19 +1,9 @@
-import { Context, InlineKeyboard } from "grammy";
-import { PhotosService } from "@photobank/shared/generated";
-import { firstNWords } from "@photobank/shared/index";
+import { Context } from "grammy";
 import {
-  apiErrorMsg,
-  sorryTryToRequestLaterMsg,
   searchPhotosEmptyMsg,
-  unknownYearLabel,
-  prevPageText,
-  nextPageText,
   searchCommandUsageMsg,
 } from "@photobank/shared/constants";
-import { currentPagePhotos, deletePhotoMessage } from "../photo";
-import { captionCache } from "./thisday";
-
-const PAGE_SIZE = 10;
+import { sendPhotosPage } from "./photosPage";
 
 function parseCaption(text?: string): string {
   if (!text) return "";
@@ -45,117 +35,12 @@ export async function sendSearchPage(
   page: number,
   edit = false,
 ) {
-  const chatId = ctx.chat?.id;
-  if (chatId) {
-    const prev = currentPagePhotos.get(chatId);
-    if (prev && prev.page !== page) {
-      await deletePhotoMessage(ctx);
-    }
-  }
-
-  const skip = (page - 1) * PAGE_SIZE;
-  let queryResult;
-  try {
-    queryResult = await PhotosService.postApiPhotosSearch({
-      caption,
-      top: PAGE_SIZE,
-      skip,
-    });
-  } catch (err) {
-    console.error(apiErrorMsg, err);
-    await ctx.reply(sorryTryToRequestLaterMsg);
-    return;
-  }
-
-  if (!queryResult.count || !queryResult.photos?.length) {
-    const fallback = searchPhotosEmptyMsg;
-    if (edit) {
-      await ctx.editMessageText(fallback).catch(() => ctx.reply(fallback));
-    } else {
-      await ctx.reply(fallback);
-    }
-    return;
-  }
-
-  const totalPages = Math.ceil(queryResult.count / PAGE_SIZE);
-  const byYear = new Map<number, Map<string, typeof queryResult.photos>>();
-
-  for (const photo of queryResult.photos) {
-    const year = photo.takenDate ? new Date(photo.takenDate).getFullYear() : 0;
-    if (!byYear.has(year)) byYear.set(year, new Map());
-    const yearMap = byYear.get(year)!;
-    const storage = photo.storageName;
-    const path = photo.relativePath;
-    const key = `${storage} / ${path}`;
-    if (!yearMap.has(key)) yearMap.set(key, []);
-    yearMap.get(key)!.push(photo);
-  }
-
-  const sections: string[] = [];
-  const keyboard = new InlineKeyboard();
-  const photoIds: number[] = [];
-
-  [...byYear.entries()]
-    .sort(([a], [b]) => b - a)
-    .forEach(([year, folders]) => {
-      sections.push(`\n📅 <b>${year || unknownYearLabel}</b>`);
-      [...folders.entries()].forEach(([folder, photos]) => {
-        sections.push(`📁 ${folder}`);
-        photos.forEach((photo) => {
-          const title = photo.name.slice(0, 10) || "Без названия";
-          const peopleCount = photo.persons?.length ?? 0;
-          const isAdult = photo.isAdultContent ? "🔞" : "";
-          const isRacy = photo.isRacyContent ? "⚠️" : "";
-
-          const metaParts: string[] = [];
-          if (peopleCount > 0) metaParts.push(`👥 ${peopleCount} чел.`);
-          if (isAdult) metaParts.push(isAdult);
-          if (isRacy) metaParts.push(isRacy);
-          const metaLine = metaParts.length ? `\n${metaParts.join(" ")}` : "";
-
-          const cap = photo.captions?.join(" ") ?? "";
-          const index = photoIds.length + 1;
-          sections.push(`[${index}] <b>${title}</b>\n${firstNWords(cap, 5)} ${metaLine}`);
-          captionCache.set(photo.id, cap);
-          photoIds.push(photo.id);
-        });
-      });
-    });
-
-  photoIds.forEach((id, index) => {
-    if (index % 5 === 0) keyboard.row();
-    keyboard.text(String(index + 1), `photo:${id}`);
+  await sendPhotosPage({
+    ctx,
+    filter: { caption },
+    page,
+    edit,
+    fallbackMessage: searchPhotosEmptyMsg,
+    buildCallbackData: (p) => `search:${p}:${encodeURIComponent(caption)}`,
   });
-
-  if (chatId) {
-    currentPagePhotos.set(chatId, { page, ids: photoIds });
-  }
-
-  keyboard.row();
-
-  sections.push(`\n📄 Страница ${page} из ${totalPages}`);
-
-  if (page > 1) keyboard.text(prevPageText, `search:${page - 1}:${encodeURIComponent(caption)}`);
-  if (page < totalPages) keyboard.text(nextPageText, `search:${page + 1}:${encodeURIComponent(caption)}`);
-
-  const text = sections.join("\n");
-
-  if (edit) {
-    await ctx
-      .editMessageText(text, {
-        parse_mode: "HTML",
-        reply_markup: keyboard,
-      })
-      .catch(() =>
-        ctx.reply(text, {
-          parse_mode: "HTML",
-          reply_markup: keyboard,
-        }),
-      );
-  } else {
-    await ctx.reply(text, {
-      parse_mode: "HTML",
-      reply_markup: keyboard,
-    });
-  }
 }

--- a/frontend/packages/telegram-bot/src/commands/thisday.ts
+++ b/frontend/packages/telegram-bot/src/commands/thisday.ts
@@ -1,19 +1,6 @@
-import {Context, InlineKeyboard} from "grammy";
-import { PhotosService } from "@photobank/shared/generated";
-import {firstNWords} from "@photobank/shared/index";
-import {
-    apiErrorMsg,
-    sorryTryToRequestLaterMsg,
-    todaysPhotosEmptyMsg,
-    unknownYearLabel,
-    prevPageText,
-    nextPageText,
-} from "@photobank/shared/constants";
-import { currentPagePhotos, deletePhotoMessage } from "../photo";
-
-export const captionCache = new Map<number, string>();
-
-const PAGE_SIZE = 10;
+import { Context } from "grammy";
+import { todaysPhotosEmptyMsg } from "@photobank/shared/constants";
+import { sendPhotosPage } from "./photosPage";
 
 function parsePage(text?: string): number {
     if (!text) return 1;
@@ -27,114 +14,13 @@ export async function handleThisDay(ctx: Context) {
 }
 
 export const thisDayCommand = handleThisDay;
-
 export async function sendThisDayPage(ctx: Context, page: number, edit = false) {
-    const chatId = ctx.chat?.id;
-    if (chatId) {
-        const prev = currentPagePhotos.get(chatId);
-        if (prev && prev.page !== page) {
-            await deletePhotoMessage(ctx);
-        }
-    }
-
-    const skip = (page - 1) * PAGE_SIZE;
-    let queryResult;
-    try {
-        queryResult = await PhotosService.postApiPhotosSearch({
-            thisDay: true,
-            top: PAGE_SIZE,
-            skip,
-        });
-    } catch (err) {
-        console.error(apiErrorMsg, err);
-        await ctx.reply(sorryTryToRequestLaterMsg);
-        return;
-    }
-
-    if (!queryResult.count || !queryResult.photos?.length) {
-        const fallback = todaysPhotosEmptyMsg;
-        if (edit) {
-            await ctx.editMessageText(fallback).catch(() => ctx.reply(fallback));
-        } else {
-            await ctx.reply(fallback);
-        }
-        return;
-    }
-
-    const totalPages = Math.ceil(queryResult.count / PAGE_SIZE);
-    const byYear = new Map<number, Map<string, typeof queryResult.photos>>();
-
-    for (const photo of queryResult.photos) {
-        const year = photo.takenDate ? new Date(photo.takenDate).getFullYear() : 0;
-        if (!byYear.has(year)) byYear.set(year, new Map());
-        const yearMap = byYear.get(year)!;
-        const storage = photo.storageName;
-        const path = photo.relativePath;
-        const key = `${storage} / ${path}`;
-        if (!yearMap.has(key)) yearMap.set(key, []);
-        yearMap.get(key)!.push(photo);
-    }
-
-    const sections: string[] = [];
-    const keyboard = new InlineKeyboard();
-    const photoIds: number[] = [];
-
-    [...byYear.entries()]
-        .sort(([a], [b]) => b - a)
-        .forEach(([year, folders]) => {
-            sections.push(`\n📅 <b>${year || unknownYearLabel}</b>`);
-            [...folders.entries()].forEach(([folder, photos]) => {
-                sections.push(`📁 ${folder}`);
-                photos.forEach(photo => {
-                    const title = photo.name.slice(0, 10) || "Без названия";
-                    const peopleCount = photo.persons?.length ?? 0;
-                    const isAdult = photo.isAdultContent ? "🔞" : "";
-                    const isRacy = photo.isRacyContent ? "⚠️" : "";
-
-                    const metaParts: string[] = [];
-                    if (peopleCount > 0) metaParts.push(`👥 ${peopleCount} чел.`);
-                    if (isAdult) metaParts.push(isAdult);
-                    if (isRacy) metaParts.push(isRacy);
-                    const metaLine = metaParts.length ? `\n${metaParts.join(" ")}` : "";
-
-                    const caption = photo.captions?.join(" ") ?? "";
-                    const index = photoIds.length + 1;
-                    sections.push(`[${index}] <b>${title}</b>\n${firstNWords(caption, 5)} ${metaLine}`);
-                    photoIds.push(photo.id);
-                });
-            });
-        });
-
-    photoIds.forEach((id, index) => {
-        if (index % 5 === 0) keyboard.row();
-        keyboard.text(String(index + 1), `photo:${id}`);
+    await sendPhotosPage({
+        ctx,
+        filter: { thisDay: true },
+        page,
+        edit,
+        fallbackMessage: todaysPhotosEmptyMsg,
+        buildCallbackData: (p) => `thisday:${p}`,
     });
-
-    if (chatId) {
-        currentPagePhotos.set(chatId, { page, ids: photoIds });
-    }
-
-    keyboard.row();
-
-    sections.push(`\n📄 Страница ${page} из ${totalPages}`);
-
-    if (page > 1) keyboard.text(prevPageText, `thisday:${page - 1}`);
-    if (page < totalPages) keyboard.text(nextPageText, `thisday:${page + 1}`);
-
-    const text = sections.join("\n");
-
-    if (edit) {
-        await ctx.editMessageText(text, {
-            parse_mode: "HTML",
-            reply_markup: keyboard,
-        }).catch(() => ctx.reply(text, {
-            parse_mode: "HTML",
-            reply_markup: keyboard,
-        }));
-    } else {
-        await ctx.reply(text, {
-            parse_mode: "HTML",
-            reply_markup: keyboard,
-        });
-    }
 }

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -19,7 +19,8 @@ import {
   AZURE_OPENAI_DEPLOYMENT,
   AZURE_OPENAI_API_VERSION,
 } from "./config";
-import { sendThisDayPage, thisDayCommand, captionCache } from "./commands/thisday";
+import { sendThisDayPage, thisDayCommand } from "./commands/thisday";
+import { captionCache } from "./photo";
 import { sendSearchPage, searchCommand } from "./commands/search";
 import { aiCommand, sendAiPage } from "./commands/ai";
 import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -5,6 +5,7 @@ import { photoNotFoundMsg, prevPageText, nextPageText } from "@photobank/shared/
 
 export const photoMessages = new Map<number, number>();
 export const currentPagePhotos = new Map<number, { page: number; ids: number[] }>();
+export const captionCache = new Map<number, string>();
 
 export async function deletePhotoMessage(ctx: Context) {
     const chatId = ctx.chat?.id;


### PR DESCRIPTION
## Summary
- centralize photo page rendering in `sendPhotosPage`
- update `/thisday`, `/search`, and `/ai` commands to use helper
- move `captionCache` to `photo.ts`

## Testing
- `pnpm --filter telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_6889d1c51e0483288a3a12f92abe87f6