### PR TITLE
fix: log update type for telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -39,7 +39,8 @@ const bot = new Bot(BOT_TOKEN);
 
 bot.use(async (ctx, next) => {
   const username = ctx.from?.username ?? String(ctx.from?.id ?? '');
-  logger.info(`update from ${username}: ${ctx.updateType}`);
+  const updateType = Object.keys(ctx.update).find(k => k !== 'update_id') ?? 'unknown';
+  logger.info(`update from ${username}: ${updateType}`);
   await next();
 });
 


### PR DESCRIPTION
## Summary
- compute update type from update payload to avoid undefined logs

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689632ef633883289fe7377e23bc4049