### PR TITLE
Configure Serilog logging and health checks

### DIFF
--- a/backend/PhotoBank.Api/appsettings.json
+++ b/backend/PhotoBank.Api/appsettings.json
@@ -11,14 +11,25 @@
     }
   },
   "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.AspNetCore": "Warning",
-        "System": "Warning"
+        "System": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
       }
-    }
+    },
+    "Enrich": [ "FromLogContext", "WithProcessId", "WithThreadId", "WithMachineName" ],
+    "WriteTo": [
+      { "Name": "Console", "Args": { "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact" } },
+      { "Name": "File", "Args": { "path": "logs/api-.ndjson", "rollingInterval": "Day", "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact" } }
+    ]
+  },
+  "HealthChecks": {
+    "LivenessPath": "/liveness",
+    "ReadinessPath": "/health"
   },
   "AllowedHosts": "*",
   "Jwt": {


### PR DESCRIPTION
## Summary
- enhance Serilog configuration with console and file sinks and enrichment
- add liveness and readiness health check paths

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: A network-related or instance-specific error occurred while establishing a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_689e2ba27d008328ae38e2985ab04e46