### PR TITLE
Improve AI command filter validation

### DIFF
--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -1,39 +1,43 @@
 import type { FilterDto } from '@photobank/shared/generated';
 
 export const DEFAULT_PHOTO_FILTER: FilterDto = {
-    thisDay: true,
-    skip: 0,
-    top: 10,
+  thisDay: true,
+  skip: 0,
+  top: 10,
 } as const;
 
-export const getPhotoErrorMsg = "🚫 Не удалось получить фото.";
-export const getProfileErrorMsg = "🚫 Не удалось получить профиль пользователя.";
-export const sorryTryToRequestLaterMsg = "🚫 Извините, попробуйте позже.";
-export const apiErrorMsg = "API error:";
+export const getPhotoErrorMsg = '🚫 Не удалось получить фото.';
+export const getProfileErrorMsg =
+  '🚫 Не удалось получить профиль пользователя.';
+export const sorryTryToRequestLaterMsg = '🚫 Извините, попробуйте позже.';
+export const apiErrorMsg = 'API error:';
 
 // Telegram bot messages
-export const welcomeBotMsg = "Добро пожаловать. Запущен и работает!";
-export const captionMissingMsg = "Без подписи.";
-export const unknownMessageReplyMsg = "Получил другое сообщение!";
-export const photoCommandUsageMsg = "❗ Используй: /photo <id>";
-export const photoNotFoundMsg = "❌ Фото не найдено.";
-export const subscribeCommandUsageMsg = "❗ Используй: /subscribe HH:MM";
-export const searchCommandUsageMsg = "❗ Используй: /search <caption>";
-export const aiCommandUsageMsg = "❗ Используй: /ai <prompt>";
-export const todaysPhotosEmptyMsg = "📭 Сегодняшних фото пока нет.";
-export const searchPhotosEmptyMsg = "📭 По вашему запросу фото не найдены.";
+export const welcomeBotMsg = 'Добро пожаловать. Запущен и работает!';
+export const captionMissingMsg = 'Без подписи.';
+export const unknownMessageReplyMsg = 'Получил другое сообщение!';
+export const photoCommandUsageMsg = '❗ Используй: /photo <id>';
+export const photoNotFoundMsg = '❌ Фото не найдено.';
+export const subscribeCommandUsageMsg = '❗ Используй: /subscribe HH:MM';
+export const searchCommandUsageMsg = '❗ Используй: /search <caption>';
+export const aiCommandUsageMsg = '❗ Используй: /ai <prompt>';
+export const aiFilterEmptyMsg =
+  '⚠️ Не удалось определить фильтр по запросу. Попробуйте уточнить.';
+export const todaysPhotosEmptyMsg = '📭 Сегодняшних фото пока нет.';
+export const searchPhotosEmptyMsg = '📭 По вашему запросу фото не найдены.';
 export const notRegisteredMsg =
-  "⚠️ Ваш телеграм не зарегистрирован. Обратитесь к администратору.";
-export const unknownYearLabel = "Неизвестный год";
-export const unknownPersonLabel = "Неизвестный";
-export const prevPageText = "◀ Назад";
-export const nextPageText = "Вперёд ▶";
-export const rolesLabel = "Роли:";
-export const rolesEmptyLabel = "Роли отсутствуют.";
-export const claimsLabel = "Права пользователя:";
-export const claimsEmptyLabel = "Права пользователя отсутствуют.";
-export const botTokenNotDefinedError = "BOT_TOKEN is not defined";
-export const apiCredentialsNotDefinedError = "API_EMAIL or API_PASSWORD is not defined";
+  '⚠️ Ваш телеграм не зарегистрирован. Обратитесь к администратору.';
+export const unknownYearLabel = 'Неизвестный год';
+export const unknownPersonLabel = 'Неизвестный';
+export const prevPageText = '◀ Назад';
+export const nextPageText = 'Вперёд ▶';
+export const rolesLabel = 'Роли:';
+export const rolesEmptyLabel = 'Роли отсутствуют.';
+export const claimsLabel = 'Права пользователя:';
+export const claimsEmptyLabel = 'Права пользователя отсутствуют.';
+export const botTokenNotDefinedError = 'BOT_TOKEN is not defined';
+export const apiCredentialsNotDefinedError =
+  'API_EMAIL or API_PASSWORD is not defined';
 
 // frontend shared constants
 export const METADATA_CACHE_KEY = 'photobank_metadata_cache';
@@ -121,7 +125,6 @@ export const loginButtonText = 'Login';
 export const registerTitle = 'Register';
 export const registerButtonText = 'Register';
 
-
 // Logout page
 export const loggingOutMsg = 'Logging out...';
 
@@ -152,7 +155,8 @@ export const adultScoreLabel = 'Adult Score';
 export const racyScoreLabel = 'Racy Score';
 export const detectedFacesTitle = 'Detected Faces';
 export const showFaceBoxesLabel = 'Show face boxes';
-export const hoverFaceHint = 'Hover over the blue boxes on the image to see face details.';
+export const hoverFaceHint =
+  'Hover over the blue boxes on the image to see face details.';
 
 // Profile page
 export const myProfileTitle = 'My Profile';

--- a/frontend/packages/telegram-bot/src/commands/ai.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.ts
@@ -1,11 +1,15 @@
 import { Context } from 'grammy';
 import {
   aiCommandUsageMsg,
+  aiFilterEmptyMsg,
   sorryTryToRequestLaterMsg,
   searchPhotosEmptyMsg,
 } from '@photobank/shared/constants';
 import { parseQueryWithOpenAI } from '@photobank/shared/ai/openai';
-import { findBestPersonId, findBestTagId } from '@photobank/shared/dictionaries';
+import {
+  findBestPersonId,
+  findBestTagId,
+} from '@photobank/shared/dictionaries';
 import type { FilterDto } from '@photobank/shared/generated';
 import { getFilterHash } from '@photobank/shared/index';
 import { sendPhotosPage } from './photosPage';
@@ -23,7 +27,7 @@ export async function sendAiPage(
   ctx: Context,
   hash: string,
   page: number,
-  edit = false,
+  edit = false
 ) {
   const filter = aiFilters.get(hash);
   if (!filter) {
@@ -61,6 +65,11 @@ export async function aiCommand(ctx: Context) {
 
     if (filter.dateFrom) dto.takenDateFrom = filter.dateFrom.toISOString();
     if (filter.dateTo) dto.takenDateTo = filter.dateTo.toISOString();
+
+    if (Object.keys(dto).length === 0) {
+      await ctx.reply(aiFilterEmptyMsg);
+      return;
+    }
 
     const hash = await getFilterHash(dto);
     aiFilters.set(hash, dto);


### PR DESCRIPTION
## Summary
- add `aiFilterEmptyMsg` for Telegram bot feedback
- warn user in `/ai` command when no filter was parsed
- test `/ai` command warning

## Testing
- `pnpm --filter telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_6889d41f7b60832884e32c37f1803ea0