### PR TITLE
Restrict person access by group

### DIFF
--- a/backend/PhotoBank.Repositories/RowAuthPoliciesContainer.cs
+++ b/backend/PhotoBank.Repositories/RowAuthPoliciesContainer.cs
@@ -63,7 +63,7 @@ namespace PhotoBank.Repositories
             {
                 var groupIds = user.Claims.Where(c => c.Type == "AllowPersonGroup").Select(c => int.Parse(c.Value)).ToList();
                 rowAuthPoliciesContainer.Register<Person>(p =>
-                    p.PersonGroups.Select(pg => pg.Id).Any(x => groupIds.Contains(x)));
+                    p.PersonGroups.Any(pg => groupIds.Contains(pg.Id)));
             }
 
             return rowAuthPoliciesContainer;

--- a/backend/PhotoBank.UnitTests/RowAuthPoliciesContainerTests.cs
+++ b/backend/PhotoBank.UnitTests/RowAuthPoliciesContainerTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class RowAuthPoliciesContainerTests
+{
+    [Test]
+    public void GetAllPersons_RespectsAllowPersonGroupClaims()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<PhotoBankDbContext>(o => o.UseInMemoryDatabase("persons"));
+        services.AddTransient(typeof(IRepository<>), typeof(Repository<>));
+        services.AddHttpContextAccessor();
+
+        var provider = services.BuildServiceProvider();
+
+        using (var scope = provider.CreateScope())
+        {
+            var context = scope.ServiceProvider.GetRequiredService<PhotoBankDbContext>();
+
+            var group1 = new PersonGroup { Id = 1, Name = "Group1" };
+            var group2 = new PersonGroup { Id = 2, Name = "Group2" };
+
+            var allowed = new Person
+            {
+                Id = 1,
+                Name = "Alice",
+                PersonGroups = new List<PersonGroup> { group2 }
+            };
+
+            var denied = new Person
+            {
+                Id = 2,
+                Name = "Bob",
+                PersonGroups = new List<PersonGroup> { group1 }
+            };
+
+            context.PersonGroups.AddRange(group1, group2);
+            context.Persons.AddRange(allowed, denied);
+            context.SaveChanges();
+        }
+
+        var httpContextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("AllowPersonGroup", "2")
+            }))
+        };
+
+        var repository = new Repository<Person>(provider, httpContextAccessor);
+
+        var persons = repository.GetAll().ToList();
+
+        Assert.That(persons.Select(p => p.Id), Is.EquivalentTo(new[] { 1 }));
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure person queries only return allowed groups
- add regression test for AllowPersonGroup filtering

## Testing
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: NuGet.Config is not valid XML)*

------
https://chatgpt.com/codex/tasks/task_e_688e0c0897308328a55e13ec51e39d96