### PR TITLE
feat(bot): add storages command

### DIFF
--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -22,6 +22,7 @@ export const helpBotMsg = `Доступные команды:
 /profile \u2013 информация о профиле
 /subscribe HH:MM \u2013 ежедневная рассылка /thisday
 /tags [prefix] \u2013 список тегов
+/storages [prefix] \u2013 список хранилищ и путей
 /persons [prefix] \u2013 список персон
 \nЛюбое сообщение без команды обрабатывается как запрос /ai.`;
 export const captionMissingMsg = 'Без подписи.';

--- a/frontend/packages/shared/test/dictionaries.test.ts
+++ b/frontend/packages/shared/test/dictionaries.test.ts
@@ -8,9 +8,13 @@ describe('dictionaries', () => {
   it('getPersonName returns loaded name', async () => {
     const getAllPersons = vi.fn().mockResolvedValue([{ id: 1, name: 'John' }]);
     const getAllTags = vi.fn().mockResolvedValue([]);
+    const getAllStorages = vi.fn().mockResolvedValue([]);
+    const getAllPaths = vi.fn().mockResolvedValue([]);
     vi.doMock('../src/generated', () => ({
       PersonsService: { getApiPersons: getAllPersons },
       TagsService: { getApiTags: getAllTags },
+      StoragesService: { getApiStorages: getAllStorages },
+      PathsService: { getApiPaths: getAllPaths },
     }));
     const dict = await import('../src/dictionaries');
     await dict.loadDictionaries();
@@ -42,13 +46,36 @@ describe('dictionaries', () => {
       { id: 10, name: 'portrait' },
       { id: 11, name: 'sea' },
     ]);
+    const getAllStorages = vi.fn().mockResolvedValue([]);
+    const getAllPaths = vi.fn().mockResolvedValue([]);
     vi.doMock('../src/generated', () => ({
       PersonsService: { getApiPersons: getAllPersons },
       TagsService: { getApiTags: getAllTags },
+      StoragesService: { getApiStorages: getAllStorages },
+      PathsService: { getApiPaths: getAllPaths },
     }));
     const dict = await import('../src/dictionaries');
     await dict.loadDictionaries();
     expect(dict.findBestPersonId('Alic')).toBe(1);
     expect(dict.findBestTagId('ocean')).toBeUndefined();
+  });
+
+  it('getAllStoragesWithPaths returns loaded data', async () => {
+    const getAllStorages = vi.fn().mockResolvedValue([{ id: 1, name: 'S1' }]);
+    const getAllPaths = vi.fn().mockResolvedValue([
+      { storageId: 1, path: '/a' },
+      { storageId: 1, path: '/b' },
+    ]);
+    vi.doMock('../src/generated', () => ({
+      PersonsService: { getApiPersons: vi.fn().mockResolvedValue([]) },
+      TagsService: { getApiTags: vi.fn().mockResolvedValue([]) },
+      StoragesService: { getApiStorages: getAllStorages },
+      PathsService: { getApiPaths: getAllPaths },
+    }));
+    const dict = await import('../src/dictionaries');
+    await dict.loadDictionaries();
+    expect(dict.getAllStoragesWithPaths()).toEqual([
+      { id: 1, name: 'S1', paths: ['/a', '/b'] },
+    ]);
   });
 });

--- a/frontend/packages/telegram-bot/src/commands/storages.ts
+++ b/frontend/packages/telegram-bot/src/commands/storages.ts
@@ -1,0 +1,28 @@
+import { Context } from "grammy";
+import { getAllStoragesWithPaths } from '@photobank/shared/dictionaries';
+import { parsePrefix, sendNamedItemsPage } from "./helpers";
+
+export async function sendStoragesPage(
+  ctx: Context,
+  prefix: string,
+  page: number,
+  edit = false,
+) {
+  await sendNamedItemsPage({
+    ctx,
+    command: "storages",
+    fetchAll: async () =>
+      getAllStoragesWithPaths().map((s) => ({
+        name: `${s.name}\n${s.paths.map((p) => `  ${p}`).join("\n")}`,
+      })),
+    prefix,
+    page,
+    edit,
+    errorMsg: "🚫 Не удалось получить список хранилищ.",
+  });
+}
+
+export async function storagesCommand(ctx: Context) {
+  const prefix = parsePrefix(ctx.message?.text);
+  await sendStoragesPage(ctx, prefix, 1);
+}

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -27,7 +27,8 @@ import { helpCommand } from "./commands/help";
 import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
 import { tagsCommand, sendTagsPage } from "./commands/tags";
 import { personsCommand, sendPersonsPage } from "./commands/persons";
-import { tagsCallbackPattern, personsCallbackPattern } from "./patterns";
+import { storagesCommand, sendStoragesPage } from "./commands/storages";
+import { tagsCallbackPattern, personsCallbackPattern, storagesCallbackPattern } from "./patterns";
 import { registerPhotoRoutes } from "./commands/photoRouter";
 import { profileCommand } from "./commands/profile";
 import { withRegistered } from './registration';
@@ -76,6 +77,7 @@ bot.command("subscribe", withRegistered(subscribeCommand));
 
 bot.command("tags", withRegistered(tagsCommand));
 bot.command("persons", withRegistered(personsCommand));
+bot.command("storages", withRegistered(storagesCommand));
 
 bot.callbackQuery(/^thisday:(\d+)$/, withRegistered(async (ctx) => {
   if (!ctx.match) {
@@ -113,6 +115,16 @@ bot.callbackQuery(personsCallbackPattern, withRegistered(async (ctx) => {
   const prefix = decodeURIComponent(ctx.match[2]);
   await ctx.answerCallbackQuery();
   await sendPersonsPage(ctx, prefix, page, true);
+}));
+
+bot.callbackQuery(storagesCallbackPattern, withRegistered(async (ctx) => {
+  if (!ctx.match) {
+    throw new Error("Callback query match is undefined.");
+  }
+  const page = parseInt(ctx.match[1], 10);
+  const prefix = decodeURIComponent(ctx.match[2]);
+  await ctx.answerCallbackQuery();
+  await sendStoragesPage(ctx, prefix, page, true);
 }));
 
 bot.callbackQuery(/^search:(\d+):(.+)$/, withRegistered(async (ctx) => {

--- a/frontend/packages/telegram-bot/src/patterns.ts
+++ b/frontend/packages/telegram-bot/src/patterns.ts
@@ -1,2 +1,3 @@
 export const tagsCallbackPattern = /^tags:(\d+):(.*)$/;
 export const personsCallbackPattern = /^persons:(\d+):(.*)$/;
+export const storagesCallbackPattern = /^storages:(\d+):(.*)$/;

--- a/frontend/packages/telegram-bot/test/personsTags.test.ts
+++ b/frontend/packages/telegram-bot/test/personsTags.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { sendTagsPage } from '../src/commands/tags';
 import { sendPersonsPage } from '../src/commands/persons';
-import { tagsCallbackPattern, personsCallbackPattern } from '../src/patterns';
+import { sendStoragesPage } from '../src/commands/storages';
+import { tagsCallbackPattern, personsCallbackPattern, storagesCallbackPattern } from '../src/patterns';
 import * as dict from '@photobank/shared/dictionaries';
 
 describe('sendTagsPage', () => {
@@ -43,6 +44,24 @@ describe('sendPersonsPage', () => {
   });
 });
 
+describe('sendStoragesPage', () => {
+  it('shows paths and paginates', async () => {
+    const storages = Array.from({ length: 11 }, (_, i) => ({
+      id: i + 1,
+      name: `st${String(i).padStart(2, '0')}`,
+      paths: [`p${i}`],
+    }));
+    vi.spyOn(dict, 'getAllStoragesWithPaths').mockReturnValue(storages as any);
+    const ctx = { reply: vi.fn() } as any;
+    await sendStoragesPage(ctx, 'st', 2);
+    expect(ctx.reply).toHaveBeenCalled();
+    const text = ctx.reply.mock.calls[0][0];
+    expect(text).toContain('st10');
+    expect(text).toContain('p10');
+    expect(text).toContain('Страница 2 из 2');
+  });
+});
+
 describe('callback regex', () => {
   it('matches empty prefix for tags', () => {
     const match = 'tags:2:'.match(tagsCallbackPattern);
@@ -53,6 +72,12 @@ describe('callback regex', () => {
   it('matches empty prefix for persons', () => {
     const match = 'persons:3:'.match(personsCallbackPattern);
     expect(match?.[1]).toBe('3');
+    expect(match?.[2]).toBe('');
+  });
+
+  it('matches empty prefix for storages', () => {
+    const match = 'storages:1:'.match(storagesCallbackPattern);
+    expect(match?.[1]).toBe('1');
     expect(match?.[2]).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- add `/storages` command that lists all storages with their paths
- include storages and paths in shared dictionaries
- mention `/storages` in bot help and register command with callback

## Testing
- `pnpm --filter @photobank/shared test`
- `pnpm --filter @photobank/telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_688dc8d7ea348328b3e6ab398924ae7e