### PR TITLE
refactor: split photo list page

### DIFF
--- a/frontend/packages/frontend/src/components/MetadataBadgeList.test.tsx
+++ b/frontend/packages/frontend/src/components/MetadataBadgeList.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect } from 'vitest';
+import { User } from 'lucide-react';
+import MetadataBadgeList from './MetadataBadgeList';
+
+describe('MetadataBadgeList', () => {
+  it('renders limited items and extra count', () => {
+    const map = { 1: 'Alice', 2: 'Bob', 3: 'Carol' };
+    render(
+      <MetadataBadgeList
+        icon={User}
+        items={[1, 2, 3]}
+        map={map}
+        maxVisible={2}
+        variant="outline"
+      />
+    );
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+});
+

--- a/frontend/packages/frontend/src/components/MetadataBadgeList.tsx
+++ b/frontend/packages/frontend/src/components/MetadataBadgeList.tsx
@@ -1,0 +1,39 @@
+import type { LucideIcon } from 'lucide-react';
+import type { ComponentProps } from 'react';
+import { Badge } from '@/components/ui/badge';
+
+export type MetadataBadgeListProps = {
+  icon: LucideIcon;
+  items: number[];
+  map: Record<number, string>;
+  maxVisible: number;
+  variant?: ComponentProps<typeof Badge>['variant'];
+};
+
+const MetadataBadgeList = ({
+  icon: Icon,
+  items,
+  map,
+  maxVisible,
+  variant = 'outline',
+}: MetadataBadgeListProps) => {
+  if (!items || items.length === 0) return null;
+  return (
+    <div className="flex items-center gap-1 flex-wrap">
+      <Icon className="w-3 h-3 text-muted-foreground" />
+      {items.slice(0, maxVisible).map((id, index) => (
+        <Badge key={index} variant={variant} className="text-xs">
+          {map[id] ?? id}
+        </Badge>
+      ))}
+      {items.length > maxVisible && (
+        <Badge variant={variant} className="text-xs">
+          +{items.length - maxVisible}
+        </Badge>
+      )}
+    </div>
+  );
+};
+
+export default MetadataBadgeList;
+

--- a/frontend/packages/frontend/src/components/PhotoFlags.tsx
+++ b/frontend/packages/frontend/src/components/PhotoFlags.tsx
@@ -1,0 +1,30 @@
+import { Badge } from '@/components/ui/badge';
+
+export type PhotoFlagsProps = {
+  isBW?: boolean;
+  isAdultContent?: boolean;
+  isRacyContent?: boolean;
+};
+
+const PhotoFlags = ({ isBW, isAdultContent, isRacyContent }: PhotoFlagsProps) => (
+  <div className="flex flex-wrap gap-1">
+    {isBW && (
+      <Badge variant="secondary" className="text-xs">
+        B&W
+      </Badge>
+    )}
+    {isAdultContent && (
+      <Badge variant="destructive" className="text-xs">
+        Adult
+      </Badge>
+    )}
+    {isRacyContent && (
+      <Badge variant="destructive" className="text-xs">
+        Racy
+      </Badge>
+    )}
+  </div>
+);
+
+export default PhotoFlags;
+

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
@@ -1,0 +1,100 @@
+import { Calendar, User, Tag } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import PhotoPreview from './PhotoPreview';
+import PhotoFlags from '@/components/PhotoFlags';
+import MetadataBadgeList from '@/components/MetadataBadgeList';
+import { formatDate, firstNWords } from '@photobank/shared';
+import type { PhotoItemDto } from '@photobank/shared/generated';
+import {
+  MAX_VISIBLE_PERSONS_LG,
+  MAX_VISIBLE_TAGS_LG,
+} from '@photobank/shared/constants';
+
+export type PhotoListItemDesktopProps = {
+  photo: PhotoItemDto;
+  personsMap: Record<number, string>;
+  tagsMap: Record<number, string>;
+  onClick: () => void;
+};
+
+const PhotoListItemDesktop = ({
+  photo,
+  personsMap,
+  tagsMap,
+  onClick,
+}: PhotoListItemDesktopProps) => (
+  <Card
+    key={photo.id}
+    className="p-4 hover:shadow-md transition-shadow cursor-pointer"
+    onClick={onClick}
+  >
+    <div className="grid grid-cols-12 gap-4 items-center">
+      <div className="col-span-1">
+        <Badge variant="outline" className="font-mono text-xs">
+          {photo.id}
+        </Badge>
+      </div>
+
+      <div className="col-span-2">
+        <PhotoPreview
+          thumbnail={photo.thumbnail}
+          alt={photo.name}
+          className="w-16 h-16"
+        />
+      </div>
+
+      <div className="col-span-2">
+        <div className="font-medium truncate">{photo.name}</div>
+        {photo.captions && photo.captions.length > 0 && (
+          <div className="text-xs text-muted-foreground truncate">
+            {firstNWords(photo.captions[0], 5)}
+          </div>
+        )}
+      </div>
+
+      <div className="col-span-1">
+        <div className="flex items-center gap-1 text-sm">
+          <Calendar className="w-3 h-3" />
+          {formatDate(photo.takenDate ?? undefined)}
+        </div>
+      </div>
+
+      <div className="col-span-2">
+        <div className="text-xs text-muted-foreground truncate">
+          {photo.storageName} {photo.relativePath}
+        </div>
+      </div>
+
+      <div className="col-span-1">
+        <PhotoFlags
+          isBW={photo.isBW}
+          isAdultContent={photo.isAdultContent}
+          isRacyContent={photo.isRacyContent}
+        />
+      </div>
+
+      <div className="col-span-3">
+        <div className="space-y-2">
+          <MetadataBadgeList
+            icon={User}
+            items={photo.persons?.map((p) => p.personId) ?? []}
+            map={personsMap}
+            maxVisible={MAX_VISIBLE_PERSONS_LG}
+            variant="outline"
+          />
+          <MetadataBadgeList
+            icon={Tag}
+            items={photo.tags?.map((t) => t.tagId) ?? []}
+            map={tagsMap}
+            maxVisible={MAX_VISIBLE_TAGS_LG}
+            variant="secondary"
+          />
+        </div>
+      </div>
+    </div>
+  </Card>
+);
+
+export default PhotoListItemDesktop;
+

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
@@ -1,0 +1,89 @@
+import { Calendar, User, Tag } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import PhotoPreview from './PhotoPreview';
+import PhotoFlags from '@/components/PhotoFlags';
+import MetadataBadgeList from '@/components/MetadataBadgeList';
+import { formatDate, firstNWords } from '@photobank/shared';
+import type { PhotoItemDto } from '@photobank/shared/generated';
+import {
+  MAX_VISIBLE_PERSONS_SM,
+  MAX_VISIBLE_TAGS_SM,
+} from '@photobank/shared/constants';
+
+export type PhotoListItemMobileProps = {
+  photo: PhotoItemDto;
+  personsMap: Record<number, string>;
+  tagsMap: Record<number, string>;
+  onClick: () => void;
+};
+
+const PhotoListItemMobile = ({
+  photo,
+  personsMap,
+  tagsMap,
+  onClick,
+}: PhotoListItemMobileProps) => (
+  <Card
+    key={photo.id}
+    className="p-4 hover:shadow-md transition-shadow cursor-pointer"
+    onClick={onClick}
+  >
+    <div className="space-y-3">
+      <div className="flex items-start gap-3">
+        <PhotoPreview
+          thumbnail={photo.thumbnail}
+          alt={photo.name}
+          className="w-20 h-20 flex-shrink-0"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="font-medium truncate">{photo.name}</div>
+          {photo.captions && photo.captions.length > 0 && (
+            <div className="text-xs text-muted-foreground truncate">
+              {firstNWords(photo.captions[0], 5)}
+            </div>
+          )}
+          <Badge variant="outline" className="font-mono text-xs mt-1">
+            {photo.id}
+          </Badge>
+        </div>
+      </div>
+
+      <div className="text-xs text-muted-foreground">
+        {photo.storageName} {photo.relativePath}
+      </div>
+
+      <div className="flex items-center gap-4 text-sm">
+        <div className="flex items-center gap-1">
+          <Calendar className="w-3 h-3" />
+          {formatDate(photo.takenDate ?? undefined)}
+        </div>
+      </div>
+
+      <PhotoFlags
+        isBW={photo.isBW}
+        isAdultContent={photo.isAdultContent}
+        isRacyContent={photo.isRacyContent}
+      />
+
+      <MetadataBadgeList
+        icon={User}
+        items={photo.persons?.map((p) => p.personId) ?? []}
+        map={personsMap}
+        maxVisible={MAX_VISIBLE_PERSONS_SM}
+        variant="outline"
+      />
+
+      <MetadataBadgeList
+        icon={Tag}
+        items={photo.tags?.map((t) => t.tagId) ?? []}
+        map={tagsMap}
+        maxVisible={MAX_VISIBLE_TAGS_SM}
+        variant="secondary"
+      />
+    </div>
+  </Card>
+);
+
+export default PhotoListItemMobile;
+

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -1,23 +1,15 @@
-import { Calendar, User, Tag } from 'lucide-react';
 import { useSelector } from 'react-redux';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { formatDate, firstNWords } from '@photobank/shared';
 import type { PhotoItemDto } from '@photobank/shared/generated';
 
 import { useSearchPhotosMutation } from '@/entities/photo/api.ts';
-import { Badge } from '@/components/ui/badge';
-import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import type { RootState } from '@/app/store.ts';
 import { useAppDispatch } from '@/app/hook.ts';
 import { setLastResult } from '@/features/photo/model/photoSlice.ts';
 import {
-  MAX_VISIBLE_PERSONS_LG,
-  MAX_VISIBLE_TAGS_LG,
-  MAX_VISIBLE_PERSONS_SM,
-  MAX_VISIBLE_TAGS_SM,
   photoGalleryTitle,
   filterButtonText,
   loadMoreButton,
@@ -30,8 +22,8 @@ import {
   colDetailsLabel,
 } from '@photobank/shared/constants';
 import PhotoDetailsModal from '@/components/PhotoDetailsModal';
-
-import PhotoPreview from './PhotoPreview';
+import PhotoListItemDesktop from './PhotoListItemDesktop';
+import PhotoListItemMobile from './PhotoListItemMobile';
 
 const PhotoListPage = () => {
   const dispatch = useAppDispatch();
@@ -118,120 +110,13 @@ const PhotoListPage = () => {
 
             <div className="space-y-3">
               {photos.map((photo) => (
-                <Card
+                <PhotoListItemDesktop
                   key={photo.id}
-                  className="p-4 hover:shadow-md transition-shadow cursor-pointer"
-                  onClick={() => {
-                    setDetailsId(photo.id);
-                  }}
-                >
-                  <div className="grid grid-cols-12 gap-4 items-center">
-                    <div className="col-span-1">
-                      <Badge variant="outline" className="font-mono text-xs">
-                        {photo.id}
-                      </Badge>
-                    </div>
-
-                    <div className="col-span-2">
-                      <PhotoPreview
-                        thumbnail={photo.thumbnail}
-                        alt={photo.name}
-                        className="w-16 h-16"
-                      />
-                    </div>
-
-                    <div className="col-span-2">
-                      <div className="font-medium truncate">{photo.name}</div>
-                      {photo.captions && photo.captions.length > 0 && (
-                        <div className="text-xs text-muted-foreground truncate">
-                          {firstNWords(photo.captions[0], 5)}
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="col-span-1">
-                      <div className="flex items-center gap-1 text-sm">
-                        <Calendar className="w-3 h-3" />
-                        {formatDate(photo.takenDate ?? undefined)}
-                      </div>
-                    </div>
-
-                    <div className="col-span-2">
-                      <div className="text-xs text-muted-foreground truncate">
-                        {photo.storageName} {photo.relativePath}
-                      </div>
-                    </div>
-
-                    <div className="col-span-1">
-                      <div className="flex flex-col gap-1">
-                        {photo.isBW && (
-                          <Badge variant="secondary" className="text-xs">
-                            B&W
-                          </Badge>
-                        )}
-                        {photo.isAdultContent && (
-                          <Badge variant="destructive" className="text-xs">
-                            Adult
-                          </Badge>
-                        )}
-                        {photo.isRacyContent && (
-                          <Badge variant="destructive" className="text-xs">
-                            Racy
-                          </Badge>
-                        )}
-                      </div>
-                    </div>
-
-                    <div className="col-span-3">
-                      <div className="space-y-2">
-                        {photo.persons && photo.persons.length > 0 && (
-                          <div className="flex items-center gap-1 flex-wrap">
-                            <User className="w-3 h-3 text-muted-foreground" />
-                            {photo.persons
-                              .slice(0, MAX_VISIBLE_PERSONS_LG)
-                              .map((person, index) => (
-                                <Badge
-                                  key={index}
-                                  variant="outline"
-                                  className="text-xs"
-                                >
-                                  {personsMap[person.personId] ??
-                                    person.personId}
-                                </Badge>
-                              ))}
-                            {photo.persons.length > MAX_VISIBLE_PERSONS_LG && (
-                              <Badge variant="outline" className="text-xs">
-                                +{photo.persons.length - MAX_VISIBLE_PERSONS_LG}
-                              </Badge>
-                            )}
-                          </div>
-                        )}
-
-                        {photo.tags && photo.tags.length > 0 && (
-                          <div className="flex items-center gap-1 flex-wrap">
-                            <Tag className="w-3 h-3 text-muted-foreground" />
-                            {photo.tags
-                              .slice(0, MAX_VISIBLE_TAGS_LG)
-                              .map((tag, index) => (
-                                <Badge
-                                  key={index}
-                                  variant="secondary"
-                                  className="text-xs"
-                                >
-                                  {tagsMap[tag.tagId] ?? tag.tagId}
-                                </Badge>
-                              ))}
-                            {photo.tags.length > MAX_VISIBLE_TAGS_LG && (
-                              <Badge variant="secondary" className="text-xs">
-                                +{photo.tags.length - MAX_VISIBLE_TAGS_LG}
-                              </Badge>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </Card>
+                  photo={photo}
+                  personsMap={personsMap}
+                  tagsMap={tagsMap}
+                  onClick={() => setDetailsId(photo.id)}
+                />
               ))}
             </div>
           </div>
@@ -240,110 +125,13 @@ const PhotoListPage = () => {
           <div className="lg:hidden">
             <div className="grid gap-4 sm:grid-cols-2">
               {photos.map((photo) => (
-                <Card
+                <PhotoListItemMobile
                   key={photo.id}
-                  className="p-4 hover:shadow-md transition-shadow cursor-pointer"
-                  onClick={() => {
-                    setDetailsId(photo.id);
-                  }}
-                >
-                  <div className="space-y-3">
-                    <div className="flex items-start gap-3">
-                      <PhotoPreview
-                        thumbnail={photo.thumbnail}
-                        alt={photo.name}
-                        className="w-20 h-20 flex-shrink-0"
-                      />
-                      <div className="flex-1 min-w-0">
-                        <div className="font-medium truncate">{photo.name}</div>
-                        {photo.captions && photo.captions.length > 0 && (
-                          <div className="text-xs text-muted-foreground truncate">
-                            {firstNWords(photo.captions[0], 5)}
-                          </div>
-                        )}
-                        <Badge
-                          variant="outline"
-                          className="font-mono text-xs mt-1"
-                        >
-                          {photo.id}
-                        </Badge>
-                      </div>
-                    </div>
-
-                    <div className="text-xs text-muted-foreground">
-                      {photo.storageName} {photo.relativePath}
-                    </div>
-
-                    <div className="flex items-center gap-4 text-sm">
-                      <div className="flex items-center gap-1">
-                        <Calendar className="w-3 h-3" />
-                        {formatDate(photo.takenDate ?? undefined)}
-                      </div>
-                    </div>
-
-                    <div className="flex flex-wrap gap-1">
-                      {photo.isBW && (
-                        <Badge variant="secondary" className="text-xs">
-                          B&W
-                        </Badge>
-                      )}
-                      {photo.isAdultContent && (
-                        <Badge variant="destructive" className="text-xs">
-                          Adult
-                        </Badge>
-                      )}
-                      {photo.isRacyContent && (
-                        <Badge variant="destructive" className="text-xs">
-                          Racy
-                        </Badge>
-                      )}
-                    </div>
-
-                    {photo.persons && photo.persons.length > 0 && (
-                      <div className="flex items-center gap-1 flex-wrap">
-                        <User className="w-3 h-3 text-muted-foreground" />
-                        {photo.persons
-                          .slice(0, MAX_VISIBLE_PERSONS_SM)
-                          .map((person, index) => (
-                            <Badge
-                              key={index}
-                              variant="outline"
-                              className="text-xs"
-                            >
-                              {personsMap[person.personId] ?? person.personId}
-                            </Badge>
-                          ))}
-                        {photo.persons.length > MAX_VISIBLE_PERSONS_SM && (
-                          <Badge variant="outline" className="text-xs">
-                            +{photo.persons.length - MAX_VISIBLE_PERSONS_SM}
-                          </Badge>
-                        )}
-                      </div>
-                    )}
-
-                    {photo.tags && photo.tags.length > 0 && (
-                      <div className="flex items-center gap-1 flex-wrap">
-                        <Tag className="w-3 h-3 text-muted-foreground" />
-                        {photo.tags
-                          .slice(0, MAX_VISIBLE_TAGS_SM)
-                          .map((tag, index) => (
-                            <Badge
-                              key={index}
-                              variant="secondary"
-                              className="text-xs"
-                            >
-                              {tagsMap[tag.tagId] ?? tag.tagId}
-                            </Badge>
-                          ))}
-                        {photo.tags.length > MAX_VISIBLE_TAGS_SM && (
-                          <Badge variant="secondary" className="text-xs">
-                            +{photo.tags.length - MAX_VISIBLE_TAGS_SM}
-                          </Badge>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </Card>
+                  photo={photo}
+                  personsMap={personsMap}
+                  tagsMap={tagsMap}
+                  onClick={() => setDetailsId(photo.id)}
+                />
               ))}
             </div>
           </div>
@@ -367,3 +155,4 @@ const PhotoListPage = () => {
 };
 
 export default PhotoListPage;
+


### PR DESCRIPTION
## Summary
- extract generic `MetadataBadgeList` for icon-tag sections
- add `PhotoFlags` component
- split desktop and mobile photo list items

## Testing
- `pnpm --filter frontend test`
- `pnpm --filter frontend lint` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.)*

------
https://chatgpt.com/codex/tasks/task_e_68924fab6c5c8328bf772223f54c5ced