### PR TITLE
test(frontend): stabilize vitest

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,18 @@
+name: Frontend Tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm -w install
+        working-directory: frontend
+      - run: pnpm -C packages/frontend test:ci
+        working-directory: frontend

--- a/frontend/packages/frontend/package.json
+++ b/frontend/packages/frontend/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss,html,json}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:ci": "vitest --run --reporter=dot --coverage"
   },
   "eslintConfig": {
     "extends": "./eslint.config.mjs"
@@ -53,6 +54,7 @@
     "@eslint/js": "^9.31.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
@@ -60,6 +62,7 @@
     "@typescript-eslint/parser": "^8.38.0",
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/ui": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.31.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/frontend/packages/frontend/src/components/MetadataBadgeList.test.tsx
+++ b/frontend/packages/frontend/src/components/MetadataBadgeList.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/vitest';
 import { describe, it, expect } from 'vitest';
 import { User } from 'lucide-react';
 

--- a/frontend/packages/frontend/test-setup.ts
+++ b/frontend/packages/frontend/test-setup.ts
@@ -1,0 +1,39 @@
+import '@testing-library/jest-dom/vitest';
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as any).ResizeObserver = ResizeObserver;
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    media: query,
+    matches: false,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  value: class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() { return []; }
+  },
+});
+
+Object.defineProperty(globalThis, 'HTMLCanvasElement', {
+  writable: true,
+  value: class {
+    getContext() { return null; }
+  },
+});

--- a/frontend/packages/frontend/test/FilterFormFields.test.tsx
+++ b/frontend/packages/frontend/test/FilterFormFields.test.tsx
@@ -7,14 +7,6 @@ import metaReducer from '../src/features/meta/model/metaSlice';
 import { Form } from '../src/components/ui/form';
 import { describe, it, beforeEach, expect, vi } from 'vitest';
 
-class RO {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
-// @ts-ignore
-global.ResizeObserver = RO;
-
 declare module '@testing-library/react' {
   interface RenderOptions {
     wrapper?: React.ComponentType;

--- a/frontend/packages/frontend/test/FilterPage.test.tsx
+++ b/frontend/packages/frontend/test/FilterPage.test.tsx
@@ -14,14 +14,6 @@ vi.mock('@photobank/shared', async () => {
   return { ...actual, useIsAdmin: () => false };
 });
 
-class RO {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
-// @ts-ignore
-global.ResizeObserver = RO;
-
 const initialMeta = {
   tags: [],
   persons: [],

--- a/frontend/packages/frontend/test/LoginPage.test.tsx
+++ b/frontend/packages/frontend/test/LoginPage.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
@@ -7,13 +8,6 @@ import metaReducer from '../src/features/meta/model/metaSlice';
 import authReducer from '../src/features/auth/model/authSlice';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-class RO {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
-// @ts-ignore
-global.ResizeObserver = RO;
 
 const renderPage = async (loginMock: any) => {
   vi.doMock('@photobank/shared/api/photobank', () => ({
@@ -43,9 +37,9 @@ describe('LoginPage', () => {
     const loginMock = vi.fn().mockRejectedValue(new Error('bad'));
     await renderPage(loginMock);
 
-    fireEvent.input(screen.getByLabelText('Email'), { target: { value: 'e@e.com' } });
-    fireEvent.input(screen.getByLabelText('Password'), { target: { value: 'p' } });
-    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+    await userEvent.type(screen.getByLabelText('Email'), 'e@e.com');
+    await userEvent.type(screen.getByLabelText('Password'), 'p');
+    await userEvent.click(screen.getByRole('button', { name: /login/i }));
 
     await screen.findByRole('alert');
     expect(loginMock).toHaveBeenCalled();
@@ -60,11 +54,11 @@ describe('LoginPage', () => {
 
     expect(passwordField.getAttribute('type')).toBe('password');
 
-    fireEvent.click(toggle);
+    await userEvent.click(toggle);
     expect(passwordField.getAttribute('type')).toBe('text');
     expect(toggle.textContent).toBe('Hide password');
 
-    fireEvent.click(toggle);
+    await userEvent.click(toggle);
     expect(passwordField.getAttribute('type')).toBe('password');
   });
 });

--- a/frontend/packages/frontend/test/RegisterPage.test.tsx
+++ b/frontend/packages/frontend/test/RegisterPage.test.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-class RO {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-}
-// @ts-ignore
-global.ResizeObserver = RO;
 
 const renderPage = async (regMock: any) => {
   vi.doMock('../src/shared/api.ts', () => ({
@@ -37,9 +31,9 @@ describe('RegisterPage', () => {
       .fn()
       .mockReturnValue({ unwrap: () => Promise.resolve({}) });
     await renderPage(regMock);
-    fireEvent.input(screen.getByLabelText('Email'), { target: { value: 'a@b.co' } });
-    fireEvent.input(screen.getByLabelText('Password'), { target: { value: '123' } });
-    fireEvent.click(screen.getByRole('button', { name: /register/i }));
+    await userEvent.type(screen.getByLabelText('Email'), 'a@b.co');
+    await userEvent.type(screen.getByLabelText('Password'), '123');
+    await userEvent.click(screen.getByRole('button', { name: /register/i }));
     await waitFor(() => {
       expect(regMock).toHaveBeenCalledWith({ email: 'a@b.co', password: '123' });
     });

--- a/frontend/packages/frontend/vitest.config.ts
+++ b/frontend/packages/frontend/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     }
   },
   test: {
-    environment: 'jsdom'
+    environment: 'jsdom',
+    setupFiles: './test-setup.ts',
+    globals: true,
+    css: true
   }
 });

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/node':
         specifier: ^24.1.0
         version: 24.1.0
@@ -2383,6 +2386,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -9108,6 +9117,10 @@ snapshots:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
   '@tsconfig/node10@1.0.11': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -9461,7 +9474,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.1.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.1.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@24.1.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary
- add a shared Vitest setup with DOM shims
- rewrite UI tests to use user-event and remove per-test shims
- wire up CI workflow for frontend tests with coverage

## Testing
- `pnpm -w install`
- `pnpm -C packages/frontend lint`
- `pnpm -C packages/frontend build` *(fails: Type 'TagDto[] | undefined' is not assignable to type 'TagDto[]')*
- `pnpm -C packages/frontend test`
- `pnpm -C frontend/packages/frontend test:ci`


------
https://chatgpt.com/codex/tasks/task_e_689dfd88c3808328b6b1c466ca48d915