### PR TITLE
refactor: use app hooks for typed redux

### DIFF
--- a/frontend/packages/frontend/src/app/App.tsx
+++ b/frontend/packages/frontend/src/app/App.tsx
@@ -1,16 +1,15 @@
-import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import { getAuthToken } from '@photobank/shared/auth';
 
 import { ThemeProvider } from '@/app/providers/ThemeProvider.tsx';
 import NavBar from '@/components/NavBar.tsx';
-import type { AppDispatch, RootState } from '@/app/store.ts';
+import { useAppDispatch, useAppSelector } from '@/app/hook.ts';
 import { loadMetadata } from '@/features/meta/model/metaSlice.ts';
 import { AppRoutes } from '@/routes/AppRoutes.tsx';
 
 export default function App() {
-  const dispatch = useDispatch<AppDispatch>();
-  const loaded = useSelector((s: RootState) => s.metadata.loaded);
+  const dispatch = useAppDispatch();
+  const loaded = useAppSelector((s) => s.metadata.loaded);
   const loggedIn = Boolean(getAuthToken());
 
   useEffect(() => {

--- a/frontend/packages/frontend/src/components/FilterFormFields.tsx
+++ b/frontend/packages/frontend/src/components/FilterFormFields.tsx
@@ -1,6 +1,6 @@
 import type {Control} from 'react-hook-form';
 import {useWatch} from 'react-hook-form';
-import {useSelector} from 'react-redux';
+import { useAppSelector } from '@/app/hook.ts';
 import {ChevronDownIcon} from 'lucide-react';
 import * as React from "react";
 import {format} from 'date-fns';
@@ -30,7 +30,6 @@ import {TriStateCheckbox} from '@/components/ui/tri-state-checkbox';
 import {MultiSelect} from '@/components/ui/multi-select';
 import {FormControl, FormField, FormItem, FormLabel, FormMessage,} from '@/components/ui/form';
 import type {FormData} from '@/features/filter/lib/form-schema.ts';
-import type {RootState} from '@/app/store.ts';
 import {Popover, PopoverContent, PopoverTrigger} from "@/components/ui/popover.tsx";
 
 import {Button} from './ui/button';
@@ -46,21 +45,21 @@ export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
     const [openTo, setOpenTo] = React.useState(false)
     const isAdmin = useIsAdmin()
 
-    const tags = useSelector((state: RootState) => state.metadata.tags)
-    const persons = useSelector((state: RootState) => state.metadata.persons)
+    const tags = useAppSelector((state) => state.metadata.tags)
+    const persons = useAppSelector((state) => state.metadata.persons)
 
     const selectedStorageIds = useWatch({
         control,
         name: 'storages',
     });
 
-    const storages = useSelector(
-        (state: RootState) => state.metadata.storages
+    const storages = useAppSelector(
+        (state) => state.metadata.storages
     ).map((s) => {
         return {label: s.name, value: s.id.toString()};
     });
 
-    const filteredPaths = useSelector((state: RootState) => state.metadata.paths)
+    const filteredPaths = useAppSelector((state) => state.metadata.paths)
         .filter((p) =>
             !selectedStorageIds || selectedStorageIds.length === 0
                 ? true

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useAppSelector } from '@/app/hook.ts';
 import { formatDate, getOrientation, getPlaceByGeoPoint } from '@photobank/shared';
 import type { FaceBoxDto } from '@photobank/shared/api/photobank';
 import {useIsAdmin} from '@photobank/shared';
@@ -35,7 +35,6 @@ import {Checkbox} from '@/components/ui/checkbox';
 import {useGetPhotoByIdQuery, useUpdateFaceMutation} from "@/shared/api.ts";
 import {ScoreBar} from '@/components/ScoreBar';
 import {FaceOverlay} from "@/components/FaceOverlay.tsx";
-import type {RootState} from "@/app/store.ts";
 import {FacePersonSelector} from "@/components/FacePersonSelector.tsx";
 
 
@@ -65,7 +64,7 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
     const [containerSize, setContainerSize] = useState({width: 0, height: 0});
     const [showFaceBoxes, setShowFaceBoxes] = useState(false);
     const [placeName, setPlaceName] = useState('');
-    const persons = useSelector((state: RootState) => state.metadata.persons);
+    const persons = useAppSelector((state) => state.metadata.persons);
     const isAdmin = useIsAdmin();
     const [updateFace] = useUpdateFaceMutation();
 

--- a/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -2,12 +2,10 @@ import {useForm} from 'react-hook-form';
 import {zodResolver} from '@hookform/resolvers/zod';
 import type {z} from 'zod';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import { DEFAULT_FORM_VALUES, filterFormTitle, applyFiltersButton, loadingText } from '@photobank/shared/constants';
 
 import { useAppDispatch, useAppSelector } from '@/app/hook.ts';
-import type { RootState } from '@/app/store.ts';
 import { setFilter } from '@/features/photo/model/photoSlice.ts';
 import { loadMetadata } from '@/features/meta/model/metaSlice.ts';
 import { Button } from '@/components/ui/button';
@@ -23,7 +21,7 @@ function FilterPage() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const location = useLocation();
-  const savedFilter = useSelector((state: RootState) => state.photo.filter);
+  const savedFilter = useAppSelector((state) => state.photo.filter);
   const loaded = useAppSelector((s) => s.metadata.loaded);
   const loading = useAppSelector((s) => s.metadata.loading);
 

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -1,4 +1,3 @@
-import { useSelector } from 'react-redux';
 import { useEffect, useMemo, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { PhotoItemDto } from '@photobank/shared/api/photobank';
@@ -18,8 +17,7 @@ import {
 import { useSearchPhotosMutation } from '@/shared/api.ts';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import type { RootState } from '@/app/store.ts';
-import { useAppDispatch } from '@/app/hook.ts';
+import { useAppDispatch, useAppSelector } from '@/app/hook.ts';
 import { setLastResult } from '@/features/photo/model/photoSlice.ts';
 import PhotoDetailsModal from '@/components/PhotoDetailsModal';
 
@@ -28,9 +26,9 @@ import PhotoListItemMobile from './PhotoListItemMobile';
 
 const PhotoListPage = () => {
   const dispatch = useAppDispatch();
-  const filter = useSelector((state: RootState) => state.photo.filter);
-  const persons = useSelector((state: RootState) => state.metadata.persons);
-  const tags = useSelector((state: RootState) => state.metadata.tags);
+  const filter = useAppSelector((state) => state.photo.filter);
+  const persons = useAppSelector((state) => state.metadata.persons);
+  const tags = useAppSelector((state) => state.metadata.tags);
 
   const personsMap = useMemo(
     () => Object.fromEntries(persons.map((p) => [p.id, p.name])),


### PR DESCRIPTION
## Summary
- replace useSelector with typed useAppSelector across frontend
- switch to useAppDispatch for dispatching actions

## Testing
- `pnpm test` (fails: Invalid hook call and timeouts in frontend tests)

------
https://chatgpt.com/codex/tasks/task_e_689df6635aa083289975e2bc564961cb