### PR TITLE
refactor: add services layer and resilient api client

### DIFF
--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -20,7 +20,8 @@
     "object-hash": "^3.0.0",
     "openai": "^5.10.2",
     "zod": "^4.0.10",
-    "zod-to-json-schema": "^3.24.6"
+    "zod-to-json-schema": "^3.24.6",
+    "p-queue": "^8.1.0"
   },
   "peerDependencies": {
     "react": "^19.1.0"

--- a/frontend/packages/shared/src/api/photobank/fetcher.ts
+++ b/frontend/packages/shared/src/api/photobank/fetcher.ts
@@ -1,6 +1,14 @@
+import PQueue from 'p-queue';
+
 let tokenProvider: (() => string | undefined | Promise<string | undefined>) | undefined;
 let baseUrl = '';
 let impersonateUser: string | null = null;
+
+const queue = new PQueue({ interval: 1000, intervalCap: 5 });
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export function configureApiAuth(provider: () => string | undefined | Promise<string | undefined>) {
   tokenProvider = provider;
@@ -14,22 +22,42 @@ export function setImpersonateUser(username: string | null | undefined) {
   impersonateUser = username ?? null;
 }
 
-export async function customFetcher<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const headers = new Headers(options.headers);
-  if (tokenProvider) {
-    const token = await tokenProvider();
-    if (token) headers.set('Authorization', `Bearer ${token}`);
-  }
-  if (impersonateUser) {
-    headers.set('X-Impersonate-User', impersonateUser);
-  }
+export async function customFetcher<T>(
+  url: string,
+  options: RequestInit = {},
+): Promise<T> {
+  return queue.add(async () => {
+    const headers = new Headers(options.headers);
+    if (tokenProvider) {
+      const token = await tokenProvider();
+      if (token) headers.set('Authorization', `Bearer ${token}`);
+    }
+    if (impersonateUser) {
+      headers.set('X-Impersonate-User', impersonateUser);
+    }
 
-  const response = await fetch(`${baseUrl}${url}`, { ...options, headers });
-  const data = await response.json().catch(() => undefined);
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await fetch(`${baseUrl}${url}`, { ...options, headers });
+      const data = await response.json().catch(() => undefined);
 
-  if (!response.ok) {
-    throw new Error(`Request failed with status ${response.status}`);
-  }
+      if (response.ok) {
+        return { data, status: response.status, headers: response.headers } as T;
+      }
 
-  return { data, status: response.status, headers: response.headers } as T;
+      if (response.status === 429) {
+        const retryAfter = Number(response.headers.get('Retry-After') ?? '1') * 1000;
+        await delay(retryAfter + Math.random() * 1000);
+        continue;
+      }
+
+      if (attempt === 2) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      const backoff = (2 ** attempt) * 100 + Math.random() * 100;
+      await delay(backoff);
+    }
+
+    throw new Error('Request failed');
+  });
 }

--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -1,16 +1,14 @@
 import { Context, InlineKeyboard } from 'grammy';
 import {
-  apiErrorMsg,
-  sorryTryToRequestLaterMsg,
   unknownYearLabel,
   prevPageText,
   nextPageText,
 } from '@photobank/shared/constants';
 import type { FilterDto } from '@photobank/shared/api/photobank';
-import { postApiPhotosSearch } from '@photobank/shared/api/photobank';
+import { searchPhotos } from '../services/photo';
+import { handleCommandError } from '../errorHandler';
 import { firstNWords } from '@photobank/shared/index';
 import { captionCache, currentPagePhotos, deletePhotoMessage } from '../photo';
-import { logger } from '../logger';
 
 export const PHOTOS_PAGE_SIZE = 10;
 
@@ -42,15 +40,14 @@ export async function sendPhotosPage({
   const skip = (page - 1) * PHOTOS_PAGE_SIZE;
   let queryResult;
   try {
-    const res = await postApiPhotosSearch({
+    const res = await searchPhotos({
       ...filter,
       top: PHOTOS_PAGE_SIZE,
       skip,
     });
     queryResult = res.data;
   } catch (err) {
-    logger.error(apiErrorMsg, err);
-    await ctx.reply(sorryTryToRequestLaterMsg);
+    await handleCommandError(ctx, err);
     return;
   }
 

--- a/frontend/packages/telegram-bot/src/commands/profile.ts
+++ b/frontend/packages/telegram-bot/src/commands/profile.ts
@@ -1,11 +1,6 @@
 import { Context } from "grammy";
+import { getUser, getUserRoles, getUserClaims } from "../services/auth";
 import {
-    authGetUser,
-    authGetUserRoles,
-    authGetUserClaims,
-} from "@photobank/shared/api/photobank";
-import {
-    apiErrorMsg,
     getProfileErrorMsg,
     rolesLabel,
     rolesEmptyLabel,
@@ -13,15 +8,15 @@ import {
     claimsEmptyLabel,
     notRegisteredMsg,
 } from "@photobank/shared/constants";
-import { logger } from "../logger";
+import { handleCommandError } from "../errorHandler";
 
 export async function profileCommand(ctx: Context) {
     const username = ctx.from?.username ?? String(ctx.from?.id ?? "");
     try {
-        await authGetUser();
+        await getUser();
         const [rolesRes, claimsRes] = await Promise.all([
-            authGetUserRoles(),
-            authGetUserClaims(),
+            getUserRoles(),
+            getUserClaims(),
         ]);
         const roles = rolesRes.data;
         const claims = claimsRes.data;
@@ -57,7 +52,7 @@ export async function profileCommand(ctx: Context) {
             await ctx.reply(notRegisteredMsg);
             return;
         }
-        logger.error(apiErrorMsg, error);
+        await handleCommandError(ctx, error);
         await ctx.reply(getProfileErrorMsg);
     }
 }

--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -1,11 +1,8 @@
 import { Context } from 'grammy';
 import axios from 'axios';
-import { uploadPhotosAdapter } from '@photobank/shared';
-import {
-  uploadFailedMsg,
-  uploadSuccessMsg,
-  uploadStorageName,
-} from '@photobank/shared/constants';
+import { uploadFailedMsg, uploadSuccessMsg, uploadStorageName } from '@photobank/shared/constants';
+import { uploadPhotos } from '../services/photo';
+import { handleCommandError } from '../errorHandler';
 
 import { BOT_TOKEN } from '../config';
 import { getStorageId } from '../dictionaries';
@@ -48,7 +45,7 @@ export async function uploadCommand(ctx: Context) {
     const storageId = getStorageId(uploadStorageName);
     const username = ctx.from?.username ?? String(ctx.from?.id ?? '');
 
-    await uploadPhotosAdapter({
+    await uploadPhotos({
       files: uploadFiles,
       storageId,
       path: username,
@@ -56,7 +53,8 @@ export async function uploadCommand(ctx: Context) {
 
     await ctx.reply(uploadSuccessMsg);
   } catch (err) {
-    await ctx.reply(uploadFailedMsg + (err instanceof Error ? `: ${err.message}` : ''));
+    await ctx.reply(uploadFailedMsg);
+    await handleCommandError(ctx, err);
   }
 }
 

--- a/frontend/packages/telegram-bot/src/dictionaries.ts
+++ b/frontend/packages/telegram-bot/src/dictionaries.ts
@@ -1,9 +1,9 @@
 import {
-  pathsGetAll,
-  personsGetAll,
-  storagesGetAll,
-  tagsGetAll,
-} from '@photobank/shared/api/photobank';
+  fetchPaths,
+  fetchPersons,
+  fetchStorages,
+  fetchTags,
+} from './services/dictionary';
 import { unknownPersonLabel } from '@photobank/shared/constants';
 import type {
   PersonDto,
@@ -44,13 +44,13 @@ function getDict(): DictData {
 
 export async function loadDictionaries() {
   if (cache.has(currentUser)) return;
-  const { data: tagList } = await tagsGetAll();
+  const { data: tagList } = await fetchTags();
   const tagMap = new Map(tagList.map(tag => [tag.id, tag.name]));
-  const { data: personList } = await personsGetAll();
+  const { data: personList } = await fetchPersons();
   const personMap = new Map(personList.map(p => [p.id, p.name]));
-  const { data: storageList } = await storagesGetAll();
+  const { data: storageList } = await fetchStorages();
   const storageMap = new Map(storageList.map((s) => [s.id, s.name]));
-  const { data: pathList } = await pathsGetAll();
+  const { data: pathList } = await fetchPaths();
   const pathsMap = new Map<number, string[]>();
   for (const p of pathList) {
     const arr = pathsMap.get(p.storageId) ?? [];

--- a/frontend/packages/telegram-bot/src/errorHandler.ts
+++ b/frontend/packages/telegram-bot/src/errorHandler.ts
@@ -1,0 +1,19 @@
+import { BotError, Context } from 'grammy';
+import { apiErrorMsg, sorryTryToRequestLaterMsg } from '@photobank/shared/constants';
+import { logger } from './logger';
+
+export function handleBotError(err: BotError<Context>) {
+  const ctx = err.ctx;
+  const username = ctx.from?.username ?? String(ctx.from?.id ?? '');
+  logger.error(`error handling update from ${username}`, err.error);
+}
+
+export async function handleCommandError(ctx: Context, error: unknown) {
+  logger.error(apiErrorMsg, error);
+  await ctx.reply(sorryTryToRequestLaterMsg);
+}
+
+export function handleServiceError(error: unknown) {
+  logger.error(apiErrorMsg, error);
+}
+

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -1,5 +1,6 @@
 import { Context, InputFile, InlineKeyboard } from "grammy";
-import { getApiPhotos, type PhotoDto } from "@photobank/shared/api/photobank";
+import type { PhotoDto } from "@photobank/shared/api/photobank";
+import { getPhoto } from "./services/photo";
 import { formatPhotoMessage } from "./formatPhotoMessage";
 import { photoNotFoundMsg, prevPageText, nextPageText } from "@photobank/shared/constants";
 
@@ -22,7 +23,7 @@ export async function deletePhotoMessage(ctx: Context) {
 
 async function fetchPhoto(id: number): Promise<PhotoDto | null> {
     try {
-        const { data } = await getApiPhotos(id);
+        const { data } = await getPhoto(id);
         return data;
     } catch {
         return null;
@@ -33,7 +34,7 @@ export async function sendPhotoById(ctx: Context, id: number) {
     let photo: PhotoDto;
 
     try {
-        const res = await getApiPhotos(id);
+        const res = await getPhoto(id);
         photo = res.data;
     } catch {
         await ctx.reply(photoNotFoundMsg);

--- a/frontend/packages/telegram-bot/src/registration.ts
+++ b/frontend/packages/telegram-bot/src/registration.ts
@@ -1,10 +1,10 @@
 import { Context } from 'grammy';
-import { authGetUser } from '@photobank/shared/api/photobank';
+import { getUser } from './services/auth';
 import { notRegisteredMsg } from '@photobank/shared/constants';
 
 export async function ensureRegistered(ctx: Context): Promise<boolean> {
   try {
-    await authGetUser();
+    await getUser();
     return true;
   } catch {
     await ctx.reply(notRegisteredMsg);

--- a/frontend/packages/telegram-bot/src/services/auth.ts
+++ b/frontend/packages/telegram-bot/src/services/auth.ts
@@ -1,0 +1,43 @@
+import {
+  authGetUser,
+  authLogin,
+  authGetUserRoles,
+  authGetUserClaims,
+} from '@photobank/shared/api/photobank';
+import { handleServiceError } from '../errorHandler';
+
+export async function login(email: string, password: string) {
+  try {
+    return await authLogin({ email, password });
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}
+
+export async function getUser() {
+  try {
+    return await authGetUser();
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}
+
+export async function getUserRoles() {
+  try {
+    return await authGetUserRoles();
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}
+
+export async function getUserClaims() {
+  try {
+    return await authGetUserClaims();
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}

--- a/frontend/packages/telegram-bot/src/services/dictionary.ts
+++ b/frontend/packages/telegram-bot/src/services/dictionary.ts
@@ -1,0 +1,38 @@
+import { pathsGetAll, personsGetAll, storagesGetAll, tagsGetAll } from '@photobank/shared/api/photobank';
+import { handleServiceError } from '../errorHandler';
+
+export async function fetchTags() {
+  try {
+    return await tagsGetAll();
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}
+
+export async function fetchPersons() {
+  try {
+    return await personsGetAll();
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}
+
+export async function fetchStorages() {
+  try {
+    return await storagesGetAll();
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}
+
+export async function fetchPaths() {
+  try {
+    return await pathsGetAll();
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -1,0 +1,31 @@
+import { postApiPhotosSearch, getApiPhotos } from '@photobank/shared/api/photobank';
+import { uploadPhotosAdapter } from '@photobank/shared';
+import type { FilterDto } from '@photobank/shared/api/photobank';
+import { handleServiceError } from '../errorHandler';
+
+export async function searchPhotos(filter: FilterDto & { top?: number; skip?: number }) {
+  try {
+    return await postApiPhotosSearch(filter);
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}
+
+export async function getPhoto(id: number) {
+  try {
+    return await getApiPhotos(id);
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}
+
+export async function uploadPhotos(options: Parameters<typeof uploadPhotosAdapter>[0]) {
+  try {
+    return await uploadPhotosAdapter(options);
+  } catch (err) {
+    handleServiceError(err);
+    throw err;
+  }
+}

--- a/frontend/packages/telegram-bot/test/aiCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/aiCommand.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { aiCommand, parseAiPrompt, aiFilters } from '../src/commands/ai';
 import * as openai from '@photobank/shared/ai/openai';
 import * as dict from '../src/dictionaries';
-import * as photosApi from '@photobank/shared/api/photobank';
+import * as photoService from '../src/services/photo';
 import * as utils from '@photobank/shared/index';
 import {
   aiCommandUsageMsg,
@@ -49,7 +49,7 @@ describe('aiCommand', () => {
     vi.spyOn(dict, 'findBestTagId').mockReturnValue(10);
     vi.spyOn(utils, 'getFilterHash').mockResolvedValue('hash');
     const searchSpy = vi
-      .spyOn(photosApi, 'postApiPhotosSearch')
+      .spyOn(photoService, 'searchPhotos')
       .mockResolvedValue({ data: { count: 0, photos: [] } } as any);
     aiFilters.clear();
 
@@ -97,7 +97,7 @@ describe('aiCommand', () => {
         dateTo: null,
       });
     vi.spyOn(utils, 'getFilterHash').mockResolvedValue('hash');
-    vi.spyOn(photosApi, 'postApiPhotosSearch').mockResolvedValue({
+    vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
       data: { count: 0, photos: [] },
     } as any);
     aiFilters.clear();

--- a/frontend/packages/telegram-bot/test/aiPage.test.ts
+++ b/frontend/packages/telegram-bot/test/aiPage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { sendAiPage, aiFilters } from '../src/commands/ai';
-import * as photosApi from '@photobank/shared/api/photobank';
+import * as photoService from '../src/services/photo';
 import * as photo from '../src/photo';
 
 const basePhoto = {
@@ -31,7 +31,7 @@ describe('sendAiPage', () => {
     aiFilters.set('hash', {} as any);
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
-    vi.spyOn(photosApi, 'postApiPhotosSearch').mockResolvedValue({
+    vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
       data: { count: 1, photos: [basePhoto] },
     } as any);
 
@@ -49,7 +49,7 @@ describe('sendAiPage', () => {
     aiFilters.set('hash', {} as any);
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
-    vi.spyOn(photosApi, 'postApiPhotosSearch').mockResolvedValue({
+    vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
       data: { count: 1, photos: [basePhoto] },
     } as any);
 

--- a/frontend/packages/telegram-bot/test/bot.test.ts
+++ b/frontend/packages/telegram-bot/test/bot.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { handleThisDay } from '../src/commands/thisday';
-import * as photosApi from '@photobank/shared/api/photobank';
+import * as photoService from '../src/services/photo';
 import { sorryTryToRequestLaterMsg } from '@photobank/shared/constants';
 
 describe('handleThisDay', () => {
   it('replies with fallback message on API failure', async () => {
     const ctx = { reply: vi.fn(), message: { text: '/thisday' } } as any;
-    vi.spyOn(photosApi, 'postApiPhotosSearch').mockRejectedValue(new Error('fail'));
+    vi.spyOn(photoService, 'searchPhotos').mockRejectedValue(new Error('fail'));
     await handleThisDay(ctx);
     expect(ctx.reply).toHaveBeenCalledWith(sorryTryToRequestLaterMsg);
   });

--- a/frontend/packages/telegram-bot/test/dictionaries.test.ts
+++ b/frontend/packages/telegram-bot/test/dictionaries.test.ts
@@ -10,11 +10,11 @@ describe('dictionaries', () => {
     const getAllTags = vi.fn().mockResolvedValue({ data: [] });
     const getAllStorages = vi.fn().mockResolvedValue({ data: [] });
     const getAllPaths = vi.fn().mockResolvedValue({ data: [] });
-    vi.doMock('@photobank/shared/api/photobank', () => ({
-      personsGetAll: getAllPersons,
-      tagsGetAll: getAllTags,
-      storagesGetAll: getAllStorages,
-      pathsGetAll: getAllPaths,
+    vi.doMock('../src/services/dictionary', () => ({
+      fetchPersons: getAllPersons,
+      fetchTags: getAllTags,
+      fetchStorages: getAllStorages,
+      fetchPaths: getAllPaths,
     }));
     const dict = await import('../src/dictionaries');
     await dict.loadDictionaries();
@@ -52,11 +52,11 @@ describe('dictionaries', () => {
     });
     const getAllStorages = vi.fn().mockResolvedValue({ data: [] });
     const getAllPaths = vi.fn().mockResolvedValue({ data: [] });
-    vi.doMock('@photobank/shared/api/photobank', () => ({
-      personsGetAll: getAllPersons,
-      tagsGetAll: getAllTags,
-      storagesGetAll: getAllStorages,
-      pathsGetAll: getAllPaths,
+    vi.doMock('../src/services/dictionary', () => ({
+      fetchPersons: getAllPersons,
+      fetchTags: getAllTags,
+      fetchStorages: getAllStorages,
+      fetchPaths: getAllPaths,
     }));
     const dict = await import('../src/dictionaries');
     await dict.loadDictionaries();
@@ -72,11 +72,11 @@ describe('dictionaries', () => {
         { storageId: 1, path: '/b' },
       ],
     });
-    vi.doMock('@photobank/shared/api/photobank', () => ({
-      personsGetAll: vi.fn().mockResolvedValue({ data: [] }),
-      tagsGetAll: vi.fn().mockResolvedValue({ data: [] }),
-      storagesGetAll: getAllStorages,
-      pathsGetAll: getAllPaths,
+    vi.doMock('../src/services/dictionary', () => ({
+      fetchPersons: vi.fn().mockResolvedValue({ data: [] }),
+      fetchTags: vi.fn().mockResolvedValue({ data: [] }),
+      fetchStorages: getAllStorages,
+      fetchPaths: getAllPaths,
     }));
     const dict = await import('../src/dictionaries');
     await dict.loadDictionaries();

--- a/frontend/packages/telegram-bot/test/photoInline.test.ts
+++ b/frontend/packages/telegram-bot/test/photoInline.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { openPhotoInline, photoMessages, currentPagePhotos } from '../src/photo';
-import * as photosApi from '@photobank/shared/api/photobank';
+import * as photoService from '../src/services/photo';
 
 const basePhoto = {
   id: 1,
@@ -20,7 +20,7 @@ beforeEach(() => {
 });
 
 it('sends new message and stores id', async () => {
-  vi.spyOn(photosApi, 'getApiPhotos').mockResolvedValue({ data: basePhoto } as any);
+  vi.spyOn(photoService, 'getPhoto').mockResolvedValue({ data: basePhoto } as any);
   const ctx = {
     chat: { id: 1 },
     replyWithPhoto: vi.fn().mockResolvedValue({ message_id: 42 }),
@@ -35,7 +35,7 @@ it('sends new message and stores id', async () => {
 });
 
 it('edits existing message when available', async () => {
-  vi.spyOn(photosApi, 'getApiPhotos').mockResolvedValue({ data: basePhoto } as any);
+  vi.spyOn(photoService, 'getPhoto').mockResolvedValue({ data: basePhoto } as any);
   photoMessages.set(1, 42);
   const ctx = {
     chat: { id: 1 },
@@ -51,7 +51,7 @@ it('edits existing message when available', async () => {
 });
 
 it('adds navigation buttons from current page list', async () => {
-  vi.spyOn(photosApi, 'getApiPhotos').mockResolvedValue({ data: basePhoto } as any);
+  vi.spyOn(photoService, 'getPhoto').mockResolvedValue({ data: basePhoto } as any);
   const ctx = {
     chat: { id: 1 },
     replyWithPhoto: vi.fn().mockResolvedValue({ message_id: 1 }),

--- a/frontend/packages/telegram-bot/test/searchCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/searchCommand.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import * as searchCommands from '../src/commands/search';
-import * as photosApi from '@photobank/shared/api/photobank';
+import * as photoService from '../src/services/photo';
 import { sorryTryToRequestLaterMsg, searchCommandUsageMsg } from '@photobank/shared/constants';
 
 describe('handleSearch', () => {
@@ -12,7 +12,7 @@ describe('handleSearch', () => {
 
   it('replies with fallback message on API failure', async () => {
     const ctx = { reply: vi.fn(), message: { text: '/search cats' } } as any;
-    vi.spyOn(photosApi, 'postApiPhotosSearch').mockRejectedValue(new Error('fail'));
+    vi.spyOn(photoService, 'searchPhotos').mockRejectedValue(new Error('fail'));
     await searchCommands.handleSearch(ctx);
     expect(ctx.reply).toHaveBeenCalledWith(sorryTryToRequestLaterMsg);
   });
@@ -20,7 +20,7 @@ describe('handleSearch', () => {
   it('strips quotes around caption', async () => {
     const ctx = { reply: vi.fn(), message: { text: '/search "dog cat"' } } as any;
     const searchSpy = vi
-      .spyOn(photosApi, 'postApiPhotosSearch')
+      .spyOn(photoService, 'searchPhotos')
       .mockResolvedValue({ data: { count: 0, photos: [] } } as any);
 
     await searchCommands.handleSearch(ctx);

--- a/frontend/packages/telegram-bot/test/searchPage.test.ts
+++ b/frontend/packages/telegram-bot/test/searchPage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { sendSearchPage } from '../src/commands/search';
-import * as photosApi from '@photobank/shared/api/photobank';
+import * as photoService from '../src/services/photo';
 import * as photo from '../src/photo';
 
 const basePhoto = {
@@ -29,7 +29,7 @@ describe('sendSearchPage', () => {
     } as any;
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
-    vi.spyOn(photosApi, 'postApiPhotosSearch').mockResolvedValue({
+    vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
       data: { count: 1, photos: [basePhoto] },
     } as any);
 
@@ -46,7 +46,7 @@ describe('sendSearchPage', () => {
     } as any;
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
-    vi.spyOn(photosApi, 'postApiPhotosSearch').mockResolvedValue({
+    vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
       data: { count: 1, photos: [basePhoto] },
     } as any);
 

--- a/frontend/packages/telegram-bot/test/thisdayPage.test.ts
+++ b/frontend/packages/telegram-bot/test/thisdayPage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { sendThisDayPage } from '../src/commands/thisday';
-import * as photosApi from '@photobank/shared/api/photobank';
+import * as photoService from '../src/services/photo';
 import * as photo from '../src/photo';
 
 const basePhoto = {
@@ -29,7 +29,7 @@ describe('sendThisDayPage', () => {
     } as any;
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
-    vi.spyOn(photosApi, 'postApiPhotosSearch').mockResolvedValue({
+    vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
       data: { count: 1, photos: [basePhoto] },
     } as any);
 
@@ -46,7 +46,7 @@ describe('sendThisDayPage', () => {
     } as any;
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
-    vi.spyOn(photosApi, 'postApiPhotosSearch').mockResolvedValue({
+    vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
       data: { count: 1, photos: [basePhoto] },
     } as any);
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       openai:
         specifier: ^5.10.2
         version: 5.10.2(ws@8.18.3)(zod@4.0.10)
+      p-queue:
+        specifier: ^8.1.0
+        version: 8.1.0
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -3700,6 +3703,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
   exec-async@2.2.0:
     resolution: {integrity: sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==}
 
@@ -5140,6 +5146,14 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-queue@8.1.0:
+    resolution: {integrity: sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==}
+    engines: {node: '>=18'}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -10596,6 +10610,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  eventemitter3@5.0.1: {}
+
   exec-async@2.2.0: {}
 
   execa@5.1.1:
@@ -12313,6 +12329,13 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-queue@8.1.0:
+    dependencies:
+      eventemitter3: 5.0.1
+      p-timeout: 6.1.4
+
+  p-timeout@6.1.4: {}
 
   p-try@2.2.0: {}
 


### PR DESCRIPTION
## Summary
- add centralized error handling and services layer for Telegram bot
- implement rate-limited API fetcher with jittered retries
- refactor commands to use services and update tests

## Testing
- `pnpm test`
- `pnpm --filter telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_689b8b32f6208328ab779304f9338163