### PR TITLE
chore(bot): configure API auth via token

### DIFF
--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -2,6 +2,7 @@ import { Bot } from "grammy";
 import { loadDictionaries, setDictionariesUser } from "./dictionaries";
 import { AuthService } from "@photobank/shared/generated";
 import { setAuthToken } from "@photobank/shared/auth";
+import { configureApiAuth } from "@photobank/shared/src/api/photobank/fetcher";
 import { configureAzureOpenAI } from "@photobank/shared/ai/openai";
 import {
   captionMissingMsg,
@@ -60,6 +61,7 @@ bot.catch((err) => {
 
 registerPhotoRoutes(bot);
 
+configureApiAuth(() => process.env.PHOTOBANK_BOT_TOKEN); // или сервисный JWT
 configureApi(API_BASE_URL);
 
 const loginRes = await AuthService.postApiAuthLogin({


### PR DESCRIPTION
## Summary
- configure API auth in telegram bot using environment token

## Testing
- `pnpm --filter telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_689a411008548328a959dc1758baf493