### PR TITLE
fix: use proper OpenAI imports and return types

### DIFF
--- a/frontend/packages/shared/src/ai/openai.ts
+++ b/frontend/packages/shared/src/ai/openai.ts
@@ -1,5 +1,5 @@
-import AzureOpenAI from 'openai';
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions/completions.mjs';
+import { AzureOpenAI } from 'openai';
+import type { ChatCompletionMessageParam } from 'openai/resources';
 
 import { FEW_SHOTS, SYSTEM_PROMPT } from '@photobank/shared/ai/constants';
 


### PR DESCRIPTION
## Summary
- switch to `AzureOpenAI` class and top-level `ChatCompletionMessageParam` import
- ensure OpenAI filter parser returns `PhotoFilter`

## Testing
- `pnpm test` *(fails: expected false to be true in aiCommand.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc045f8483289a01c27221641e2b