### PR TITLE
Run frontend tests sequentially

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "bot": "pnpm --filter telegram-bot start",
     "lint": "pnpm -r lint",
     "format": "pnpm -r format",
-    "test": "pnpm -r test"
+    "test": "pnpm -r --workspace-concurrency=1 test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- Run monorepo tests sequentially to prevent Vitest from failing during concurrent runs

## Testing
- `cd frontend && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688df138d4208328997f6fc4ec977271