### PR TITLE
feat(frontend): add photobank API

### DIFF
--- a/frontend/packages/frontend/src/main.tsx
+++ b/frontend/packages/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { API_BASE_URL } from '@/config.ts';
 import { configureApi } from './lib/api';
+import { configureApiAuth } from '@photobank/shared/src/api/photobank/fetcher';
 
 import { store } from '@/app/store';
 
@@ -11,6 +12,7 @@ import App from './app/App.tsx';
 import './index.css';
 
 function start() {
+  configureApiAuth(() => localStorage.getItem('pb_token') ?? undefined);
   configureApi(API_BASE_URL);
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/frontend/packages/frontend/src/shared/api.ts
+++ b/frontend/packages/frontend/src/shared/api.ts
@@ -1,0 +1,33 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import * as Api from '@photobank/shared/src/api/photobank';
+import type { LoginRequestDto, LoginResponseDto } from '@photobank/shared/types';
+
+export const photobankApi = createApi({
+  reducerPath: 'photobankApi',
+  baseQuery: fakeBaseQuery<{ status: number; data?: unknown; problem?: unknown }>(),
+  endpoints: (build) => ({
+    login: build.mutation<LoginResponseDto, LoginRequestDto>({
+      async queryFn(body) {
+        try {
+          const data = await Api.postApiAuthLogin(body);
+          return { data };
+        } catch (e: any) {
+          return { error: { status: e.status ?? 500, problem: e.problem, data: undefined } };
+        }
+      },
+    }),
+    getPhotoById: build.query<Api.PhotoDto, string>({
+      async queryFn(id) {
+        try {
+          const data = await Api.getApiPhotosById({ id });
+          return { data };
+        } catch (e: any) {
+          return { error: { status: e.status ?? 500, problem: e.problem } };
+        }
+      },
+    }),
+    // add other endpoints similarly
+  }),
+});
+
+export const { useLoginMutation, useGetPhotoByIdQuery } = photobankApi;


### PR DESCRIPTION
## Summary
- add RTK Query wrapper for Photobank API endpoints
- configure API auth using localStorage token

## Testing
- `pnpm lint` *(fails: Cannot find package 'typescript-eslint' imported from eslint.config.mjs)*
- `pnpm test` *(fails: spawn ENOENT for `vitest`)*


------
https://chatgpt.com/codex/tasks/task_e_689a327146148328a0b125d88537f592