### PR TITLE
feat(bot): show geo link in preview

### DIFF
--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -17,6 +17,12 @@ export function formatPhotoMessage(photo: PhotoDto): { caption: string, hasSpoil
     if (photo.captions?.[0]) lines.push(`📝 ${photo.captions[0]}`);
     if (photo.tags?.length) lines.push(`🏷️ ${photo.tags.join(", ")}`);
 
+    if (photo.location) {
+        const { latitude, longitude } = photo.location;
+        const coords = `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
+        lines.push(`📍 <a href="https://www.google.com/maps?q=${latitude},${longitude}">${coords}</a>`);
+    }
+
     if (photo.faces?.length) {
         const people = photo.faces.map(f => getPersonName(f.personId));
         if (people.some(Boolean)) {

--- a/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
+++ b/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
@@ -48,4 +48,14 @@ describe('formatPhotoMessage', () => {
     });
     expect(caption).toContain('👤 Неизвестный');
   });
+
+  it('adds geo point link when location is present', () => {
+    const { caption } = formatPhotoMessage({
+      ...basePhoto,
+      location: { latitude: 10, longitude: 20 },
+    });
+    expect(caption).toContain('📍');
+    expect(caption).toContain('https://www.google.com/maps?q=10,20');
+    expect(caption).toContain('10.00000, 20.00000');
+  });
 });


### PR DESCRIPTION
## Summary
- display location link when photo has geo point in Telegram bot preview
- test formatting with geolocation

## Testing
- `pnpm test` *(fails: test/aiCommand.test.ts expected true but received false)*
- `pnpm --filter @photobank/telegram-bot test test/formatPhotoMessage.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689dc346a4dc8328bda1f7989a8106f6