### PR TITLE
Refactor enrichers to persist and link metadata

### DIFF
--- a/backend/PhotoBank.Services/Enrichers/ObjectPropertyEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/ObjectPropertyEnricher.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Repositories;
 using PhotoBank.Services.Models;
@@ -13,8 +13,6 @@ namespace PhotoBank.Services.Enrichers
     public class ObjectPropertyEnricher : IEnricher
     {
         private readonly IRepository<PropertyName> _propertyNameRepository;
-        private readonly ConcurrentDictionary<string, Lazy<Task<PropertyName>>> _cache =
-            new(StringComparer.OrdinalIgnoreCase);
 
         public ObjectPropertyEnricher(IRepository<PropertyName> propertyNameRepository)
         {
@@ -22,26 +20,44 @@ namespace PhotoBank.Services.Enrichers
         }
 
         public EnricherType EnricherType => EnricherType.ObjectProperty;
-        public Type[] Dependencies => new Type[1] { typeof(AnalyzeEnricher) };
+        public Type[] Dependencies => new[] { typeof(AnalyzeEnricher) };
 
         public async Task EnrichAsync(Photo photo, SourceDataDto sourceData, CancellationToken cancellationToken = default)
         {
-            photo.ObjectProperties = new List<ObjectProperty>();
+            var incoming = sourceData.ImageAnalysis.Objects
+                .Select(o => o.ObjectProperty?.Trim())
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            var query = _propertyNameRepository.GetByCondition(p => incoming.Contains(p.Name));
+            List<PropertyName> existing;
+            try
+            {
+                existing = await query.ToListAsync(cancellationToken);
+            }
+            catch (InvalidOperationException)
+            {
+                existing = query.ToList();
+            }
+
+            var map = existing.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var name in incoming)
+            {
+                if (!map.TryGetValue(name, out var propertyName))
+                {
+                    propertyName = new PropertyName { Name = name };
+                    await _propertyNameRepository.InsertAsync(propertyName);
+                    map[name] = propertyName;
+                }
+            }
+
+            photo.ObjectProperties ??= new List<ObjectProperty>();
+
             foreach (var detectedObject in sourceData.ImageAnalysis.Objects)
             {
-                var propertyName = await _cache.GetOrAdd(detectedObject.ObjectProperty, name =>
-                    new Lazy<Task<PropertyName>>(async () =>
-                    {
-                        var existing = _propertyNameRepository.GetByCondition(t => t.Name == name).FirstOrDefault();
-                        if (existing == null)
-                        {
-                            existing = new PropertyName { Name = name };
-                            await _propertyNameRepository.InsertAsync(existing);
-                        }
-
-                        return existing;
-                    })).Value;
-
+                var propertyName = map[detectedObject.ObjectProperty];
                 photo.ObjectProperties.Add(new ObjectProperty
                 {
                     PropertyName = propertyName,

--- a/backend/PhotoBank.UnitTests/Enrichers/TagEnricherTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichers/TagEnricherTests.cs
@@ -63,17 +63,22 @@ namespace PhotoBank.UnitTests.Enrichers
                 }
             };
 
+            _mockTagRepository.Setup(r => r.GetByCondition(It.IsAny<System.Linq.Expressions.Expression<System.Func<Tag, bool>>>()
+                ))
+                .Returns(Enumerable.Empty<Tag>().AsQueryable());
+            _mockTagRepository.Setup(r => r.InsertAsync(It.IsAny<Tag>()))
+                .ReturnsAsync((Tag t) => t);
+
             // Act
             await _tagEnricher.EnrichAsync(photo, sourceData);
 
             // Assert
             photo.PhotoTags.Should().HaveCount(2);
-            photo.PhotoTags.Should().Contain(pt => pt.Tag.Name == "car" && pt.Confidence == 0.9);
-            photo.PhotoTags.Should().Contain(pt => pt.Tag.Name == "tree" && pt.Confidence == 0.8);
+            photo.PhotoTags.Should().Contain(pt => pt.Tag.Name == "Car" && pt.Confidence == 0.9);
+            photo.PhotoTags.Should().Contain(pt => pt.Tag.Name == "Tree" && pt.Confidence == 0.8);
         }
 
         [Test]
-        [Ignore("This test is not working")]
         public async Task EnrichAsync_ShouldInsertNewTagIfNotExists()
         {
             // Arrange
@@ -89,8 +94,11 @@ namespace PhotoBank.UnitTests.Enrichers
                 }
             };
 
-            _mockTagRepository.Setup(repo => repo.GetByCondition(It.IsAny<System.Linq.Expressions.Expression<System.Func<Tag, bool>>>()))
+            _mockTagRepository.Setup(r => r.GetByCondition(It.IsAny<System.Linq.Expressions.Expression<System.Func<Tag, bool>>>()
+                ))
                 .Returns(Enumerable.Empty<Tag>().AsQueryable());
+            _mockTagRepository.Setup(r => r.InsertAsync(It.IsAny<Tag>()))
+                .ReturnsAsync((Tag t) => t);
 
             // Act
             await _tagEnricher.EnrichAsync(photo, sourceData);


### PR DESCRIPTION
## Summary
- refactor Tag, Category, and ObjectProperty enrichers to batch lookup existing records, create missing ones, and link them to photos
- extend CategoryEnricher and ObjectPropertyEnricher unit tests to verify insertion and linking behavior

## Testing
- ⚠️ `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: NoEncodeDelegateForThisImageFormat `XC`)*
- ✅ `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --filter "FullyQualifiedName~TagEnricherTests|FullyQualifiedName~ObjectPropertyEnricherTests|FullyQualifiedName~CategoryEnricherTests"`


------
https://chatgpt.com/codex/tasks/task_e_689ccaed61788328adc3c3716c98bfa3