### PR TITLE
feat: auto apply EF migrations

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -7,6 +7,7 @@ using PhotoBank.Services;
 using PhotoBank.Api.Middleware;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.Extensions.DependencyInjection;
 using System.Text;
 using Serilog.Events;
 using Serilog;
@@ -124,6 +125,12 @@ namespace PhotoBank.Api
             });
 
             var app = builder.Build();
+
+            using (var scope = app.Services.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<PhotoBankDbContext>();
+                dbContext.Database.Migrate();
+            }
 
             // Configure the HTTP request pipeline.
 //            if (app.Environment.IsDevelopment())

--- a/backend/PhotoBank.Console/Program.cs
+++ b/backend/PhotoBank.Console/Program.cs
@@ -25,6 +25,13 @@ namespace PhotoBank.Console
 
             var services = ConfigureServices();
             var serviceProvider = services.BuildServiceProvider();
+
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<PhotoBankDbContext>();
+                dbContext.Database.Migrate();
+            }
+
             var app = serviceProvider.GetService<App>();
             app?.Run().Wait();
             DisposeServices(serviceProvider);

--- a/backend/PhotoBank.DbContext/DbContext/DbInitializer.cs
+++ b/backend/PhotoBank.DbContext/DbContext/DbInitializer.cs
@@ -1,10 +1,12 @@
-﻿namespace PhotoBank.DbContext.DbContext
+using Microsoft.EntityFrameworkCore;
+
+namespace PhotoBank.DbContext.DbContext
 {
     public static class DbInitializer
     {
         public static void Initialize(PhotoBankDbContext context)
         {
-            context.Database.EnsureCreated();
+            context.Database.Migrate();
         }
     }
 }

--- a/backend/Photobank.ServerBlazorApp/Program.cs
+++ b/backend/Photobank.ServerBlazorApp/Program.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using PhotoBank.ServerBlazorApp.Components;
 using PhotoBank.Services;
 using Radzen;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace PhotoBank.ServerBlazorApp
 {
@@ -94,6 +95,12 @@ namespace PhotoBank.ServerBlazorApp
             });
 
             WebApplication app = builder.Build();
+
+            using (var scope = app.Services.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<PhotoBankDbContext>();
+                dbContext.Database.Migrate();
+            }
 
             // Configure the HTTP request pipeline.
             if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- migrate database at startup in API, Console, and Blazor Server apps
- switch DbInitializer to use `Database.Migrate()`

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: NoEncodeDelegateForThisImageFormat `XC` in ImageMagick)*


------
https://chatgpt.com/codex/tasks/task_e_688f3577eb748328a737473764515642