### PR TITLE
Configure DbContext pooling and SQL Server options

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -17,6 +17,8 @@ using Serilog;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Serilog.Formatting.Compact;
 using FluentValidation;
 using FluentValidation.AspNetCore;
@@ -77,19 +79,25 @@ namespace PhotoBank.Api
 
             builder.Services.AddHttpContextAccessor();
 
-            builder.Services.AddDbContext<PhotoBankDbContext>(options =>
+            builder.Services.AddDbContextPool<PhotoBankDbContext>((sp, options) =>
             {
-                options.UseLoggerFactory(LoggerFactory.Create(loggingBuilder => loggingBuilder.AddDebug()));
-                options.UseSqlServer(connectionString,
-                    optionsBuilder =>
+                options.UseLoggerFactory(sp.GetRequiredService<ILoggerFactory>());
+                options
+                    .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+                    .EnableDetailedErrors(builder.Environment.IsDevelopment())
+                    .EnableSensitiveDataLogging(builder.Environment.IsDevelopment());
+
+                options.UseSqlServer(
+                    connectionString,
+                    sql =>
                     {
-                        optionsBuilder.MigrationsAssembly(typeof(PhotoBankDbContext).GetTypeInfo().Assembly.GetName()
-                            .Name);
-                        optionsBuilder.UseNetTopologySuite();
-                        optionsBuilder.CommandTimeout(120);
+                        sql.MigrationsAssembly(typeof(PhotoBankDbContext).GetTypeInfo().Assembly.GetName().Name);
+                        sql.UseNetTopologySuite();
+                        sql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(5), null);
+                        sql.CommandTimeout(60);
+                        sql.MaxBatchSize(128);
+                        sql.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
                     });
-                options.EnableSensitiveDataLogging();
-                options.EnableDetailedErrors();
             });
 
             builder.Services.AddDefaultIdentity<ApplicationUser>()


### PR DESCRIPTION
## Summary
- use DbContext pooling with default no-tracking queries
- enable detailed and sensitive logging in development
- tune SQL Server provider with retry policy, command timeout, batch size and query splitting

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: ImageMagick.MagickMissingDelegateErrorException in FaceEnricherAws)*

------
https://chatgpt.com/codex/tasks/task_e_689e2c99af188328ba5f9f6c89a5bb7d