### PR TITLE
Limit paths returned in /storages command to avoid message overflow

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/storages.ts
+++ b/frontend/packages/telegram-bot/src/commands/storages.ts
@@ -2,6 +2,8 @@ import { Context } from "grammy";
 import { getAllStoragesWithPaths } from '@photobank/shared/dictionaries';
 import { parsePrefix, sendNamedItemsPage } from "./helpers";
 
+const MAX_PATHS_PER_STORAGE = 20;
+
 export async function sendStoragesPage(
   ctx: Context,
   prefix: string,
@@ -12,9 +14,13 @@ export async function sendStoragesPage(
     ctx,
     command: "storages",
     fetchAll: async () =>
-      getAllStoragesWithPaths().map((s) => ({
-        name: `${s.name}\n${s.paths.map((p) => `  ${p}`).join("\n")}`,
-      })),
+      getAllStoragesWithPaths().map((s) => {
+        const paths = s.paths.slice(0, MAX_PATHS_PER_STORAGE);
+        const rest = s.paths.length > MAX_PATHS_PER_STORAGE ? ["  ..."] : [];
+        return {
+          name: `${s.name}\n${paths.map((p) => `  ${p}`).concat(rest).join("\n")}`,
+        };
+      }),
     prefix,
     page,
     edit,

--- a/frontend/packages/telegram-bot/test/personsTags.test.ts
+++ b/frontend/packages/telegram-bot/test/personsTags.test.ts
@@ -60,6 +60,24 @@ describe('sendStoragesPage', () => {
     expect(text).toContain('p10');
     expect(text).toContain('Страница 2 из 2');
   });
+
+  it('limits number of paths per storage', async () => {
+    const storages = [
+      {
+        id: 1,
+        name: 'st00',
+        paths: Array.from({ length: 25 }, (_, i) => `p${i}`),
+      },
+    ];
+    vi.spyOn(dict, 'getAllStoragesWithPaths').mockReturnValue(storages as any);
+    const ctx = { reply: vi.fn() } as any;
+    await sendStoragesPage(ctx, '', 1);
+    expect(ctx.reply).toHaveBeenCalled();
+    const text = ctx.reply.mock.calls[0][0];
+    expect(text).toContain('p19');
+    expect(text).not.toContain('p20');
+    expect(text).toContain('...');
+  });
 });
 
 describe('callback regex', () => {


### PR DESCRIPTION
## Summary
- truncate storages command output to at most 20 paths per storage to keep Telegram messages within limits
- add regression test ensuring extra paths are clipped and ellipsis shown

## Testing
- `dotnet test PhotoBank.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `pnpm test` *(fails: PhotoDetailsPage.test.tsx timed out)*

------
https://chatgpt.com/codex/tasks/task_e_688df22d681c83289289e19d9f7801d9