### PR TITLE
feat: use file adapter for telegram uploads

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -1,6 +1,4 @@
 import { Context } from 'grammy';
-import axios from 'axios';
-import { File } from 'fetch-blob/file.js';
 import { PhotosService } from '@photobank/shared/generated';
 import {
   uploadFailedMsg,
@@ -8,46 +6,17 @@ import {
   uploadStorageName,
 } from '@photobank/shared/constants';
 
-import { BOT_TOKEN } from '../config';
 import { getStorageId } from '../dictionaries';
-
-async function fetchFileBuffer(ctx: Context, fileId: string, fileName: string) {
-  const file = await ctx.api.getFile(fileId);
-  if (!file.file_path) throw new Error('file path missing');
-  const url = `https://api.telegram.org/file/bot${BOT_TOKEN}/${file.file_path}`;
-  const res = await axios.get<ArrayBuffer>(url, { responseType: 'arraybuffer' });
-  return { buffer: Buffer.from(res.data), name: fileName };
-}
+import { getUploadFiles } from '../fileAdapter';
 
 export async function uploadCommand(ctx: Context) {
   try {
-    const files: Array<Promise<{ buffer: Buffer; name: string }>> = [];
+    const uploadFiles = await getUploadFiles(ctx);
 
-    if (ctx.message?.photo?.length) {
-      const photo = ctx.message.photo[ctx.message.photo.length - 1];
-      files.push(fetchFileBuffer(ctx, photo.file_id, `${photo.file_unique_id}.jpg`));
-    }
-
-    if (ctx.message?.document) {
-      const doc = ctx.message.document;
-      files.push(
-        fetchFileBuffer(
-          ctx,
-          doc.file_id,
-          doc.file_name || doc.file_unique_id || 'file',
-        ),
-      );
-    }
-
-    if (!files.length) {
+    if (!uploadFiles.length) {
       await ctx.reply(uploadFailedMsg);
       return;
     }
-
-    const buffers = await Promise.all(files);
-    const uploadFiles = buffers.map(
-      ({ buffer, name }) => new File([buffer], name),
-    );
 
     const storageId = getStorageId(uploadStorageName);
     const username = ctx.from?.username ?? String(ctx.from?.id ?? '');

--- a/frontend/packages/telegram-bot/src/fileAdapter.ts
+++ b/frontend/packages/telegram-bot/src/fileAdapter.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+import { File } from 'fetch-blob/file.js';
+import type { Context } from 'grammy';
+import { BOT_TOKEN } from './config';
+
+async function fetchFileBuffer(ctx: Context, fileId: string, fileName: string) {
+  const file = await ctx.api.getFile(fileId);
+  if (!file.file_path) throw new Error('file path missing');
+  const url = `https://api.telegram.org/file/bot${BOT_TOKEN}/${file.file_path}`;
+  const res = await axios.get<ArrayBuffer>(url, { responseType: 'arraybuffer' });
+  return { buffer: Buffer.from(res.data), name: fileName };
+}
+
+/**
+ * Adapter to download files from Telegram messages and convert them to File objects.
+ */
+export async function getUploadFiles(ctx: Context): Promise<File[]> {
+  const files: Array<Promise<{ buffer: Buffer; name: string }>> = [];
+
+  if (ctx.message?.photo?.length) {
+    const photo = ctx.message.photo[ctx.message.photo.length - 1];
+    files.push(fetchFileBuffer(ctx, photo.file_id, `${photo.file_unique_id}.jpg`));
+  }
+
+  if (ctx.message?.document) {
+    const doc = ctx.message.document;
+    files.push(
+      fetchFileBuffer(
+        ctx,
+        doc.file_id,
+        doc.file_name || doc.file_unique_id || 'file',
+      ),
+    );
+  }
+
+  const buffers = await Promise.all(files);
+  return buffers.map(({ buffer, name }) => new File([buffer], name));
+}

--- a/frontend/packages/telegram-bot/test/uploadCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/uploadCommand.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { uploadFailedMsg, uploadSuccessMsg } from '@photobank/shared/constants';
+
+describe('uploadCommand', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.BOT_TOKEN = 'token';
+    process.env.API_EMAIL = 'e';
+    process.env.API_PASSWORD = 'p';
+  });
+
+  it('replies with failure when no files provided', async () => {
+    const adapter = await import('../src/fileAdapter');
+    const { uploadCommand } = await import('../src/commands/upload');
+    const ctx = { reply: vi.fn() } as any;
+    const adapterSpy = vi.spyOn(adapter, 'getUploadFiles').mockResolvedValue([]);
+    await uploadCommand(ctx);
+    expect(adapterSpy).toHaveBeenCalledWith(ctx);
+    expect(ctx.reply).toHaveBeenCalledWith(uploadFailedMsg);
+  });
+
+  it('uploads files and replies success', async () => {
+    const adapter = await import('../src/fileAdapter');
+    const { uploadCommand } = await import('../src/commands/upload');
+    const dictionaries = await import('../src/dictionaries');
+    const photosApi = await import('@photobank/shared/generated');
+    const ctx = { reply: vi.fn(), from: { username: 'user' } } as any;
+    const fakeFile = {} as any;
+    vi.spyOn(adapter, 'getUploadFiles').mockResolvedValue([fakeFile]);
+    vi.spyOn(dictionaries, 'getStorageId').mockReturnValue(1);
+    const uploadSpy = vi
+      .spyOn(photosApi.PhotosService, 'postApiPhotosUpload')
+      .mockResolvedValue(undefined as any);
+    await uploadCommand(ctx);
+    expect(uploadSpy).toHaveBeenCalledWith({
+      files: [fakeFile],
+      storageId: 1,
+      path: 'user',
+    });
+    expect(ctx.reply).toHaveBeenCalledWith(uploadSuccessMsg);
+  });
+});


### PR DESCRIPTION
## Summary
- add adapter to turn Telegram messages into File objects
- use adapter in `/upload` command
- cover upload flow with tests

## Testing
- `pnpm --filter telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_68922ae026c48328884888c2b924e371