### PR TITLE
feat: add S3 migration columns

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -35,7 +35,10 @@ namespace PhotoBank.DbContext.DbContext
             base.OnModelCreating(modelBuilder);
 
             modelBuilder.Entity<Photo>()
-                .HasIndex(p => new { p.Id });
+                .HasIndex(p => p.Id)
+                .HasDatabaseName("IX_Photos_NeedsMigration")
+                .HasFilter("[S3Key_Preview] IS NULL OR [S3Key_Thumbnail] IS NULL")
+                .IncludeProperties(p => new { p.S3Key_Preview, p.S3Key_Thumbnail });
 
             modelBuilder.Entity<Photo>()
                 .HasIndex(p => new { p.Name, p.RelativePath });
@@ -111,6 +114,12 @@ namespace PhotoBank.DbContext.DbContext
 
             modelBuilder.Entity<Face>()
                 .HasIndex(p => new { p.PhotoId, p.Id, p.PersonId });
+
+            modelBuilder.Entity<Face>()
+                .HasIndex(p => p.Id)
+                .HasDatabaseName("IX_Faces_NeedsMigration")
+                .HasFilter("[S3Key_Image] IS NULL")
+                .IncludeProperties(p => new { p.S3Key_Image });
 
             modelBuilder.Entity<Photo>()
                 .HasIndex(p => p.StorageId)

--- a/backend/PhotoBank.DbContext/Models/Face.cs
+++ b/backend/PhotoBank.DbContext/Models/Face.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using NetTopologySuite.Geometries;
 
@@ -13,6 +14,14 @@ namespace PhotoBank.DbContext.Models
         public bool? Gender { get; set; }
         public double? Smile { get; set; }
         public byte[] Image { get; set; }
+        [MaxLength(512)]
+        public string S3Key_Image { get; set; }
+        [MaxLength(128)]
+        public string S3ETag_Image { get; set; }
+        [MaxLength(64)]
+        public string Sha256_Image { get; set; }
+        public long? BlobSize_Image { get; set; }
+        public DateTime? MigratedAt_Image { get; set; }
         public PersonGroupFace PersonGroupFace { get; set; }
         public int? PersonId { get; set; }
         public Person Person { get; set; }

--- a/backend/PhotoBank.DbContext/Models/Photo.cs
+++ b/backend/PhotoBank.DbContext/Models/Photo.cs
@@ -31,6 +31,22 @@ namespace PhotoBank.DbContext.Models
         public Point Location { get; set; }
         public byte[] PreviewImage { get; set; }
         public byte[] Thumbnail { get; set; }
+        [MaxLength(512)]
+        public string S3Key_Preview { get; set; }
+        [MaxLength(128)]
+        public string S3ETag_Preview { get; set; }
+        [MaxLength(64)]
+        public string Sha256_Preview { get; set; }
+        public long? BlobSize_Preview { get; set; }
+        public DateTime? MigratedAt_Preview { get; set; }
+        [MaxLength(512)]
+        public string S3Key_Thumbnail { get; set; }
+        [MaxLength(128)]
+        public string S3ETag_Thumbnail { get; set; }
+        [MaxLength(64)]
+        public string Sha256_Thumbnail { get; set; }
+        public long? BlobSize_Thumbnail { get; set; }
+        public DateTime? MigratedAt_Thumbnail { get; set; }
         public uint? Height { get; set; }
         public uint? Width { get; set; }
         public int? Orientation { get; set; }


### PR DESCRIPTION
## Summary
- add S3 metadata fields for photo previews, thumbnails, and face images
- create filtered indexes to track non-migrated blobs

## Testing
- `dotnet test PhotoBank.Backend.sln -c Release --logger:"console;verbosity=normal" --no-build` *(fails: A network-related or instance-specific error occurred while establishing a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_689ae1952d0c8328b428a76fa48abab2