### PR TITLE
Refactor console app with host builder and parallel processing

### DIFF
--- a/backend/PhotoBank.Console/ConsoleOptions.cs
+++ b/backend/PhotoBank.Console/ConsoleOptions.cs
@@ -1,0 +1,29 @@
+namespace PhotoBank.Console
+{
+    public record ConsoleOptions(bool RegisterPersons = true, int? StorageId = null)
+    {
+        public static ConsoleOptions Parse(string[] args)
+        {
+            var options = new ConsoleOptions();
+            for (var i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "--storage":
+                    case "-s":
+                        if (i + 1 < args.Length && int.TryParse(args[i + 1], out var id))
+                        {
+                            options = options with { StorageId = id };
+                            i++;
+                        }
+                        break;
+                    case "--no-register":
+                        options = options with { RegisterPersons = false };
+                        break;
+                }
+            }
+            return options;
+        }
+    }
+}
+

--- a/backend/PhotoBank.Console/Program.cs
+++ b/backend/PhotoBank.Console/Program.cs
@@ -1,10 +1,8 @@
-﻿using System.IO;
-using System.Reflection;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using PhotoBank.DbContext.DbContext;
 using PhotoBank.Repositories;
 using PhotoBank.Services;
@@ -13,69 +11,49 @@ using Serilog;
 
 namespace PhotoBank.Console
 {
-    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
 
-    class Program
+    public class Program
     {
-        static void Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
-            Log.Logger = new LoggerConfiguration()
-                .WriteTo.File("consoleapp.log")
-                .CreateLogger();
+            var options = ConsoleOptions.Parse(args);
 
-            var services = ConfigureServices();
-            var serviceProvider = services.BuildServiceProvider();
-            var app = serviceProvider.GetService<App>();
-            app?.Run().Wait();
-            DisposeServices(serviceProvider);
-        }
+            using var host = Host.CreateDefaultBuilder(args)
+                .UseSerilog((context, services, configuration) => configuration
+                    .ReadFrom.Configuration(context.Configuration)
+                    .WriteTo.Console()
+                    .WriteTo.File("consoleapp.log"))
+                .ConfigureServices((context, services) =>
+                {
+                    var connectionString = context.Configuration.GetConnectionString("DefaultConnection");
 
-        private static IServiceCollection ConfigureServices()
-        {
-            IServiceCollection services = new ServiceCollection();
-            var config = LoadConfiguration();
-            var connectionString = config.GetConnectionString("DefaultConnection");
-
-            services.AddDbContext<PhotoBankDbContext>(options =>
-            {
-                options.UseSqlServer(connectionString,
-                    builder =>
+                    services.AddDbContext<PhotoBankDbContext>(opts =>
                     {
-                        builder.MigrationsAssembly(typeof(PhotoBankDbContext).GetTypeInfo().Assembly.GetName().Name);
-                        builder.UseNetTopologySuite();
-                        builder.CommandTimeout(120);
+                        opts.UseSqlServer(connectionString, builder =>
+                        {
+                            builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
+                            builder.UseNetTopologySuite();
+                            builder.CommandTimeout(120);
+                        });
+                        opts.EnableSensitiveDataLogging();
+                        opts.EnableDetailedErrors();
                     });
-                options.EnableSensitiveDataLogging();
-                options.EnableDetailedErrors();
-            });
 
-            RegisterServicesForConsole.Configure(services, config);
+                    RegisterServicesForConsole.Configure(services, context.Configuration);
 
-            services.AddSingleton(config);
-            services.AddTransient<App>();
+                    services.AddSingleton<App>();
+                    services.AddAutoMapper(cfg => cfg.AddProfile<MappingProfile>());
+                })
+                .Build();
 
-            services.AddLogging();
-            services.AddAutoMapper(cfg =>
-            {
-                cfg.AddProfile<MappingProfile>();
-            });
-            services.AddLogging(configure => configure.AddSerilog());
-
-            return services;
-        }
-
-        private static IConfiguration LoadConfiguration()
-        {
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
-
-            return builder.Build();
-        }
-
-        private static void DisposeServices(IDisposable serviceProvider)
-        {
-            serviceProvider?.Dispose();
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            var app = host.Services.GetRequiredService<App>();
+            await app.RunAsync(options, lifetime.ApplicationStopping);
+            await host.StopAsync();
+            return 0;
         }
     }
 }
+

--- a/backend/PhotoBank.Console/appsettings.json
+++ b/backend/PhotoBank.Console/appsettings.json
@@ -1,14 +1,14 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=STRIX;Database=Photobank;Trusted_Connection=True;MultipleActiveResultSets=true;Encrypt=False;"
+    "DefaultConnection": ""
   },
   "ComputerVision": {
-    "Key": "3f3a349db12a4fccbbc32f2083dfc5c2",
-    "Endpoint": "https://computervisionphotobank.cognitiveservices.azure.com/"
+    "Key": "",
+    "Endpoint": ""
   },
   "Face": {
-    "Key": "656e7fc98fa447df826e86dfaea9be7b",
-    "Endpoint": "https://facephotobank.cognitiveservices.azure.com/"
+    "Key": "",
+    "Endpoint": ""
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- switch console app startup to Generic Host with Serilog console/file logging
- add command-line options for registering persons and processing storage
- parallelize photo imports with cancellation and improve logging
- remove hardcoded connection strings and API keys from configuration

## Testing
- `dotnet build backend/PhotoBank.Console/PhotoBank.Console.csproj`
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: NoEncodeDelegateForThisImageFormat `XC`)*

------
https://chatgpt.com/codex/tasks/task_e_689c414479248328b284e94cc00c636f