### PR TITLE
feat: add Orval adapter for RTK Query

### DIFF
--- a/frontend/packages/frontend/src/shared/orvalAdapter.ts
+++ b/frontend/packages/frontend/src/shared/orvalAdapter.ts
@@ -1,0 +1,15 @@
+// Унифицируем возврат ошибки в стиле RTK Query
+export function orvalQuery<TArg, TResult>(
+  call: (arg: TArg, opt?: { signal?: AbortSignal }) => Promise<TResult>
+) {
+  return async (arg: TArg, api: { signal: AbortSignal }) => {
+    try {
+      const data = await call(arg, { signal: api.signal });
+      return { data };
+    } catch (e: any) {
+      return { error: { status: e.status ?? 500, data: e.problem ?? e.message ?? e } };
+    }
+  };
+}
+
+export const orvalMutation = orvalQuery; // сигнатура та же


### PR DESCRIPTION
## Summary
- add adapter to wrap orval API calls and normalize errors for RTK Query

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689ad26372588328a48c2896ea6a3b98