### PR TITLE
feat: add pagination base classes

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PhotosController.cs
+++ b/backend/PhotoBank.Api/Controllers/PhotosController.cs
@@ -21,7 +21,7 @@ namespace PhotoBank.Api.Controllers
         {
             logger.LogInformation("Searching photos with filter {@Filter}", request);
             var result = await photoService.GetAllPhotosAsync(request);
-            logger.LogInformation("Found {Count} photos", result.Count);
+            logger.LogInformation("Found {Count} photos", result.TotalCount);
             return Ok(result);
         }
 

--- a/backend/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
+++ b/backend/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
@@ -74,10 +74,11 @@ public class GetAllPhotosIntegrationTests
         {
             TakenDateFrom = new DateTime(2015, 1, 1),
             TakenDateTo = new DateTime(2016, 1, 1),
+            PageSize = 10000
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(5180);
-        result.Photos.Should().HaveCount(5180);
+        result.TotalCount.Should().Be(5180);
+        result.Items.Should().HaveCount(5180);
     }
 
     [Test]
@@ -87,11 +88,11 @@ public class GetAllPhotosIntegrationTests
         {
             TakenDateFrom = new DateTime(2015, 1, 1),
             TakenDateTo = new DateTime(2016, 1, 1),
-            Top = 10
+            PageSize = 10
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(5180);
-        result.Photos.Should().HaveCount(10);
+        result.TotalCount.Should().Be(5180);
+        result.Items.Should().HaveCount(10);
     }
 
     [Test]
@@ -101,12 +102,12 @@ public class GetAllPhotosIntegrationTests
         {
             TakenDateFrom = new DateTime(2015, 1, 1),
             TakenDateTo = new DateTime(2016, 1, 1),
-            Top = 10,
-            Skip = 10
+            PageSize = 10,
+            Page = 2
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(5180);
-        result.Photos.Should().HaveCount(10);
+        result.TotalCount.Should().Be(5180);
+        result.Items.Should().HaveCount(10);
     }
 
     [Test]
@@ -119,7 +120,7 @@ public class GetAllPhotosIntegrationTests
             IsBW = true
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(60);
+        result.TotalCount.Should().Be(60);
     }
 
     [Test]
@@ -132,7 +133,7 @@ public class GetAllPhotosIntegrationTests
             IsAdultContent = true
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(20);
+        result.TotalCount.Should().Be(20);
     }
 
     [Test]
@@ -145,7 +146,7 @@ public class GetAllPhotosIntegrationTests
             IsRacyContent = true
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(71);
+        result.TotalCount.Should().Be(71);
     }
 
     [Test]
@@ -158,7 +159,7 @@ public class GetAllPhotosIntegrationTests
             Storages = new []{3, 4}
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(1385);
+        result.TotalCount.Should().Be(1385);
     }
 
     [Test]
@@ -172,7 +173,7 @@ public class GetAllPhotosIntegrationTests
             RelativePath = "Test"
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(0);
+        result.TotalCount.Should().Be(0);
     }
 
     [Test]
@@ -185,7 +186,7 @@ public class GetAllPhotosIntegrationTests
             Tags = new []{ 3504 }
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(2462);
+        result.TotalCount.Should().Be(2462);
     }
 
     [Test]
@@ -198,7 +199,7 @@ public class GetAllPhotosIntegrationTests
             Persons = new[] { 1 }
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(401);
+        result.TotalCount.Should().Be(401);
     }
 
     [Test]
@@ -211,7 +212,7 @@ public class GetAllPhotosIntegrationTests
             Tags = new[] { 3504, 3505 }
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(2420);
+        result.TotalCount.Should().Be(2420);
     }
 
     [Test]
@@ -224,7 +225,7 @@ public class GetAllPhotosIntegrationTests
             Persons = new[] { 1, 2 }
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(104);
+        result.TotalCount.Should().Be(104);
     }
 
     [Test]
@@ -237,6 +238,6 @@ public class GetAllPhotosIntegrationTests
             Caption = "sky and grass"
         };
         var result = await MeasureGetAllPhotosAsync(filterDto);
-        result.Count.Should().Be(163);
+        result.TotalCount.Should().Be(163);
     }
 }

--- a/backend/PhotoBank.MAUI.Blazor/Components/Pages/PhotoOverview.razor
+++ b/backend/PhotoBank.MAUI.Blazor/Components/Pages/PhotoOverview.razor
@@ -115,11 +115,14 @@
         if (Filter.IsNotEmpty())
         {
             Filter.OrderBy = args.OrderBy;
-            Filter.Skip = args.Skip;
-            Filter.Top = args.Top;
+            if (args.Top.HasValue)
+            {
+                Filter.PageSize = args.Top.Value;
+                Filter.Page = args.Skip / args.Top.Value + 1;
+            }
             var queryResult = await RestService.GetPhotos(Filter);
-            photos = queryResult.Photos;
-            count = queryResult.Count;
+            photos = queryResult.Items;
+            count = queryResult.TotalCount;
         }
         else
         {

--- a/backend/PhotoBank.Services/Api/PhotoService.cs
+++ b/backend/PhotoBank.Services/Api/PhotoService.cs
@@ -132,17 +132,18 @@ public class PhotoService : IPhotoService
         var count = await query.CountAsync();
 
         // Execute the photos query next
+        var skip = (filter.Page - 1) * filter.PageSize;
         var photos = await query
             .OrderByDescending(p => p.TakenDate)
-            .Skip(filter.Skip ?? 0)
-            .Take(filter.Top ?? int.MaxValue)
+            .Skip(skip)
+            .Take(filter.PageSize)
             .ProjectTo<PhotoItemDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
 
         return new QueryResult
         {
-            Count = count,
-            Photos = photos
+            TotalCount = count,
+            Items = photos
         };
     }
 

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -81,8 +81,8 @@ namespace PhotoBank.UnitTests.Services
             var result = await service.GetAllPhotosAsync(filter);
 
             // Assert
-            result.Count.Should().Be(2);
-            result.Photos.Should().HaveCount(2);
+            result.TotalCount.Should().Be(2);
+            result.Items.Should().HaveCount(2);
         }
 
         [Test]
@@ -123,8 +123,8 @@ namespace PhotoBank.UnitTests.Services
             var result = await service.GetAllPhotosAsync(filter);
 
             // Assert
-            result.Count.Should().Be(1);
-            result.Photos.Should().ContainSingle(p => p.Name == "bw");
+            result.TotalCount.Should().Be(1);
+            result.Items.Should().ContainSingle(p => p.Name == "bw");
         }
 
         [Ignore("Could not translated")]
@@ -170,8 +170,8 @@ namespace PhotoBank.UnitTests.Services
             var result = await service.GetAllPhotosAsync(filter);
 
             // Assert
-            result.Count.Should().Be(1);
-            result.Photos.Should().ContainSingle(p => p.Name == "withTag");
+            result.TotalCount.Should().Be(1);
+            result.Items.Should().ContainSingle(p => p.Name == "withTag");
         }
 
         [Ignore("Could not translated")]
@@ -236,8 +236,8 @@ namespace PhotoBank.UnitTests.Services
             var result = await service.GetAllPhotosAsync(filter);
 
             // Assert
-            result.Count.Should().Be(1);
-            result.Photos.Should().ContainSingle(p => p.Name == "all");
+            result.TotalCount.Should().Be(1);
+            result.Items.Should().ContainSingle(p => p.Name == "all");
         }
 
         [Ignore("Could not translated")]
@@ -302,8 +302,8 @@ namespace PhotoBank.UnitTests.Services
             var result = await service.GetAllPhotosAsync(filter);
 
             // Assert
-            result.Count.Should().Be(1);
-            result.Photos.Should().ContainSingle(p => p.Name == "both");
+            result.TotalCount.Should().Be(1);
+            result.Items.Should().ContainSingle(p => p.Name == "both");
         }
     }
 }

--- a/backend/PhotoBank.ViewModel.Dto/FilterDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/FilterDto.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace PhotoBank.ViewModel.Dto
 {
-    public class FilterDto
+    public class FilterDto : PageRequest
     {
         public IEnumerable<int>? Storages { get; set; }
         public bool? IsBW { get; set; }
@@ -20,8 +20,6 @@ namespace PhotoBank.ViewModel.Dto
         public IEnumerable<int>? Tags { get; set; }
 
         public string? OrderBy { get; set; }
-        public int? Skip { get; set; }
-        public int? Top { get; set; }
 
         public bool IsNotEmpty()
         {

--- a/backend/PhotoBank.ViewModel.Dto/PageRequest.cs
+++ b/backend/PhotoBank.ViewModel.Dto/PageRequest.cs
@@ -1,0 +1,8 @@
+namespace PhotoBank.ViewModel.Dto
+{
+    public class PageRequest
+    {
+        public int Page { get; set; } = 1; // Номер страницы, начиная с 1
+        public int PageSize { get; set; } = 10; // Размер страницы
+    }
+}

--- a/backend/PhotoBank.ViewModel.Dto/PageResponse.cs
+++ b/backend/PhotoBank.ViewModel.Dto/PageResponse.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace PhotoBank.ViewModel.Dto
+{
+    public class PageResponse<T>
+    {
+        public int TotalCount { get; set; }
+        public IReadOnlyCollection<T> Items { get; set; } = Array.Empty<T>();
+    }
+}

--- a/backend/PhotoBank.ViewModel.Dto/QueryResult.cs
+++ b/backend/PhotoBank.ViewModel.Dto/QueryResult.cs
@@ -1,10 +1,6 @@
-﻿using System.Collections.Generic;
-
 namespace PhotoBank.ViewModel.Dto
 {
-    public class QueryResult
+    public class QueryResult : PageResponse<PhotoItemDto>
     {
-        public int Count { get; set; }
-        public IEnumerable<PhotoItemDto>? Photos { get; set; }
     }
 }

--- a/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoOverviewBase.cs
+++ b/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoOverviewBase.cs
@@ -42,11 +42,14 @@ namespace PhotoBank.ServerBlazorApp.Components.Pages
             if (Filter.IsNotEmpty())
             {
                 Filter.OrderBy = args.OrderBy;
-                Filter.Skip = args.Skip;
-                Filter.Top = args.Top;
+                if (args.Top.HasValue)
+                {
+                    Filter.PageSize = args.Top.Value;
+                    Filter.Page = args.Skip / args.Top.Value + 1;
+                }
                 var queryResult = await PhotoService.GetAllPhotosAsync(Filter);
-                Count = queryResult.Count;
-                Photos = queryResult.Photos;
+                Count = queryResult.TotalCount;
+                Photos = queryResult.Items;
             }
             else
             {

--- a/frontend/packages/shared/src/generated/index.ts
+++ b/frontend/packages/shared/src/generated/index.ts
@@ -14,6 +14,8 @@ export type { FilterDto } from './models/FilterDto';
 export type { GeoPointDto } from './models/GeoPointDto';
 export type { LoginRequestDto } from './models/LoginRequestDto';
 export type { LoginResponseDto } from './models/LoginResponseDto';
+export type { PageRequest } from './models/PageRequest';
+export type { PageResponseOfPhotoItemDto } from './models/PageResponseOfPhotoItemDto';
 export type { PathDto } from './models/PathDto';
 export type { PersonDto } from './models/PersonDto';
 export type { PersonItemDto } from './models/PersonItemDto';

--- a/frontend/packages/shared/src/generated/models/FilterDto.ts
+++ b/frontend/packages/shared/src/generated/models/FilterDto.ts
@@ -2,7 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type FilterDto = {
+import type { PageRequest } from './PageRequest';
+export type FilterDto = (PageRequest & {
     storages?: Array<number> | null;
     isBW?: boolean | null;
     isAdultContent?: boolean | null;
@@ -16,7 +17,5 @@ export type FilterDto = {
     persons?: Array<number> | null;
     tags?: Array<number> | null;
     orderBy?: string | null;
-    skip?: number | null;
-    top?: number | null;
-};
+});
 

--- a/frontend/packages/shared/src/generated/models/PageRequest.ts
+++ b/frontend/packages/shared/src/generated/models/PageRequest.ts
@@ -2,6 +2,8 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { PageResponseOfPhotoItemDto } from './PageResponseOfPhotoItemDto';
-export type QueryResult = PageResponseOfPhotoItemDto;
+export type PageRequest = {
+    page?: number;
+    pageSize?: number;
+};
 

--- a/frontend/packages/shared/src/generated/models/PageResponseOfPhotoItemDto.ts
+++ b/frontend/packages/shared/src/generated/models/PageResponseOfPhotoItemDto.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { PhotoItemDto } from './PhotoItemDto';
+export type PageResponseOfPhotoItemDto = {
+    totalCount?: number;
+    items?: Array<PhotoItemDto> | null;
+};
+

--- a/frontend/packages/shared/src/generated/services/AuthService.ts
+++ b/frontend/packages/shared/src/generated/services/AuthService.ts
@@ -18,7 +18,7 @@ export class AuthService {
      * @returns LoginResponseDto OK
      * @throws ApiError
      */
-    public static postApiAuthLogin(
+    public static authLogin(
         requestBody?: LoginRequestDto,
     ): CancelablePromise<LoginResponseDto> {
         return __request(OpenAPI, {
@@ -36,7 +36,7 @@ export class AuthService {
      * @returns any OK
      * @throws ApiError
      */
-    public static postApiAuthRegister(
+    public static authRegister(
         requestBody?: RegisterRequestDto,
     ): CancelablePromise<any> {
         return __request(OpenAPI, {
@@ -53,7 +53,7 @@ export class AuthService {
      * @returns UserDto OK
      * @throws ApiError
      */
-    public static getApiAuthUser(): CancelablePromise<UserDto> {
+    public static authGetUser(): CancelablePromise<UserDto> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/auth/user',
@@ -64,7 +64,7 @@ export class AuthService {
      * @returns any OK
      * @throws ApiError
      */
-    public static putApiAuthUser(
+    public static authUpdateUser(
         requestBody?: UpdateUserDto,
     ): CancelablePromise<any> {
         return __request(OpenAPI, {
@@ -81,7 +81,7 @@ export class AuthService {
      * @returns ClaimDto OK
      * @throws ApiError
      */
-    public static getApiAuthClaims(): CancelablePromise<Array<ClaimDto>> {
+    public static authGetUserClaims(): CancelablePromise<Array<ClaimDto>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/auth/claims',
@@ -91,7 +91,7 @@ export class AuthService {
      * @returns RoleDto OK
      * @throws ApiError
      */
-    public static getApiAuthRoles(): CancelablePromise<Array<RoleDto>> {
+    public static authGetUserRoles(): CancelablePromise<Array<RoleDto>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/auth/roles',

--- a/frontend/packages/shared/src/generated/services/FacesService.ts
+++ b/frontend/packages/shared/src/generated/services/FacesService.ts
@@ -12,7 +12,7 @@ export class FacesService {
      * @returns any OK
      * @throws ApiError
      */
-    public static putApiFaces(
+    public static facesUpdate(
         requestBody?: UpdateFaceDto,
     ): CancelablePromise<any> {
         return __request(OpenAPI, {

--- a/frontend/packages/shared/src/generated/services/PathsService.ts
+++ b/frontend/packages/shared/src/generated/services/PathsService.ts
@@ -11,7 +11,7 @@ export class PathsService {
      * @returns PathDto OK
      * @throws ApiError
      */
-    public static getApiPaths(): CancelablePromise<Array<PathDto>> {
+    public static pathsGetAll(): CancelablePromise<Array<PathDto>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/paths',

--- a/frontend/packages/shared/src/generated/services/PersonsService.ts
+++ b/frontend/packages/shared/src/generated/services/PersonsService.ts
@@ -11,7 +11,7 @@ export class PersonsService {
      * @returns PersonDto OK
      * @throws ApiError
      */
-    public static getApiPersons(): CancelablePromise<Array<PersonDto>> {
+    public static personsGetAll(): CancelablePromise<Array<PersonDto>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/persons',

--- a/frontend/packages/shared/src/generated/services/PhotosService.ts
+++ b/frontend/packages/shared/src/generated/services/PhotosService.ts
@@ -52,7 +52,7 @@ export class PhotosService {
      * @returns any OK
      * @throws ApiError
      */
-    public static postApiPhotosUpload(
+    public static photosUpload(
         formData?: {
             files?: Array<Blob>;
             storageId?: number;
@@ -73,7 +73,7 @@ export class PhotosService {
      * @returns PhotoItemDto OK
      * @throws ApiError
      */
-    public static getApiPhotosDuplicates(
+    public static photosGetDuplicates(
         id?: number,
         hash?: string,
         threshold: number = 5,

--- a/frontend/packages/shared/src/generated/services/StoragesService.ts
+++ b/frontend/packages/shared/src/generated/services/StoragesService.ts
@@ -11,7 +11,7 @@ export class StoragesService {
      * @returns StorageDto OK
      * @throws ApiError
      */
-    public static getApiStorages(): CancelablePromise<Array<StorageDto>> {
+    public static storagesGetAll(): CancelablePromise<Array<StorageDto>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/storages',

--- a/frontend/packages/shared/src/generated/services/TagsService.ts
+++ b/frontend/packages/shared/src/generated/services/TagsService.ts
@@ -11,7 +11,7 @@ export class TagsService {
      * @returns TagDto OK
      * @throws ApiError
      */
-    public static getApiTags(): CancelablePromise<Array<TagDto>> {
+    public static tagsGetAll(): CancelablePromise<Array<TagDto>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/tags',

--- a/frontend/packages/shared/src/generated/services/UsersService.ts
+++ b/frontend/packages/shared/src/generated/services/UsersService.ts
@@ -13,7 +13,7 @@ export class UsersService {
      * @returns UserWithClaimsDto OK
      * @throws ApiError
      */
-    public static getApiAdminUsers(): CancelablePromise<Array<UserWithClaimsDto>> {
+    public static usersGetAll(): CancelablePromise<Array<UserWithClaimsDto>> {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/api/admin/users',
@@ -25,7 +25,7 @@ export class UsersService {
      * @returns any OK
      * @throws ApiError
      */
-    public static putApiAdminUsers(
+    public static usersUpdate(
         id: string,
         requestBody?: UpdateUserDto,
     ): CancelablePromise<any> {
@@ -49,7 +49,7 @@ export class UsersService {
      * @returns any OK
      * @throws ApiError
      */
-    public static putApiAdminUsersClaims(
+    public static usersSetClaims(
         id: string,
         requestBody?: Array<ClaimDto>,
     ): CancelablePromise<any> {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -242,7 +242,7 @@ paths:
     post:
       tags:
         - Photos
-      operationId: Photos_SearchPhotos
+      operationId: postApiPhotosSearch
       requestBody:
         content:
           application/json:
@@ -283,7 +283,7 @@ paths:
     get:
       tags:
         - Photos
-      operationId: Photos_GetPhoto
+      operationId: getApiPhotos
       parameters:
         - name: id
           in: path
@@ -628,71 +628,77 @@ components:
           minLength: 1
           type: string
       additionalProperties: false
-    FilterDto:
+    PageRequest:
       type: object
       properties:
-        storages:
-          type: array
-          items:
-            type: integer
-            format: int32
-          nullable: true
-        isBW:
-          type: boolean
-          nullable: true
-        isAdultContent:
-          type: boolean
-          nullable: true
-        isRacyContent:
-          type: boolean
-          nullable: true
-        relativePath:
-          type: string
-          nullable: true
-        paths:
-          type: array
-          items:
-            type: integer
-            format: int32
-          nullable: true
-        caption:
-          type: string
-          nullable: true
-        takenDateFrom:
-          type: string
-          format: date-time
-          nullable: true
-        takenDateTo:
-          type: string
-          format: date-time
-          nullable: true
-        thisDay:
-          type: boolean
-          nullable: true
-        persons:
-          type: array
-          items:
-            type: integer
-            format: int32
-          nullable: true
-        tags:
-          type: array
-          items:
-            type: integer
-            format: int32
-          nullable: true
-        orderBy:
-          type: string
-          nullable: true
-        skip:
+        page:
           type: integer
           format: int32
-          nullable: true
-        top:
+          default: 1
+        pageSize:
           type: integer
           format: int32
-          nullable: true
+          default: 10
       additionalProperties: false
+    FilterDto:
+      allOf:
+        - $ref: '#/components/schemas/PageRequest'
+        - type: object
+          properties:
+            storages:
+              type: array
+              items:
+                type: integer
+                format: int32
+              nullable: true
+            isBW:
+              type: boolean
+              nullable: true
+            isAdultContent:
+              type: boolean
+              nullable: true
+            isRacyContent:
+              type: boolean
+              nullable: true
+            relativePath:
+              type: string
+              nullable: true
+            paths:
+              type: array
+              items:
+                type: integer
+                format: int32
+              nullable: true
+            caption:
+              type: string
+              nullable: true
+            takenDateFrom:
+              type: string
+              format: date-time
+              nullable: true
+            takenDateTo:
+              type: string
+              format: date-time
+              nullable: true
+            thisDay:
+              type: boolean
+              nullable: true
+            persons:
+              type: array
+              items:
+                type: integer
+                format: int32
+              nullable: true
+            tags:
+              type: array
+              items:
+                type: integer
+                format: int32
+              nullable: true
+            orderBy:
+              type: string
+              nullable: true
+          additionalProperties: false
     GeoPointDto:
       type: object
       properties:
@@ -895,18 +901,24 @@ components:
           type: string
           nullable: true
       additionalProperties: { }
-    QueryResult:
+    PageResponseOfPhotoItemDto:
       type: object
       properties:
-        count:
+        totalCount:
           type: integer
           format: int32
-        photos:
+        items:
           type: array
           items:
             $ref: '#/components/schemas/PhotoItemDto'
           nullable: true
       additionalProperties: false
+    QueryResult:
+      allOf:
+        - $ref: '#/components/schemas/PageResponseOfPhotoItemDto'
+        - type: object
+          properties: { }
+          additionalProperties: false
     RegisterRequestDto:
       required:
         - email


### PR DESCRIPTION
## Summary
- add `PageRequest` and `PageResponse<T>` for pagination
- adapt photo search request/response and service to use page parameters
- regenerate API client and update OpenAPI schema

## Testing
- `pnpm --filter @photobank/shared test`
- `pnpm test` *(fails: postApiPhotosSearch does not exist)*
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: NoEncodeDelegateForThisImageFormat)*

------
https://chatgpt.com/codex/tasks/task_e_6899cfe41fa88328be49787bf593f736