### PR TITLE
feat(shared): add photos upload adapter

### DIFF
--- a/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
+++ b/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import FormData from 'form-data';
+
+import { OpenAPI } from '../generated';
+
+export async function uploadPhotosAdapter(
+  params: {
+    files: File[];
+    storageId: number;
+    path: string;
+  }
+) {
+  const { files, storageId, path } = params;
+
+  const form = new FormData();
+  for (const file of files) {
+    form.append('files', file, file.name);
+  }
+  form.append('storageId', storageId.toString());
+  form.append('path', path);
+
+  const headers: Record<string, string> = {
+    ...form.getHeaders(),
+  };
+
+  if (OpenAPI.TOKEN) {
+    headers['Authorization'] = `Bearer ${String(OpenAPI.TOKEN)}`;
+  }
+
+  return axios.post(`${OpenAPI.BASE}/api/photos/upload`, form, {
+    headers,
+  });
+}

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -40,3 +40,4 @@ export const firstNWords = (sentence: string, count: number): string => {
 export { checkIsAdmin } from './utils/admin';
 export { useIsAdmin } from './hooks/useIsAdmin';
 export { getPlaceByGeoPoint } from './utils/geocode';
+export { uploadPhotosAdapter } from './adapters/photos-upload.adapter';


### PR DESCRIPTION
## Summary
- add photo upload adapter built on axios and OpenAPI
- expose adapter from shared package

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68937b12e5d8832883c9d93a02037bb5