### PR TITLE
fix: resolve OpenAPI token for uploads

### DIFF
--- a/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
+++ b/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
@@ -25,8 +25,14 @@ export async function uploadPhotosAdapter(
     ...form.getHeaders(),
   };
 
-  if (OpenAPI.TOKEN) {
-    headers['Authorization'] = `Bearer ${String(OpenAPI.TOKEN)}`;
+  let token: string | undefined;
+  if (typeof OpenAPI.TOKEN === 'function') {
+    token = await OpenAPI.TOKEN({} as any);
+  } else {
+    token = OpenAPI.TOKEN;
+  }
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
   }
 
   return axios.post(`${OpenAPI.BASE}/api/photos/upload`, form, {

--- a/frontend/packages/shared/test/photos-upload.adapter.test.ts
+++ b/frontend/packages/shared/test/photos-upload.adapter.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import axios from 'axios';
+import { OpenAPI } from '../src/generated';
+import { uploadPhotosAdapter } from '../src/adapters/photos-upload.adapter';
+
+describe('uploadPhotosAdapter', () => {
+  it('adds Authorization header when OpenAPI.TOKEN is resolver', async () => {
+    OpenAPI.TOKEN = async () => 'token123';
+    const post = vi.spyOn(axios, 'post').mockResolvedValue({} as any);
+
+    await uploadPhotosAdapter({
+      files: [{ buffer: Buffer.from('data'), name: 'a.txt' }],
+      storageId: 1,
+      path: 'user',
+    });
+
+    expect(post).toHaveBeenCalled();
+    const headers = post.mock.calls[0][2]?.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer token123');
+  });
+});


### PR DESCRIPTION
## Summary
- properly resolve async OpenAPI token in photo upload adapter
- add tests ensuring Authorization header uses resolved token

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68950ac8e4008328974f9c892be4e163