### PR TITLE
refactor: tighten upload token typing

### DIFF
--- a/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
+++ b/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import FormData from 'form-data';
 
 import { OpenAPI } from '../generated';
+import type { ApiRequestOptions } from '../generated/core/ApiRequestOptions';
 
 type UploadFile = { buffer: Buffer; name: string };
 
@@ -27,7 +28,11 @@ export async function uploadPhotosAdapter(
 
   let token: string | undefined;
   if (typeof OpenAPI.TOKEN === 'function') {
-    token = await OpenAPI.TOKEN({} as any);
+    const options: ApiRequestOptions = {
+      method: 'POST',
+      url: '/api/photos/upload',
+    };
+    token = await OpenAPI.TOKEN(options);
   } else {
     token = OpenAPI.TOKEN;
   }

--- a/frontend/packages/shared/test/photos-upload.adapter.test.ts
+++ b/frontend/packages/shared/test/photos-upload.adapter.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
-import axios from 'axios';
+import axios, { type AxiosResponse } from 'axios';
+
 import { OpenAPI } from '../src/generated';
 import { uploadPhotosAdapter } from '../src/adapters/photos-upload.adapter';
 
 describe('uploadPhotosAdapter', () => {
   it('adds Authorization header when OpenAPI.TOKEN is resolver', async () => {
-    OpenAPI.TOKEN = async () => 'token123';
-    const post = vi.spyOn(axios, 'post').mockResolvedValue({} as any);
+    OpenAPI.TOKEN = () => Promise.resolve('token123');
+    const post = vi
+      .spyOn(axios, 'post')
+      .mockResolvedValue({} as unknown as AxiosResponse);
 
     await uploadPhotosAdapter({
       files: [{ buffer: Buffer.from('data'), name: 'a.txt' }],


### PR DESCRIPTION
## Summary
- add ApiRequestOptions type when resolving auth token in photo upload adapter
- clean up upload adapter test imports and typings

## Testing
- `pnpm --filter shared lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68961766135c83289eb931a6aef554e3