### PR TITLE
chore: upgrade zod to v4

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,6 @@
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "zod": "^4.0.10"
+    "zod": "^4.0.17"
   }
 }

--- a/frontend/packages/frontend/package.json
+++ b/frontend/packages/frontend/package.json
@@ -47,7 +47,7 @@
     "react-router-dom": "^7.7.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.11",
-    "zod": "^4.0.10"
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -36,7 +36,7 @@
     "object-hash": "^3.0.0",
     "openai": "^5.12.2",
     "p-queue": "^8.1.0",
-    "zod": "^3.23.8"
+    "zod": "^4.0.17"
   },
   "peerDependencies": {
     "react": "^19.1.1"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^8.38.0
         version: 8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3)
       zod:
-        specifier: ^4.0.10
-        version: 4.0.10
+        specifier: ^4.0.17
+        version: 4.0.17
 
   packages/frontend:
     dependencies:
@@ -165,8 +165,8 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11
       zod:
-        specifier: ^4.0.10
-        version: 4.0.10
+        specifier: ^4.0.17
+        version: 4.0.17
     devDependencies:
       '@eslint/js':
         specifier: ^9.31.0
@@ -278,7 +278,7 @@ importers:
         version: 3.0.0
       openai:
         specifier: ^5.12.2
-        version: 5.12.2(ws@8.18.3)(zod@3.25.76)
+        version: 5.12.2(ws@8.18.3)(zod@4.0.17)
       p-queue:
         specifier: ^8.1.0
         version: 8.1.0
@@ -286,8 +286,8 @@ importers:
         specifier: ^19.1.1
         version: 19.1.1
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.0.17
+        version: 4.0.17
     devDependencies:
       '@faker-js/faker':
         specifier: ^9.9.0
@@ -6657,11 +6657,8 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zod@4.0.10:
-    resolution: {integrity: sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==}
+  zod@4.0.17:
+    resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
 
 snapshots:
 
@@ -12327,10 +12324,10 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@5.12.2(ws@8.18.3)(zod@3.25.76):
+  openai@5.12.2(ws@8.18.3)(zod@4.0.17):
     optionalDependencies:
       ws: 8.18.3
-      zod: 3.25.76
+      zod: 4.0.17
 
   openapi-types@12.1.3: {}
 
@@ -14024,6 +14021,4 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  zod@3.25.76: {}
-
-  zod@4.0.10: {}
+  zod@4.0.17: {}


### PR DESCRIPTION
## Summary
- upgrade zod dependency to ^4.0.17 across frontend packages
- regenerate pnpm lockfile

## Testing
- `pnpm test` *(fails: Invalid hook call: Cannot read properties of null (reading 'useState'))*

------
https://chatgpt.com/codex/tasks/task_e_689df2c1e5e08328a17dcd69d987aa07