### PR TITLE
Restrict photos by allowed person groups

### DIFF
--- a/backend/PhotoBank.Repositories/RowAuthPoliciesContainer.cs
+++ b/backend/PhotoBank.Repositories/RowAuthPoliciesContainer.cs
@@ -61,9 +61,17 @@ namespace PhotoBank.Repositories
 
             if (user.HasClaim(c => c.Type == "AllowPersonGroup"))
             {
-                var groupIds = user.Claims.Where(c => c.Type == "AllowPersonGroup").Select(c => int.Parse(c.Value)).ToList();
+                var groupIds = user.Claims
+                    .Where(c => c.Type == "AllowPersonGroup")
+                    .Select(c => int.Parse(c.Value))
+                    .ToList();
+
                 rowAuthPoliciesContainer.Register<Person>(p =>
                     p.PersonGroups.Any(pg => groupIds.Contains(pg.Id)));
+
+                rowAuthPoliciesContainer.Register<Photo>(p =>
+                    !p.Faces.Any(f => f.PersonId == null ||
+                                      !f.Person.PersonGroups.Any(pg => groupIds.Contains(pg.Id))));
             }
 
             return rowAuthPoliciesContainer;

--- a/backend/PhotoBank.UnitTests/RowAuthPoliciesContainerTests.cs
+++ b/backend/PhotoBank.UnitTests/RowAuthPoliciesContainerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -64,6 +65,96 @@ public class RowAuthPoliciesContainerTests
         var persons = repository.GetAll().ToList();
 
         Assert.That(persons.Select(p => p.Id), Is.EquivalentTo(new[] { 1 }));
+    }
+
+    private static ServiceProvider BuildProviderWithPhotos()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<PhotoBankDbContext>(o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        services.AddTransient(typeof(IRepository<>), typeof(Repository<>));
+        services.AddHttpContextAccessor();
+
+        var provider = services.BuildServiceProvider();
+
+        var context = provider.GetRequiredService<PhotoBankDbContext>();
+
+        var group1 = new PersonGroup { Id = 1, Name = "Group1" };
+        var group2 = new PersonGroup { Id = 2, Name = "Group2" };
+
+        var allowed = new Person { Id = 1, Name = "Alice" };
+        var denied = new Person { Id = 2, Name = "Bob" };
+
+        allowed.PersonGroups = new List<PersonGroup> { group2 };
+        denied.PersonGroups = new List<PersonGroup> { group1 };
+        group2.Persons = new List<Person> { allowed };
+        group1.Persons = new List<Person> { denied };
+
+        var storage = new Storage { Id = 1, Name = "s" };
+
+        var photoAllowed = new Photo { Id = 1, Name = "Allowed", StorageId = storage.Id, Faces = new List<Face>() };
+        var photoDenied = new Photo { Id = 2, Name = "Denied", StorageId = storage.Id, Faces = new List<Face>() };
+        var photoNoPersons = new Photo { Id = 3, Name = "None", StorageId = storage.Id, Faces = new List<Face>() };
+
+        var faceAllowed = new Face { Id = 1, Photo = photoAllowed, PhotoId = photoAllowed.Id, Person = allowed, PersonId = allowed.Id };
+        var faceDenied = new Face { Id = 2, Photo = photoDenied, PhotoId = photoDenied.Id, Person = denied, PersonId = denied.Id };
+
+        photoAllowed.Faces.Add(faceAllowed);
+        photoDenied.Faces.Add(faceDenied);
+
+        context.PersonGroups.AddRange(group1, group2);
+        context.Persons.AddRange(allowed, denied);
+        context.Storages.Add(storage);
+        context.Photos.AddRange(photoAllowed, photoDenied, photoNoPersons);
+        context.Faces.AddRange(faceAllowed, faceDenied);
+        context.SaveChanges();
+
+        return provider;
+    }
+
+    [Test]
+    public void GetAllPhotos_RespectsAllowPersonGroupClaims()
+    {
+        var provider = BuildProviderWithPhotos();
+
+        var httpContextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
+        var context = provider.GetRequiredService<PhotoBankDbContext>();
+        context.Persons.Include(p => p.PersonGroups).Load();
+        httpContextAccessor.HttpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("AllowPersonGroup", "2")
+            }))
+        };
+
+        var repository = new Repository<Photo>(provider, httpContextAccessor);
+
+        var photos = repository.GetAll().ToList();
+
+        Assert.That(photos.Select(p => p.Id), Is.EquivalentTo(new[] { 1, 3 }));
+    }
+
+    [Test]
+    public void GetAllPhotos_NoGroupsAllowed_ReturnsOnlyPhotosWithoutPersons()
+    {
+        var provider = BuildProviderWithPhotos();
+
+        var httpContextAccessor = provider.GetRequiredService<IHttpContextAccessor>();
+        var context = provider.GetRequiredService<PhotoBankDbContext>();
+        context.Persons.Include(p => p.PersonGroups).Load();
+        httpContextAccessor.HttpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("AllowPersonGroup", "-1")
+            }))
+        };
+
+        var repository = new Repository<Photo>(provider, httpContextAccessor);
+
+        var photos = repository.GetAll().ToList();
+
+        Assert.That(photos.Select(p => p.Id), Is.EquivalentTo(new[] { 3 }));
     }
 }
 


### PR DESCRIPTION
## Summary
- enforce person group claims when querying photos
- add unit tests covering allowed and disallowed person groups

## Testing
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --filter RowAuthPoliciesContainerTests`

------
https://chatgpt.com/codex/tasks/task_e_688f8c8821648328b3d1cd6bdc58e528