### PR TITLE
fix shared package lint issues

### DIFF
--- a/frontend/packages/shared/src/cache/filterResultsCache.ts
+++ b/frontend/packages/shared/src/cache/filterResultsCache.ts
@@ -1,5 +1,6 @@
 import Dexie, { type Table } from 'dexie';
 import { LRUCache } from 'lru-cache';
+
 import { isBrowser } from '../utils/isBrowser';
 import type { PhotoItemDto } from '../generated';
 
@@ -34,11 +35,16 @@ export async function cacheFilterResult(
   hash: string,
   result: { count: number; photos: PhotoItemDto[] }
 ): Promise<void> {
-  const cached: CachedFilterResult = { hash, count: result.count, photos: result.photos, added: Date.now() };
+  const cached: CachedFilterResult = {
+    hash,
+    count: result.count,
+    photos: result.photos,
+    added: Date.now(),
+  };
   if (isBrowser()) {
-    await db!.filterResults.put(cached);
+    await db?.filterResults.put(cached);
   } else {
-    memoryCache!.set(hash, cached);
+    memoryCache?.set(hash, cached);
   }
 }
 
@@ -46,7 +52,8 @@ export async function getCachedFilterResult(
   hash: string
 ): Promise<CachedFilterResult | undefined> {
   if (isBrowser()) {
-    return db!.filterResults.get(hash);
+    if (!db) return Promise.resolve(undefined);
+    return db.filterResults.get(hash);
   }
-  return Promise.resolve(memoryCache!.get(hash));
+  return Promise.resolve(memoryCache?.get(hash));
 }

--- a/frontend/packages/shared/src/cache/photosCache.ts
+++ b/frontend/packages/shared/src/cache/photosCache.ts
@@ -1,5 +1,6 @@
 import Dexie, { type Table } from 'dexie';
 import { LRUCache } from 'lru-cache';
+
 import { isBrowser } from '../utils/isBrowser';
 import type { PhotoDto } from '../generated';
 
@@ -30,15 +31,16 @@ if (isBrowser()) {
 export async function cachePhoto(photo: PhotoDto): Promise<void> {
   const cached = { ...photo, added: Date.now() };
   if (isBrowser()) {
-    await db!.photos.put(cached);
+    await db?.photos.put(cached);
   } else {
-    photoCache!.set(photo.id, cached);
+    photoCache?.set(photo.id, cached);
   }
 }
 
 export async function getCachedPhoto(id: number): Promise<CachedPhoto | undefined> {
   if (isBrowser()) {
-    return db!.photos.get(id);
+    if (!db) return Promise.resolve(undefined);
+    return db.photos.get(id);
   }
-  return Promise.resolve(photoCache!.get(id));
+  return Promise.resolve(photoCache?.get(id));
 }

--- a/frontend/packages/shared/src/hooks/useIsAdmin.ts
+++ b/frontend/packages/shared/src/hooks/useIsAdmin.ts
@@ -1,10 +1,15 @@
 import { useEffect, useState } from 'react';
+
 import { checkIsAdmin } from '../utils/admin';
 
 export const useIsAdmin = (): boolean | null => {
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   useEffect(() => {
-    checkIsAdmin().then(setIsAdmin).catch(() => setIsAdmin(false));
+    checkIsAdmin()
+      .then(setIsAdmin)
+      .catch(() => {
+        setIsAdmin(false);
+      });
   }, []);
   return isAdmin;
 };

--- a/frontend/packages/shared/src/utils/geocode.ts
+++ b/frontend/packages/shared/src/utils/geocode.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+
 import type { GeoPointDto } from '../generated';
 
 /**
@@ -10,18 +11,21 @@ export async function getPlaceByGeoPoint(point: GeoPointDto): Promise<string> {
   const lat = point.latitude ?? 0;
   const lon = point.longitude ?? 0;
   try {
-    const res = await axios.get('https://nominatim.openstreetmap.org/reverse', {
-      params: {
-        format: 'json',
-        lat,
-        lon,
-      },
-      headers: {
-        'User-Agent': 'photobank',
-      },
-    });
+    const res = await axios.get<{ display_name?: string }>(
+      'https://nominatim.openstreetmap.org/reverse',
+      {
+        params: {
+          format: 'json',
+          lat,
+          lon,
+        },
+        headers: {
+          'User-Agent': 'photobank',
+        },
+      }
+    );
 
-    const name = res.data?.display_name as string | undefined;
+    const name = res.data.display_name;
     return name ?? `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
   } catch {
     return `${lat.toFixed(4)}, ${lon.toFixed(4)}`;

--- a/frontend/packages/shared/src/utils/getFilterHash.ts
+++ b/frontend/packages/shared/src/utils/getFilterHash.ts
@@ -1,26 +1,27 @@
-import type {FilterDto} from '../generated';
 import objectHash from 'object-hash';
+
+import type { FilterDto } from '../generated';
 
 /**
  * Creates a stable hash for a filter. Works in both Node.js and browser.
  * Uses the `object-hash` package for consistent results.
  */
-export async function getFilterHash(filter: FilterDto): Promise<string> {
-    const now = new Date();
+export function getFilterHash(filter: FilterDto): string {
+  const now = new Date();
 
-    // Normalize and sort filter keys
-    const normalized: Record<string, unknown> = {};
-    for (const key of Object.keys(filter).sort()) {
-        const value = filter[key as keyof FilterDto];
-        if (value === undefined) continue;
+  // Normalize and sort filter keys
+  const normalized: Record<string, unknown> = {};
+  for (const key of Object.keys(filter).sort()) {
+    const value = filter[key as keyof FilterDto];
+    if (value === undefined) continue;
 
-        if (key === 'thisDay' && value) {
-            normalized.day = now.getDate();
-            normalized.month = now.getMonth() + 1;
-        } else {
-            normalized[key] = value;
-        }
+    if (key === 'thisDay' && value) {
+      normalized.day = now.getDate();
+      normalized.month = now.getMonth() + 1;
+    } else {
+      normalized[key] = value;
     }
+  }
 
-    return objectHash(normalized);
+  return objectHash(normalized);
 }

--- a/frontend/packages/shared/src/utils/getOrientation.ts
+++ b/frontend/packages/shared/src/utils/getOrientation.ts
@@ -10,5 +10,5 @@ export function getOrientation(orientation?: number): string {
     8: 'Rotate 270°',
   };
   if (orientation === undefined) return 'unknown';
-  return map[orientation] ?? `unknown (${orientation})`;
+  return map[orientation] ?? `unknown (${String(orientation)})`;
 }

--- a/frontend/packages/shared/test/filterResultsCache.test.ts
+++ b/frontend/packages/shared/test/filterResultsCache.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+type GlobalWithWindow = typeof globalThis & { window?: unknown };
+const globalWithWindow = globalThis as GlobalWithWindow;
+
 describe('filterResultsCache', () => {
   beforeEach(() => {
     vi.resetModules();
     // ensure non-browser environment
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (global as any).window;
+    delete globalWithWindow.window;
   });
 
   it('stores and retrieves photos by hash', async () => {

--- a/frontend/packages/shared/test/getFilterHash.test.ts
+++ b/frontend/packages/shared/test/getFilterHash.test.ts
@@ -1,26 +1,27 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
 import { getFilterHash } from '../src';
 import type { FilterDto } from '../src/generated';
 
 describe('getFilterHash', () => {
-  it('returns stable hash for identical filters', async () => {
+  it('returns stable hash for identical filters', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-05-05T12:00:00Z'));
     const filter1: FilterDto = { caption: 'a', thisDay: true };
     const filter2: FilterDto = { thisDay: true, caption: 'a' };
-    const hash1 = await getFilterHash(filter1);
-    const hash2 = await getFilterHash(filter2);
+    const hash1 = getFilterHash(filter1);
+    const hash2 = getFilterHash(filter2);
     expect(hash1).toBe(hash2);
     vi.useRealTimers();
   });
 
-  it('changes when day changes for thisDay filter', async () => {
+  it('changes when day changes for thisDay filter', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-05-05T12:00:00Z'));
     const filter: FilterDto = { thisDay: true };
-    const hash1 = await getFilterHash(filter);
+    const hash1 = getFilterHash(filter);
     vi.setSystemTime(new Date('2024-05-06T12:00:00Z'));
-    const hash2 = await getFilterHash(filter);
+    const hash2 = getFilterHash(filter);
     vi.useRealTimers();
     expect(hash1).not.toBe(hash2);
   });

--- a/frontend/packages/shared/test/getOrientation.test.ts
+++ b/frontend/packages/shared/test/getOrientation.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+
 import { getOrientation } from '../src/utils/getOrientation';
 
 describe('getOrientation', () => {

--- a/frontend/packages/shared/test/index.test.ts
+++ b/frontend/packages/shared/test/index.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { formatDate, getGenderText } from '../src';
 import { format, parseISO } from 'date-fns';
+import { describe, expect, it } from 'vitest';
+
+import { formatDate, getGenderText } from '../src';
 
 // FormatDate tests
 


### PR DESCRIPTION
## Summary
- replace non-null assertions in caches with safe optional access
- improve utilities and tests to satisfy eslint rules
- clean up hook implementation to avoid confusing void usage

## Testing
- `pnpm --filter @photobank/shared lint`
- `pnpm --filter @photobank/shared test`


------
https://chatgpt.com/codex/tasks/task_e_68908d1048d48328840aaba97303e11b