### PR TITLE
Skip Raspberry Pi face enricher tests

### DIFF
--- a/backend/PhotoBank.UnitTests/Enrichers/FaceEnricherAwsTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichers/FaceEnricherAwsTests.cs
@@ -12,6 +12,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Enrichers;
 using PhotoBank.Services.Models;
+using PhotoBank.UnitTests;
 using Person = PhotoBank.DbContext.Models.Person;
 
 namespace PhotoBank.UnitTests.Enrichers
@@ -94,7 +95,7 @@ namespace PhotoBank.UnitTests.Enrichers
             photo.FaceIdentifyStatus.Should().Be(FaceIdentifyStatus.Detected);
         }
 
-        [Test]
+        [RaspberrySkipFact]
         public async Task EnrichAsync_ShouldAddFacesToPhoto_WhenFacesDetected()
         {
             // Arrange
@@ -117,7 +118,7 @@ namespace PhotoBank.UnitTests.Enrichers
             photo.Faces.Should().HaveCount(1);
         }
 
-        [Test]
+        [RaspberrySkipFact]
         public async Task EnrichAsync_ShouldIdentifyFaces_WhenFacesDetected()
         {
             // Arrange

--- a/backend/PhotoBank.UnitTests/RaspberrySkipFactAttribute.cs
+++ b/backend/PhotoBank.UnitTests/RaspberrySkipFactAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace PhotoBank.UnitTests;
+
+/// <summary>
+/// NUnit test attribute that skips execution when running on Raspberry Pi (ARM) architecture.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public class RaspberrySkipFactAttribute : TestAttribute, IApplyToTest
+{
+    public new void ApplyToTest(Test test)
+    {
+        if (RuntimeInformation.OSArchitecture == Architecture.Arm ||
+            RuntimeInformation.OSArchitecture == Architecture.Arm64)
+        {
+            test.RunState = RunState.Ignored;
+            test.Properties.Set(PropertyNames.SkipReason, "Skipped on Raspberry Pi");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RaspberrySkipFact` NUnit attribute to skip tests on Raspberry Pi
- annotate face enricher tests with the new attribute

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln --no-restore --configuration Release`
- `dotnet test PhotoBank.Backend.sln --no-build --configuration Release --filter "FullyQualifiedName~PhotoBank.UnitTests"` *(fails: NoEncodeDelegateForThisImageFormat `XC`)*

------
https://chatgpt.com/codex/tasks/task_e_688dfdeb6c888328bb3d2273851a2168