### PR TITLE
feat: use ImageMagick perceptual hash

### DIFF
--- a/backend/PhotoBank.DbContext/Migrations/20250701121000_AddImageHash.cs
+++ b/backend/PhotoBank.DbContext/Migrations/20250701121000_AddImageHash.cs
@@ -13,8 +13,8 @@ namespace PhotoBank.DbContext.Migrations
             migrationBuilder.AddColumn<string>(
                 name: "ImageHash",
                 table: "Photos",
-                type: "nvarchar(64)",
-                maxLength: 64,
+                type: "nvarchar(256)",
+                maxLength: 256,
                 nullable: true);
         }
 

--- a/backend/PhotoBank.DbContext/Migrations/PhotoBankDbContextModelSnapshot.cs
+++ b/backend/PhotoBank.DbContext/Migrations/PhotoBankDbContextModelSnapshot.cs
@@ -550,8 +550,8 @@ namespace PhotoBank.DbContext.Migrations
                         .HasColumnType("bigint");
 
                     b.Property<string>("ImageHash")
-                        .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<bool>("IsAdultContent")
                         .HasColumnType("bit");

--- a/backend/PhotoBank.DbContext/Models/Photo.cs
+++ b/backend/PhotoBank.DbContext/Models/Photo.cs
@@ -59,7 +59,7 @@ namespace PhotoBank.DbContext.Models
         public double AdultScore { get; set; }
         public bool IsRacyContent { get; set; }
         public double RacyScore { get; set; }
-        [MaxLength(64)]
+        [MaxLength(256)]
         public string ImageHash { get; set; }
         [MaxLength(255)]
         public string RelativePath { get; set; }

--- a/backend/PhotoBank.Services/ImageHashHelper.cs
+++ b/backend/PhotoBank.Services/ImageHashHelper.cs
@@ -8,48 +8,17 @@ public static class ImageHashHelper
     public static string ComputeHash(byte[] data)
     {
         using var image = new MagickImage(data);
-        image.Resize(8, 8);
-        image.ColorSpace = ColorSpace.Gray;
-
-        var pixels = image.GetPixels();
-        ulong total = 0;
-        for (int y = 0; y < 8; y++)
-        {
-            for (int x = 0; x < 8; x++)
-            {
-                total += pixels.GetPixel(x, y).GetChannel(0);
-            }
-        }
-
-        ulong avg = total / 64;
-        ulong hash = 0;
-        for (int y = 0; y < 8; y++)
-        {
-            for (int x = 0; x < 8; x++)
-            {
-                if (pixels.GetPixel(x, y).GetChannel(0) >= avg)
-                {
-                    hash |= 1UL << (y * 8 + x);
-                }
-            }
-        }
-
-        return hash.ToString("X16");
+        var hash = image.PerceptualHash();
+        return hash.ToString();
     }
 
-    public static int HammingDistance(string hash1, string hash2)
+    public static double HammingDistance(string hash1, string hash2)
     {
         if (string.IsNullOrEmpty(hash1) || string.IsNullOrEmpty(hash2))
-            return int.MaxValue;
-        ulong h1 = Convert.ToUInt64(hash1, 16);
-        ulong h2 = Convert.ToUInt64(hash2, 16);
-        ulong x = h1 ^ h2;
-        int setBits = 0;
-        while (x != 0)
-        {
-            setBits += (int)(x & 1);
-            x >>= 1;
-        }
-        return setBits;
+            return double.MaxValue;
+
+        var h1 = new PerceptualHash(hash1);
+        var h2 = new PerceptualHash(hash2);
+        return h1.SumSquaredDistance(h2);
     }
 }


### PR DESCRIPTION
## Summary
- switch custom aHash to ImageMagick's built-in perceptual hash
- expand ImageHash column to accommodate longer hashes

## Testing
- `dotnet build backend/PhotoBank.DbContext`
- `dotnet build backend/PhotoBank.Services`


------
https://chatgpt.com/codex/tasks/task_e_689ce1b27cc08328b0160e71cd1c9fe6