### PR TITLE
Handle plain text with AI in Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ VITE_AZURE_OPENAI_KEY=your_key
 VITE_AZURE_OPENAI_DEPLOYMENT=gpt-4
 ```
 
+По умолчанию любое текстовое сообщение без команды обрабатывается как запрос `/ai`, поэтому достаточно просто отправить текст с описанием запроса.
+
 ### MAUI/Blazor клиент
 
 ```bash
@@ -189,6 +191,9 @@ VITE_AZURE_OPENAI_ENDPOINT=https://example.openai.azure.com
 VITE_AZURE_OPENAI_KEY=your_key
 VITE_AZURE_OPENAI_DEPLOYMENT=gpt-4
 ```
+
+Any plain text message sent to the bot is interpreted as an `/ai` request, so you
+can simply type a query without the command prefix.
 
 ### MAUI/Blazor client
 

--- a/frontend/packages/telegram-bot/src/commands/ai.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.ts
@@ -45,8 +45,8 @@ export async function sendAiPage(
   });
 }
 
-export async function aiCommand(ctx: Context) {
-  const prompt = parseAiPrompt(ctx.message?.text);
+export async function aiCommand(ctx: Context, promptOverride?: string) {
+  const prompt = promptOverride ?? parseAiPrompt(ctx.message?.text);
   if (!prompt) {
     await ctx.reply(aiCommandUsageMsg);
     return;

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -133,5 +133,11 @@ bot.callbackQuery(/^ai:(\d+):([\w-]+)$/, withRegistered(async (ctx) => {
   await sendAiPage(ctx, hash, page, true);
 }));
 
+bot.on('message:text', withRegistered(async (ctx) => {
+  const text = ctx.message?.text;
+  if (!text || text.startsWith('/')) return;
+  await aiCommand(ctx, text);
+}));
+
 bot.start();
 initSubscriptionScheduler(bot);

--- a/frontend/packages/telegram-bot/test/aiCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/aiCommand.test.ts
@@ -85,4 +85,26 @@ describe('aiCommand', () => {
     expect(aiFilters.size).toBe(0);
     expect(ctx.reply).toHaveBeenCalledWith(aiFilterEmptyMsg);
   });
+
+  it('accepts prompt override', async () => {
+    const ctx = { reply: vi.fn(), message: { text: 'test' } } as any;
+    const parseSpy = vi
+      .spyOn(openai, 'parseQueryWithOpenAI')
+      .mockResolvedValue({
+        persons: [],
+        tags: [],
+        dateFrom: null,
+        dateTo: null,
+      });
+    vi.spyOn(utils, 'getFilterHash').mockResolvedValue('hash');
+    vi.spyOn(photosApi.PhotosService, 'postApiPhotosSearch').mockResolvedValue({
+      count: 0,
+      photos: [],
+    } as any);
+    aiFilters.clear();
+
+    await aiCommand(ctx, 'cats');
+
+    expect(parseSpy).toHaveBeenCalledWith('cats');
+  });
 });


### PR DESCRIPTION
## Summary
- trigger `aiCommand` when users send regular text messages
- allow `aiCommand` to take a prompt override
- document the new behaviour in README
- test `aiCommand` prompt override

## Testing
- `pnpm -r test` *(fails: FilterPage.test.tsx and PhotoDetailsPage.test.tsx timed out)*

------
https://chatgpt.com/codex/tasks/task_e_688a0812cfcc832895a14d1fac636d67