### PR TITLE
fix(shared): improve browser detection heuristic

### DIFF
--- a/frontend/packages/shared/src/utils/isBrowser.ts
+++ b/frontend/packages/shared/src/utils/isBrowser.ts
@@ -1,3 +1,3 @@
 export function isBrowser(): boolean {
-  return typeof window !== 'undefined' && typeof window.crypto !== 'undefined';
+  return typeof window !== 'undefined' && typeof document !== 'undefined';
 }

--- a/frontend/packages/shared/test/isBrowser.test.ts
+++ b/frontend/packages/shared/test/isBrowser.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isBrowser } from '../src/utils/isBrowser';
+
+type GlobalWithDom = typeof globalThis & {
+  window?: unknown;
+  document?: unknown;
+};
+const globalWithDom = globalThis as GlobalWithDom;
+
+describe('isBrowser', () => {
+  beforeEach(() => {
+    delete globalWithDom.window;
+    delete globalWithDom.document;
+  });
+
+  afterEach(() => {
+    delete globalWithDom.window;
+    delete globalWithDom.document;
+  });
+
+  it('returns false when window or document are undefined', () => {
+    expect(isBrowser()).toBe(false);
+  });
+
+  it('returns true when window and document are defined', () => {
+    globalWithDom.window = {};
+    globalWithDom.document = {};
+    expect(isBrowser()).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- detect browser by checking for both `window` and `document`
- add unit tests for `isBrowser`

## Testing
- `pnpm test` *(fails: @photobank/telegram-bot test: vitest run)*
- `pnpm --filter @photobank/shared test`
- `pnpm --filter @photobank/shared lint`


------
https://chatgpt.com/codex/tasks/task_e_689dcf8c1d3083288f9e03dd534e078e