### PR TITLE
feat: extend API logging

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PhotosController.cs
+++ b/backend/PhotoBank.Api/Controllers/PhotosController.cs
@@ -3,8 +3,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
-using System.Diagnostics.Metrics;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PhotoBank.Api.Controllers
 {
@@ -19,7 +19,9 @@ namespace PhotoBank.Api.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<QueryResult>> SearchPhotos([FromBody] FilterDto request)
         {
+            logger.LogInformation("Searching photos with filter {@Filter}", request);
             var result = await photoService.GetAllPhotosAsync(request);
+            logger.LogInformation("Found {Count} photos", result.Count);
             return Ok(result);
         }
 
@@ -28,10 +30,15 @@ namespace PhotoBank.Api.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<PhotoDto>> GetPhoto(int id)
         {
+            logger.LogInformation("Fetching photo with id {Id}", id);
             var photo = await photoService.GetPhotoAsync(id);
             if (photo == null)
+            {
+                logger.LogWarning("Photo with id {Id} not found", id);
                 return NotFound();
+            }
 
+            logger.LogInformation("Returning photo with id {Id}", id);
             return Ok(photo);
         }
 
@@ -39,7 +46,9 @@ namespace PhotoBank.Api.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         public async Task<IActionResult> Upload([FromForm] List<IFormFile> files, [FromForm] int storageId, [FromForm] string path)
         {
+            logger.LogInformation("Uploading {Count} files to storage {StorageId} at {Path}", files.Count, storageId, path);
             await photoService.UploadPhotosAsync(files, storageId, path);
+            logger.LogInformation("Uploaded {Count} files", files.Count);
             return Ok();
         }
 
@@ -47,7 +56,9 @@ namespace PhotoBank.Api.Controllers
         [ProducesResponseType(typeof(IEnumerable<PhotoItemDto>), StatusCodes.Status200OK)]
         public async Task<ActionResult<IEnumerable<PhotoItemDto>>> GetDuplicates([FromQuery] int? id, [FromQuery] string? hash, [FromQuery] int threshold = 5)
         {
+            logger.LogInformation("Searching duplicates for id {Id} hash {Hash} with threshold {Threshold}", id, hash, threshold);
             var result = await photoService.FindDuplicatesAsync(id, hash, threshold);
+            logger.LogInformation("Found {Count} duplicates", result.Count());
             return Ok(result);
         }
     }

--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -32,7 +32,9 @@ namespace PhotoBank.Api
                 .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
                 .Enrich.FromLogContext()
+                .WriteTo.Console()
                 .WriteTo.Debug()
+                .WriteTo.File("Logs/log-.txt", rollingInterval: RollingInterval.Day)
                 .CreateLogger();
 
             var builder = WebApplication.CreateBuilder(args);
@@ -132,6 +134,7 @@ namespace PhotoBank.Api
                 app.UseSwaggerUI();
             }
 
+            app.UseSerilogRequestLogging();
             app.UseCors("AllowAll");
             // Disabled HTTPS redirection to ensure CORS headers are applied
             // correctly during local development when running over HTTP.


### PR DESCRIPTION
## Summary
- log API requests via Serilog middleware
- log PhotoController operations for easier traceability
- output logs to console and rolling files

## Testing
- `dotnet test PhotoBank.Backend.sln -v minimal | tail -n 20` *(failed: connection to SQL Server could not be opened)*

------
https://chatgpt.com/codex/tasks/task_e_68962d95cd78832892efbc9fdae98e80