### PR TITLE
Add security rel attribute for map links

### DIFF
--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -272,7 +272,7 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                             <a
                                                 href={`https://www.google.com/maps?q=${photo.location.latitude},${photo.location.longitude}`}
                                                 target="_blank"
-                                                rel="noreferrer"
+                                                rel="noopener noreferrer"
                                                 className="mt-1 block text-primary underline"
                                             >
                                                 {openInMapsText}: {placeName}

--- a/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
+++ b/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
@@ -94,6 +94,7 @@ describe('PhotoDetailsPage', () => {
     const placeLink = await screen.findByRole('link', { name: /Nice place/ });
     expect(placeLink).toBeTruthy();
     expect(placeLink.getAttribute('href')).toContain('10,20');
+    expect(placeLink.getAttribute('rel')).toBe('noopener noreferrer');
   });
 
   it('toggles face boxes visibility', async () => {


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to external map link on photo details page
- ensure tests check for the link's rel attribute

## Testing
- `pnpm test` *(fails: Invalid hook call and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_689df33e38c083288921761b88563d77