### PR TITLE
feat: add descriptive Swagger operation IDs

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.EntityFrameworkCore;
 using PhotoBank.DbContext.DbContext;
 using PhotoBank.DbContext.Models;
@@ -117,7 +119,20 @@ namespace PhotoBank.Api
             builder.Services.AddControllers();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
+            builder.Services.AddSwaggerGen(c =>
+            {
+                c.CustomOperationIds(apiDesc =>
+                {
+                    if (apiDesc.ActionDescriptor is ControllerActionDescriptor descriptor)
+                    {
+                        var controllerName = descriptor.ControllerName;
+                        var actionName = descriptor.ActionName;
+                        return $"{controllerName}_{actionName}";
+                    }
+
+                    return null;
+                });
+            });
 
             RegisterServicesForApi.Configure(builder.Services);
             builder.Services.AddAutoMapper(cfg =>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,6 +7,7 @@ paths:
     post:
       tags:
         - Auth
+      operationId: Auth_Login
       requestBody:
         content:
           application/json:
@@ -47,6 +48,7 @@ paths:
     post:
       tags:
         - Auth
+      operationId: Auth_Register
       requestBody:
         content:
           application/json:
@@ -77,6 +79,7 @@ paths:
     get:
       tags:
         - Auth
+      operationId: Auth_GetUser
       responses:
         '200':
           description: OK
@@ -93,6 +96,7 @@ paths:
     put:
       tags:
         - Auth
+      operationId: Auth_UpdateUser
       requestBody:
         content:
           application/json:
@@ -123,6 +127,7 @@ paths:
     get:
       tags:
         - Auth
+      operationId: Auth_GetUserClaims
       responses:
         '200':
           description: OK
@@ -146,6 +151,7 @@ paths:
     get:
       tags:
         - Auth
+      operationId: Auth_GetUserRoles
       responses:
         '200':
           description: OK
@@ -169,6 +175,7 @@ paths:
     put:
       tags:
         - Faces
+      operationId: Faces_Update
       requestBody:
         content:
           application/json:
@@ -187,6 +194,7 @@ paths:
     get:
       tags:
         - Paths
+      operationId: Paths_GetAll
       responses:
         '200':
           description: OK
@@ -210,6 +218,7 @@ paths:
     get:
       tags:
         - Persons
+      operationId: Persons_GetAll
       responses:
         '200':
           description: OK
@@ -233,6 +242,7 @@ paths:
     post:
       tags:
         - Photos
+      operationId: Photos_SearchPhotos
       requestBody:
         content:
           application/json:
@@ -273,6 +283,7 @@ paths:
     get:
       tags:
         - Photos
+      operationId: Photos_GetPhoto
       parameters:
         - name: id
           in: path
@@ -309,6 +320,7 @@ paths:
     post:
       tags:
         - Photos
+      operationId: Photos_Upload
       requestBody:
         content:
           multipart/form-data:
@@ -339,6 +351,7 @@ paths:
     get:
       tags:
         - Photos
+      operationId: Photos_GetDuplicates
       parameters:
         - name: id
           in: query
@@ -378,6 +391,7 @@ paths:
     get:
       tags:
         - Storages
+      operationId: Storages_GetAll
       responses:
         '200':
           description: OK
@@ -401,6 +415,7 @@ paths:
     get:
       tags:
         - Tags
+      operationId: Tags_GetAll
       responses:
         '200':
           description: OK
@@ -424,6 +439,7 @@ paths:
     get:
       tags:
         - Users
+      operationId: Users_GetAll
       responses:
         '200':
           description: OK
@@ -447,6 +463,7 @@ paths:
     put:
       tags:
         - Users
+      operationId: Users_Update
       parameters:
         - name: id
           in: path
@@ -495,6 +512,7 @@ paths:
     put:
       tags:
         - Users
+      operationId: Users_SetClaims
       parameters:
         - name: id
           in: path


### PR DESCRIPTION
## Summary
- derive Swagger operationId values from controller and action names
- regenerate OpenAPI spec including user-friendly operationIds

## Testing
- `dotnet build backend/PhotoBank.Api/PhotoBank.Api.csproj`
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build` *(fails: build was cancelled)*
- `pnpm -r test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6899ccc6356483288908cb7832421c7a