### PR TITLE
fix: correct face box position for rotated images

### DIFF
--- a/frontend/packages/frontend/src/lib/faceBox.ts
+++ b/frontend/packages/frontend/src/lib/faceBox.ts
@@ -1,0 +1,39 @@
+import type { FaceBoxDto } from '@photobank/shared/generated';
+
+/**
+ * Transforms face box coordinates according to EXIF orientation.
+ * Width and height parameters correspond to the original (unrotated) image dimensions.
+ */
+export function transformFaceBox(
+  box: FaceBoxDto,
+  orientation: number | undefined,
+  width: number,
+  height: number
+): FaceBoxDto {
+  switch (orientation) {
+    case 6: // Rotate 90°
+      return {
+        left: box.top,
+        top: width - box.left - box.width,
+        width: box.height,
+        height: box.width,
+      };
+    case 8: // Rotate 270°
+      return {
+        left: height - box.top - box.height,
+        top: box.left,
+        width: box.height,
+        height: box.width,
+      };
+    case 3: // Rotate 180°
+      return {
+        left: width - box.left - box.width,
+        top: height - box.top - box.height,
+        width: box.width,
+        height: box.height,
+      };
+    default:
+      return box;
+  }
+}
+

--- a/frontend/packages/frontend/test/faceBox.test.ts
+++ b/frontend/packages/frontend/test/faceBox.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import type { FaceBoxDto } from '@photobank/shared/generated';
+import { transformFaceBox } from '../src/lib/faceBox';
+
+describe('transformFaceBox', () => {
+  const box: FaceBoxDto = { left: 10, top: 20, width: 30, height: 40 };
+
+  it('returns same box for orientation 1', () => {
+    expect(transformFaceBox(box, 1, 100, 200)).toEqual(box);
+  });
+
+  it('rotates box for orientation 6', () => {
+    const result = transformFaceBox(box, 6, 100, 200);
+    expect(result).toEqual({ left: 20, top: 100 - 10 - 30, width: 40, height: 30 });
+  });
+
+  it('rotates box for orientation 8', () => {
+    const result = transformFaceBox(box, 8, 100, 200);
+    expect(result).toEqual({ left: 200 - 20 - 40, top: 10, width: 40, height: 30 });
+  });
+});
+


### PR DESCRIPTION
## Summary
- handle portrait rotations when displaying face overlays
- adjust face box coordinates based on EXIF orientation
- add tests for face box orientation handling

## Testing
- `pnpm lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore" ...)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689079edbeac8328a785a629bee5728b