### PR TITLE
Add /help command for Telegram bot

### DIFF
--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -14,6 +14,16 @@ export const apiErrorMsg = 'API error:';
 
 // Telegram bot messages
 export const welcomeBotMsg = 'Добро пожаловать. Запущен и работает!';
+export const helpBotMsg = `Доступные команды:
+/thisday [страница] \u2013 показать фото этого дня
+/search <caption> \u2013 поиск по подписи
+/ai <prompt> \u2013 поиск с помощью ИИ
+/photo <id> \u2013 показать фото по идентификатору
+/profile \u2013 информация о профиле
+/subscribe HH:MM \u2013 ежедневная рассылка /thisday
+/tags [prefix] \u2013 список тегов
+/persons [prefix] \u2013 список персон
+\nЛюбое сообщение без команды обрабатывается как запрос /ai.`;
 export const captionMissingMsg = 'Без подписи.';
 export const unknownMessageReplyMsg = 'Получил другое сообщение!';
 export const photoCommandUsageMsg = '❗ Используй: /photo <id>';

--- a/frontend/packages/telegram-bot/src/commands/help.ts
+++ b/frontend/packages/telegram-bot/src/commands/help.ts
@@ -1,0 +1,7 @@
+import { Context } from 'grammy';
+import { helpBotMsg } from '@photobank/shared/constants';
+
+export async function helpCommand(ctx: Context) {
+  await ctx.reply(helpBotMsg);
+}
+

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -23,6 +23,7 @@ import { sendThisDayPage, thisDayCommand } from "./commands/thisday";
 import { captionCache } from "./photo";
 import { sendSearchPage, searchCommand } from "./commands/search";
 import { aiCommand, sendAiPage } from "./commands/ai";
+import { helpCommand } from "./commands/help";
 import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
 import { tagsCommand, sendTagsPage } from "./commands/tags";
 import { personsCommand, sendPersonsPage } from "./commands/persons";
@@ -63,6 +64,7 @@ bot.command(
   "start",
   (ctx) => ctx.reply(welcomeBotMsg),
 );
+bot.command("help", helpCommand);
 
 bot.command("thisday", withRegistered(thisDayCommand));
 bot.command("search", withRegistered(searchCommand));

--- a/frontend/packages/telegram-bot/test/helpCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/helpCommand.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+import { helpCommand } from '../src/commands/help';
+import { helpBotMsg } from '@photobank/shared/constants';
+
+describe('helpCommand', () => {
+  it('replies with help message', async () => {
+    const ctx = { reply: vi.fn() } as any;
+    await helpCommand(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith(helpBotMsg);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `helpBotMsg` string constant describing available commands
- implement `/help` telegram command
- test help command

## Testing
- `pnpm --filter telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_688a3085f4f88328aebe1bfdfe212ad0