### PR TITLE
Wrap filter form submit handler in void callback

### DIFF
--- a/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -86,8 +86,7 @@ function FilterPage() {
         </CardHeader>
         <CardContent>
           <Form {...form}>
-            {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <form onSubmit={form.handleSubmit((d) => { void onSubmit(d); })} className="space-y-6">
               <FilterFormFields control={form.control} />
               {/* Submit Button */}
               <Button type="submit" className="w-full">


### PR DESCRIPTION
## Summary
- remove no-misused-promises directive in FilterPage
- wrap filter form submit handler in void callback

## Testing
- `pnpm --filter @photobank/frontend lint` *(fails: Promise-returning function provided to attribute where a void return was expected)*
- `pnpm --filter @photobank/frontend test` *(fails: TypeError: Cannot read properties of null (reading 'useState'))*

------
https://chatgpt.com/codex/tasks/task_e_689df3632c30832882e0b512cf6fc2b3