### PR TITLE
Add database health check to API

### DIFF
--- a/backend/PhotoBank.Api/PhotoBank.Api.csproj
+++ b/backend/PhotoBank.Api/PhotoBank.Api.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -122,7 +122,8 @@ namespace PhotoBank.Api
             });
 
             builder.Services.AddProblemDetails();
-            builder.Services.AddHealthChecks();
+            builder.Services.AddHealthChecks()
+                .AddDbContextCheck<PhotoBankDbContext>("Database");
             builder.Services.AddControllers();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
## Summary
- add database connection check to health checks
- include EF Core health check package

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: NoEncodeDelegateForThisImageFormat `XC`)*

------
https://chatgpt.com/codex/tasks/task_e_6899e6034f7c8328b10a44193a569673