### PR TITLE
feat: add enrichment pipeline

### DIFF
--- a/backend/PhotoBank.Services/Enrichment/DependsOnAttribute.cs
+++ b/backend/PhotoBank.Services/Enrichment/DependsOnAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace PhotoBank.Services.Enrichment;
+
+/// <summary>
+/// Optional attribute for declaring dependencies between enrichers.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class DependsOnAttribute : Attribute
+{
+    public DependsOnAttribute(Type enricherType) => EnricherType = enricherType;
+    public Type EnricherType { get; }
+}
+

--- a/backend/PhotoBank.Services/Enrichment/EnricherDependencyResolver.cs
+++ b/backend/PhotoBank.Services/Enrichment/EnricherDependencyResolver.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace PhotoBank.Services.Enrichment;
+
+internal static class EnricherDependencyResolver
+{
+    public static Type[] Sort(IReadOnlyList<Type> types, IServiceProvider provider)
+    {
+        var byName = types
+            .GroupBy(t => t.Name)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        static IEnumerable<Type> GetAttrDeps(Type t) =>
+            t.GetCustomAttributes<DependsOnAttribute>(inherit: true).Select(a => a.EnricherType);
+
+        static IEnumerable<Type> GetPropertyDeps(Type t, object? instance, IReadOnlyDictionary<string, Type> map)
+        {
+            var prop = t.GetProperty("Dependencies", BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy | BindingFlags.Static);
+            if (prop == null) return Array.Empty<Type>();
+
+            object? value = prop.GetMethod?.IsStatic == true
+                ? prop.GetValue(null)
+                : instance != null
+                    ? prop.GetValue(instance)
+                    : null;
+
+            if (value is IEnumerable<Type> typeEnum)
+                return typeEnum;
+
+            if (value is IEnumerable<string> nameEnum)
+            {
+                var result = new List<Type>();
+                foreach (var name in nameEnum)
+                {
+                    if (!map.TryGetValue(name, out var depType))
+                        throw new InvalidOperationException($"Enricher {t.Name} declares unknown dependency by name: '{name}'.");
+                    result.Add(depType);
+                }
+                return result;
+            }
+
+            return Array.Empty<Type>();
+        }
+
+        var edges = new Dictionary<Type, HashSet<Type>>();
+        var indegree = new Dictionary<Type, int>();
+
+        foreach (var t in types)
+        {
+            edges[t] = new HashSet<Type>();
+            indegree[t] = 0;
+        }
+
+        var tempInstances = new Dictionary<Type, object?>();
+        foreach (var t in types)
+        {
+            object? instance = null;
+            try { instance = ActivatorUtilities.CreateInstance(provider, t); } catch { }
+            tempInstances[t] = instance;
+        }
+
+        foreach (var t in types)
+        {
+            var deps = new HashSet<Type>();
+            foreach (var d in GetAttrDeps(t)) deps.Add(d);
+            foreach (var d in GetPropertyDeps(t, tempInstances[t], byName)) deps.Add(d);
+
+            foreach (var d in deps)
+            {
+                if (!edges.ContainsKey(d))
+                    throw new InvalidOperationException($"Enricher {t.Name} depends on {d.Name}, which is not registered.");
+                if (d == t)
+                    throw new InvalidOperationException($"Enricher {t.Name} cannot depend on itself.");
+                if (edges[d].Add(t))
+                    indegree[t]++;
+            }
+        }
+
+        var queue = new Queue<Type>(indegree.Where(kv => kv.Value == 0).Select(kv => kv.Key));
+        var ordered = new List<Type>(types.Count);
+
+        while (queue.Count > 0)
+        {
+            var n = queue.Dequeue();
+            ordered.Add(n);
+
+            foreach (var m in edges[n])
+            {
+                indegree[m]--;
+                if (indegree[m] == 0)
+                    queue.Enqueue(m);
+            }
+        }
+
+        if (ordered.Count != types.Count)
+        {
+            var cycle = FindCycle(edges);
+            var path = string.Join(" -> ", cycle.Select(t => t.Name));
+            throw new InvalidOperationException($"A dependency cycle was detected among enrichers: {path}");
+        }
+
+        return ordered.ToArray();
+    }
+
+    private static IReadOnlyList<Type> FindCycle(Dictionary<Type, HashSet<Type>> edges)
+    {
+        var color = new Dictionary<Type, int>();
+        var stack = new Stack<Type>();
+        var cycle = new List<Type>();
+
+        bool Dfs(Type v)
+        {
+            color[v] = 1;
+            stack.Push(v);
+
+            foreach (var u in edges[v])
+            {
+                if (!color.TryGetValue(u, out var c)) c = 0;
+                if (c == 0)
+                {
+                    if (Dfs(u)) return true;
+                }
+                else if (c == 1)
+                {
+                    var arr = stack.ToArray();
+                    Array.Reverse(arr);
+                    var idx = Array.IndexOf(arr, u);
+                    cycle.AddRange(arr[idx..]);
+                    cycle.Add(u);
+                    return true;
+                }
+            }
+
+            stack.Pop();
+            color[v] = 2;
+            return false;
+        }
+
+        foreach (var v in edges.Keys)
+        {
+            if (!color.TryGetValue(v, out var c) || c == 0)
+            {
+                if (Dfs(v)) break;
+            }
+        }
+        return cycle;
+    }
+}
+

--- a/backend/PhotoBank.Services/Enrichment/EnrichmentPipeline.cs
+++ b/backend/PhotoBank.Services/Enrichment/EnrichmentPipeline.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Enrichers;
+using PhotoBank.Services.Models;
+
+namespace PhotoBank.Services.Enrichment;
+
+/// <summary>
+/// Executes enrichers in dependency order with logging, cancellation and error handling.
+/// </summary>
+public sealed class EnrichmentPipeline : IEnrichmentPipeline
+{
+    private readonly IServiceProvider _rootProvider;
+    private readonly ILogger<EnrichmentPipeline> _logger;
+    private readonly EnrichmentPipelineOptions _options;
+
+    private readonly Type[] _orderedTypes;
+    private readonly Func<IServiceProvider, IEnricher>[] _factories;
+
+    public EnrichmentPipeline(
+        IServiceProvider rootProvider,
+        IEnumerable<Type> enricherTypes,
+        IOptions<EnrichmentPipelineOptions> options,
+        ILogger<EnrichmentPipeline> logger)
+    {
+        _rootProvider = rootProvider;
+        _logger = logger;
+        _options = options.Value;
+
+        var types = enricherTypes.Distinct().ToArray();
+        if (types.Length == 0)
+            throw new InvalidOperationException("No IEnricher implementations were provided to the pipeline.");
+
+        _orderedTypes = EnricherDependencyResolver.Sort(types, rootProvider);
+        _factories = _orderedTypes.Select(CreateFactory).ToArray();
+
+        _logger.LogInformation("EnrichmentPipeline initialized with {Count} enrichers: {Names}",
+            _orderedTypes.Length, string.Join(", ", _orderedTypes.Select(t => t.Name)));
+    }
+
+    public async Task RunAsync(Photo photo, SourceDataDto source, CancellationToken ct = default)
+    {
+        using var scope = _rootProvider.CreateScope();
+        var sp = scope.ServiceProvider;
+
+        for (var i = 0; i < _factories.Length; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var enricher = _factories[i](sp);
+            var stepName = enricher.GetType().Name;
+
+            var sw = _options.LogTimings ? Stopwatch.StartNew() : null;
+            try
+            {
+                _logger.LogDebug("➡️ Starting enricher: {Step}", stepName);
+                await enricher.EnrichAsync(photo, source, ct);
+                if (_options.LogTimings)
+                    _logger.LogInformation("✅ {Step} completed in {Ms} ms", stepName, sw!.Elapsed.TotalMilliseconds);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogWarning("⏹️ Pipeline canceled during {Step}", stepName);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "❌ Enricher {Step} failed", stepName);
+                if (!_options.ContinueOnError)
+                    throw;
+            }
+            finally
+            {
+                sw?.Stop();
+            }
+        }
+    }
+
+    public async Task RunBatchAsync(IEnumerable<(Photo photo, SourceDataDto source)> items, CancellationToken ct = default)
+    {
+        var list = items as (Photo photo, SourceDataDto source)[] ?? items.ToArray();
+        if (list.Length == 0) return;
+
+        var dop = _options.MaxDegreeOfParallelism.HasValue && _options.MaxDegreeOfParallelism > 0
+            ? _options.MaxDegreeOfParallelism.Value
+            : Environment.ProcessorCount;
+
+        _logger.LogInformation("Batch pipeline started for {Count} items with DOP={Dop}", list.Length, dop);
+
+        await Parallel.ForEachAsync(list, new ParallelOptions
+        {
+            CancellationToken = ct,
+            MaxDegreeOfParallelism = dop
+        }, async (item, token) =>
+        {
+            await RunAsync(item.photo, item.source, token);
+        });
+
+        _logger.LogInformation("Batch pipeline completed for {Count} items", list.Length);
+    }
+
+    private static Func<IServiceProvider, IEnricher> CreateFactory(Type t) =>
+        sp => (IEnricher)sp.GetRequiredService(t);
+}
+

--- a/backend/PhotoBank.Services/Enrichment/EnrichmentPipelineOptions.cs
+++ b/backend/PhotoBank.Services/Enrichment/EnrichmentPipelineOptions.cs
@@ -1,0 +1,17 @@
+namespace PhotoBank.Services.Enrichment;
+
+/// <summary>
+/// Pipeline execution options.
+/// </summary>
+public sealed class EnrichmentPipelineOptions
+{
+    /// <summary>Continue executing subsequent enrichers if one fails (default: false).</summary>
+    public bool ContinueOnError { get; init; } = false;
+
+    /// <summary>Log timing for each step (default: true).</summary>
+    public bool LogTimings { get; init; } = true;
+
+    /// <summary>Max parallelism for batch runs. null or <=0 means use Environment.ProcessorCount.</summary>
+    public int? MaxDegreeOfParallelism { get; init; }
+}
+

--- a/backend/PhotoBank.Services/Enrichment/EnrichmentPipelineServiceCollectionExtensions.cs
+++ b/backend/PhotoBank.Services/Enrichment/EnrichmentPipelineServiceCollectionExtensions.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using PhotoBank.Services.Enrichers;
+
+namespace PhotoBank.Services.Enrichment;
+
+public static class EnrichmentPipelineServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers all <see cref="IEnricher"/> implementations found in the provided assemblies and the pipeline itself.
+    /// </summary>
+    public static IServiceCollection AddEnrichmentPipeline(
+        this IServiceCollection services,
+        Action<EnrichmentPipelineOptions>? configure,
+        params Assembly[] scanAssemblies)
+    {
+        if (scanAssemblies == null || scanAssemblies.Length == 0)
+            scanAssemblies = new[] { Assembly.GetExecutingAssembly() };
+
+        var enricherTypes = new HashSet<Type>();
+        foreach (var asm in scanAssemblies)
+        {
+            foreach (var t in asm.GetTypes())
+            {
+                if (t.IsAbstract || t.IsInterface) continue;
+                if (typeof(IEnricher).IsAssignableFrom(t))
+                {
+                    services.AddTransient(t);
+                    enricherTypes.Add(t);
+                }
+            }
+        }
+
+        if (configure != null)
+            services.Configure(configure);
+        else
+            services.Configure<EnrichmentPipelineOptions>(_ => { });
+
+        services.AddSingleton<IEnrichmentPipeline>(sp =>
+        {
+            var opts = sp.GetRequiredService<IOptions<EnrichmentPipelineOptions>>();
+            var logger = sp.GetRequiredService<ILogger<EnrichmentPipeline>>();
+            return new EnrichmentPipeline(sp, enricherTypes, opts, logger);
+        });
+
+        return services;
+    }
+}
+

--- a/backend/PhotoBank.Services/Enrichment/IEnrichmentPipeline.cs
+++ b/backend/PhotoBank.Services/Enrichment/IEnrichmentPipeline.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Models;
+
+namespace PhotoBank.Services.Enrichment;
+
+public interface IEnrichmentPipeline
+{
+    /// <summary>Run all enrichers for a single item.</summary>
+    Task RunAsync(Photo photo, SourceDataDto source, CancellationToken ct = default);
+
+    /// <summary>Run pipeline for many items with optional parallelism.</summary>
+    Task RunBatchAsync(IEnumerable<(Photo photo, SourceDataDto source)> items, CancellationToken ct = default);
+}
+


### PR DESCRIPTION
## Summary
- split enrichment pipeline into modular classes and extracted dependency resolver
- support dependency declarations via attribute and configurable execution options
- add service registration extension scanning assemblies for enrichers

## Testing
- `dotnet build backend/PhotoBank.Services/PhotoBank.Services.csproj`
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: ImageMagick.MagickMissingDelegateErrorException)*

------
https://chatgpt.com/codex/tasks/task_e_689cbf06516c8328a72ffa42e482a650