### PR TITLE
fix: stable keys for list rendering

### DIFF
--- a/frontend/packages/frontend/src/components/MetadataBadgeList.tsx
+++ b/frontend/packages/frontend/src/components/MetadataBadgeList.tsx
@@ -22,8 +22,8 @@ const MetadataBadgeList = ({
   return (
     <div className="flex items-center gap-1 flex-wrap">
       <Icon className="w-3 h-3 text-muted-foreground" />
-      {items.slice(0, maxVisible).map((id, index) => (
-        <Badge key={index} variant={variant} className="text-xs">
+      {items.slice(0, maxVisible).map((id) => (
+        <Badge key={id} variant={variant} className="text-xs">
           {map[id] ?? id}
         </Badge>
       ))}

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -290,8 +290,8 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                     </CardHeader>
                                     <CardContent>
                                         <div className="flex flex-wrap gap-2">
-                                            {photo.tags.map((tag, index) => (
-                                                <Badge key={index} variant="secondary"
+                                            {photo.tags.map((tag) => (
+                                                <Badge key={tag} variant="secondary"
                                                        className="bg-secondary text-secondary-foreground">
                                                     {tag}
                                                 </Badge>
@@ -309,9 +309,9 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                     </CardHeader>
                                     <CardContent>
                                         <div className="space-y-2">
-                                            {photo.captions.map((caption, index) => (
+                                            {photo.captions.map((caption) => (
                                                 <Textarea
-                                                    key={index}
+                                                    key={caption}
                                                     value={caption}
                                                     readOnly
                                                     className="min-h-[60px] resize-none bg-muted"
@@ -362,7 +362,7 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                             {photo.faces.map((face, index) => {
                                                 return (
                                                     <FacePersonSelector
-                                                        key={index}
+                                                        key={face.id}
                                                         faceIndex={index}
                                                         personId={face.personId ?? undefined}
                                                         persons={persons}


### PR DESCRIPTION
## Summary
- ensure MetadataBadgeList uses ID-based keys
- replace array index keys with stable identifiers in photo details lists

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Invalid hook call / expected false to be true)*

------
https://chatgpt.com/codex/tasks/task_e_689df293af2c832887ab68a50381f3b8