### PR TITLE
Add compression of preview images in blob migrator

### DIFF
--- a/backend/PhotoBank.BlobMigrator/PhotoBank.BlobMigrator.csproj
+++ b/backend/PhotoBank.BlobMigrator/PhotoBank.BlobMigrator.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageReference Include="Minio" Version="6.0.5" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.7.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- compress preview images during blob migration to reduce size
- add Magick.NET dependency for image processing

## Testing
- `dotnet build backend/PhotoBank.BlobMigrator`
- `dotnet test backend/PhotoBank.UnitTests` *(fails: MagickMissingDelegateErrorException and logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_689d81e96cb483288efd0c0591abc5e4