### PR TITLE
feat: add ProblemDetails, structured logs and health checks to API

### DIFF
--- a/backend/PhotoBank.Api/PhotoBank.Api.csproj
+++ b/backend/PhotoBank.Api/PhotoBank.Api.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add Serilog compact JSON logging
- expose health check endpoints and enable RFC7807 ProblemDetails

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: MagickMissingDelegateErrorException and MSB4017 logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_6899d605cf0c8328a7d11047f71e18a9