### PR TITLE
Refactor storage sync to track relative file paths

### DIFF
--- a/backend/PhotoBank.Services/Enrichment/EnrichmentPipeline.cs
+++ b/backend/PhotoBank.Services/Enrichment/EnrichmentPipeline.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;


### PR DESCRIPTION
## Summary
- compute disk file set relative to storage root and reactivate files that returned
- detect new files not yet tracked in DB
- add explicit usings for enrichment pipeline compilation

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: MagickMissingDelegateErrorException in FaceEnricherAws)*

------
https://chatgpt.com/codex/tasks/task_e_689cd71108cc832884511805e4f08c2f