### PR TITLE
fix: use node-compatible file for bot uploads

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -14,6 +14,7 @@
     "@grammyjs/conversations": "^2.1.0",
     "@photobank/shared": "workspace:*",
     "axios": "^1.11.0",
+    "fetch-blob": "^4.0.0",
     "dotenv": "^17.2.1",
     "grammy": "^1.37.0"
   },

--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -1,5 +1,6 @@
 import { Context } from 'grammy';
 import axios from 'axios';
+import File from 'fetch-blob/file.js';
 import { PhotosService } from '@photobank/shared/generated';
 import {
   uploadFailedMsg,

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -316,6 +316,9 @@ importers:
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
+      fetch-blob:
+        specifier: ^4.0.0
+        version: 4.0.0
       grammy:
         specifier: ^1.37.0
         version: 1.37.0
@@ -3479,6 +3482,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@4.0.0:
+    resolution: {integrity: sha512-nPmnhRmpNMjYWnp9EBMGs6z5lq9RXed5W1vuZcECrsDVQInM8AMQSooVb3X183Aole60adzjWbH9qlRFWzDDTA==}
+    engines: {node: '>=16.7'}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
@@ -4495,6 +4502,11 @@ packages:
 
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -9594,6 +9606,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-blob@4.0.0:
+    dependencies:
+      node-domexception: 1.0.0
+
   fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
@@ -10821,6 +10837,8 @@ snapshots:
   nested-error-stacks@2.0.1: {}
 
   node-abort-controller@3.1.1: {}
+
+  node-domexception@1.0.0: {}
 
   node-fetch@2.7.0:
     dependencies:


### PR DESCRIPTION
## Summary
- fix telegram bot upload by using fetch-blob File for Node compatibility

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68907795b3d48328b4780ccb0e9e26fe