### PR TITLE
Fix Telegram bot upload buffer handling

### DIFF
--- a/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
+++ b/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
@@ -3,9 +3,11 @@ import FormData from 'form-data';
 
 import { OpenAPI } from '../generated';
 
+type UploadFile = { buffer: Buffer; name: string };
+
 export async function uploadPhotosAdapter(
   params: {
-    files: File[];
+    files: UploadFile[];
     storageId: number;
     path: string;
   }
@@ -13,8 +15,8 @@ export async function uploadPhotosAdapter(
   const { files, storageId, path } = params;
 
   const form = new FormData();
-  for (const file of files) {
-    form.append('files', file, file.name);
+  for (const { buffer, name } of files) {
+    form.append('files', buffer, name);
   }
   form.append('storageId', storageId.toString());
   form.append('path', path);

--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -1,6 +1,5 @@
 import { Context } from 'grammy';
 import axios from 'axios';
-import { File } from 'fetch-blob/file.js';
 import { uploadPhotosAdapter } from '@photobank/shared';
 import {
   uploadFailedMsg,
@@ -44,10 +43,7 @@ export async function uploadCommand(ctx: Context) {
       return;
     }
 
-    const buffers = await Promise.all(files);
-    const uploadFiles = buffers.map(
-      ({ buffer, name }) => new File([buffer], name),
-    );
+    const uploadFiles = await Promise.all(files);
 
     const storageId = getStorageId(uploadStorageName);
     const username = ctx.from?.username ?? String(ctx.from?.id ?? '');

--- a/frontend/packages/telegram-bot/test/uploadCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/uploadCommand.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import axios from 'axios';
+import * as shared from '@photobank/shared';
+import * as dict from '../src/dictionaries';
+
+vi.mock('../src/config', () => ({ BOT_TOKEN: 'token' }));
+
+import { uploadCommand } from '../src/commands/upload';
+import { uploadSuccessMsg } from '@photobank/shared/constants';
+
+describe('uploadCommand', () => {
+  it('uploads photo buffers via adapter', async () => {
+    const ctx: any = {
+      api: { getFile: vi.fn().mockResolvedValue({ file_path: 'photo.jpg' }) },
+      message: { photo: [{}, { file_id: '123', file_unique_id: 'uniq123' }] },
+      reply: vi.fn(),
+      from: { username: 'john' },
+    };
+
+    vi.spyOn(dict, 'getStorageId').mockReturnValue(1);
+    vi.spyOn(axios, 'get').mockResolvedValue({ data: new ArrayBuffer(0) });
+    const uploadSpy = vi
+      .spyOn(shared, 'uploadPhotosAdapter')
+      .mockResolvedValue({} as any);
+
+    await uploadCommand(ctx);
+
+    expect(uploadSpy).toHaveBeenCalledWith({
+      files: [expect.objectContaining({ name: 'uniq123.jpg' })],
+      storageId: 1,
+      path: 'john',
+    });
+    expect(ctx.reply).toHaveBeenCalledWith(uploadSuccessMsg);
+  });
+});
+


### PR DESCRIPTION
## Summary
- fix Telegram bot uploads by sending buffers instead of File objects
- update shared adapter to handle Buffer uploads
- add test covering upload command

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6895059d42ec8328b595b0d1ecc66424