### PR TITLE
feat(bot): add upload command for media files

### DIFF
--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -38,6 +38,9 @@ export const todaysPhotosEmptyMsg = '📭 Сегодняшних фото пок
 export const searchPhotosEmptyMsg = '📭 По вашему запросу фото не найдены.';
 export const notRegisteredMsg =
   '⚠️ Ваш телеграм не зарегистрирован. Обратитесь к администратору.';
+export const uploadSuccessMsg = '✅ Файлы загружены.';
+export const uploadFailedMsg = '🚫 Не удалось загрузить файлы.';
+export const uploadStorageId = 1;
 export const unknownYearLabel = 'Неизвестный год';
 export const unknownPersonLabel = 'Неизвестный';
 export const prevPageText = '◀ Назад';

--- a/frontend/packages/shared/src/generated/services/PhotosService.ts
+++ b/frontend/packages/shared/src/generated/services/PhotosService.ts
@@ -29,6 +29,25 @@ export class PhotosService {
         });
     }
     /**
+     * @param formData
+     * @returns any OK
+     * @throws ApiError
+     */
+    public static postApiPhotosUpload(
+        formData?: {
+            files: Array<Blob>;
+            storageId: number;
+            path: string;
+        },
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/photos/upload',
+            formData: formData,
+            mediaType: 'multipart/form-data',
+        });
+    }
+    /**
      * @param id
      * @param hash
      * @param threshold

--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -1,0 +1,63 @@
+import { Context } from 'grammy';
+import axios from 'axios';
+import { PhotosService } from '@photobank/shared/generated';
+import {
+  uploadFailedMsg,
+  uploadSuccessMsg,
+  uploadStorageId,
+} from '@photobank/shared/constants';
+import { BOT_TOKEN } from '../config';
+
+async function fetchFileBuffer(ctx: Context, fileId: string, fileName: string) {
+  const file = await ctx.api.getFile(fileId);
+  if (!file.file_path) throw new Error('file path missing');
+  const url = `https://api.telegram.org/file/bot${BOT_TOKEN}/${file.file_path}`;
+  const res = await axios.get<ArrayBuffer>(url, { responseType: 'arraybuffer' });
+  return { buffer: Buffer.from(res.data), name: fileName };
+}
+
+export async function uploadCommand(ctx: Context) {
+  try {
+    const files: Array<Promise<{ buffer: Buffer; name: string }>> = [];
+
+    if (ctx.message?.photo?.length) {
+      const photo = ctx.message.photo[ctx.message.photo.length - 1];
+      files.push(fetchFileBuffer(ctx, photo.file_id, `${photo.file_unique_id}.jpg`));
+    }
+
+    if (ctx.message?.document) {
+      const doc = ctx.message.document;
+      files.push(
+        fetchFileBuffer(
+          ctx,
+          doc.file_id,
+          doc.file_name ?? doc.file_unique_id ?? 'file',
+        ),
+      );
+    }
+
+    if (!files.length) {
+      await ctx.reply(uploadFailedMsg);
+      return;
+    }
+
+    const buffers = await Promise.all(files);
+    const uploadFiles = buffers.map(
+      ({ buffer, name }) => new File([buffer], name),
+    );
+
+    const username = ctx.from?.username ?? String(ctx.from?.id ?? '');
+    await PhotosService.postApiPhotosUpload({
+      files: uploadFiles,
+      storageId: uploadStorageId,
+      path: username,
+    });
+
+    await ctx.reply(uploadSuccessMsg);
+  } catch (err) {
+    await ctx.reply(uploadFailedMsg);
+  }
+}
+
+export const upload = uploadCommand;
+

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -31,6 +31,7 @@ import { storagesCommand, sendStoragesPage } from "./commands/storages";
 import { tagsCallbackPattern, personsCallbackPattern, storagesCallbackPattern } from "./patterns";
 import { registerPhotoRoutes } from "./commands/photoRouter";
 import { profileCommand } from "./commands/profile";
+import { uploadCommand } from "./commands/upload";
 import { withRegistered } from './registration';
 
 const bot = new Bot(BOT_TOKEN);
@@ -75,6 +76,7 @@ bot.command("ai", withRegistered(aiCommand));
 bot.command("profile", profileCommand);
 
 bot.command("subscribe", withRegistered(subscribeCommand));
+bot.command("upload", withRegistered(uploadCommand));
 
 bot.command("tags", withRegistered(tagsCommand));
 bot.command("persons", withRegistered(personsCommand));
@@ -153,6 +155,9 @@ bot.on('message:text', withRegistered(async (ctx) => {
   if (!text || text.startsWith('/')) return;
   await aiCommand(ctx, text);
 }));
+
+bot.on('message:photo', withRegistered(uploadCommand));
+bot.on('message:document', withRegistered(uploadCommand));
 
 bot.start();
 initSubscriptionScheduler(bot);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -269,6 +269,33 @@ paths:
             text/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  /api/photos/upload:
+    post:
+      tags:
+        - Photos
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                storageId:
+                  type: integer
+                  format: int32
+                path:
+                  type: string
+              required:
+                - files
+                - storageId
+                - path
+      responses:
+        '200':
+          description: OK
   /api/photos/duplicates:
     get:
       tags:


### PR DESCRIPTION
## Summary
- add constants for upload status and storage ID
- add upload command to send media to backend using generated PhotosService
- trigger upload on photo or document messages
- document photo upload endpoint in OpenAPI and regenerate client

## Testing
- `pnpm --filter @photobank/shared test`
- `pnpm --filter telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_688fb5e049d8832890f35012409a3477