### PR TITLE
refactor: use web binary data for uploads

### DIFF
--- a/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
+++ b/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
@@ -1,6 +1,6 @@
 import { photosUpload } from '../api/photobank';
 
-export type UploadFile = { buffer: Buffer; name: string };
+export type UploadFile = { data: BlobPart | ArrayBuffer | Uint8Array; name: string };
 
 export async function uploadPhotosAdapter(params: {
   files: UploadFile[];
@@ -8,6 +8,6 @@ export async function uploadPhotosAdapter(params: {
   path: string;
 }) {
   const { files, storageId, path } = params;
-  const blobs = files.map(({ buffer, name }) => new File([buffer], name));
+  const blobs = files.map(({ data, name }) => new File([data], name));
   await photosUpload({ files: blobs, storageId, path });
 }

--- a/frontend/packages/shared/test/photos-upload.adapter.test.ts
+++ b/frontend/packages/shared/test/photos-upload.adapter.test.ts
@@ -16,7 +16,7 @@ describe('uploadPhotosAdapter', () => {
     // @ts-expect-error assign mock fetch
     global.fetch = fetchMock;
     await uploadPhotosAdapter({
-      files: [{ buffer: Buffer.from('data'), name: 'a.txt' }],
+      files: [{ data: 'data', name: 'a.txt' }],
       storageId: 1,
       path: 'user',
     });

--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -7,27 +7,27 @@ import { handleCommandError } from '../errorHandler';
 import { BOT_TOKEN } from '../config';
 import { getStorageId } from '../dictionaries';
 
-async function fetchFileBuffer(ctx: Context, fileId: string, fileName: string) {
+async function fetchFile(ctx: Context, fileId: string, fileName: string) {
   const file = await ctx.api.getFile(fileId);
   if (!file.file_path) throw new Error('file path missing');
   const url = `https://api.telegram.org/file/bot${BOT_TOKEN}/${file.file_path}`;
   const res = await axios.get<ArrayBuffer>(url, { responseType: 'arraybuffer' });
-  return { buffer: Buffer.from(res.data), name: fileName };
+  return { data: res.data, name: fileName };
 }
 
 export async function uploadCommand(ctx: Context) {
   try {
-    const files: Array<Promise<{ buffer: Buffer; name: string }>> = [];
+    const files: Array<Promise<{ data: ArrayBuffer; name: string }>> = [];
 
     if (ctx.message?.photo?.length) {
       const photo = ctx.message.photo[ctx.message.photo.length - 1];
-      files.push(fetchFileBuffer(ctx, photo.file_id, `${photo.file_unique_id}.jpg`));
+      files.push(fetchFile(ctx, photo.file_id, `${photo.file_unique_id}.jpg`));
     }
 
     if (ctx.message?.document) {
       const doc = ctx.message.document;
       files.push(
-        fetchFileBuffer(
+        fetchFile(
           ctx,
           doc.file_id,
           doc.file_name || doc.file_unique_id || 'file',

--- a/frontend/packages/telegram-bot/test/uploadCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/uploadCommand.test.ts
@@ -9,7 +9,7 @@ import { uploadCommand } from '../src/commands/upload';
 import { uploadSuccessMsg } from '@photobank/shared/constants';
 
 describe('uploadCommand', () => {
-  it('uploads photo buffers via adapter', async () => {
+  it('uploads photo data via adapter', async () => {
     const ctx: any = {
       api: { getFile: vi.fn().mockResolvedValue({ file_path: 'photo.jpg' }) },
       message: { photo: [{}, { file_id: '123', file_unique_id: 'uniq123' }] },


### PR DESCRIPTION
## Summary
- remove Node `Buffer` from photo upload adapter to avoid leaking Node types
- fetch photo bytes as `ArrayBuffer` in telegram bot upload command
- update tests for new `data` field

## Testing
- `pnpm --filter @photobank/shared lint`
- `pnpm --filter @photobank/shared test`
- `pnpm --filter @photobank/telegram-bot lint`
- `pnpm --filter @photobank/telegram-bot test` *(fails: aiCommand.test.ts > requests photos with parsed filter)*
- `pnpm --filter @photobank/telegram-bot exec vitest run test/uploadCommand.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689dce8f27648328a13b649e1b209ca7