### PR TITLE
Use no-tracking queries for read operations

### DIFF
--- a/backend/PhotoBank.Api/Controllers/Admin/UsersController.cs
+++ b/backend/PhotoBank.Api/Controllers/Admin/UsersController.cs
@@ -17,7 +17,7 @@ public class UsersController(UserManager<ApplicationUser> userManager) : Control
     [ProducesResponseType(typeof(IEnumerable<UserWithClaimsDto>), StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<UserWithClaimsDto>>> GetAllAsync()
     {
-        var users = await userManager.Users.ToListAsync();
+        var users = await userManager.Users.AsNoTracking().ToListAsync();
         var result = new List<UserWithClaimsDto>();
         foreach (var user in users)
         {

--- a/backend/PhotoBank.Api/Middleware/ImpersonationMiddleware.cs
+++ b/backend/PhotoBank.Api/Middleware/ImpersonationMiddleware.cs
@@ -25,7 +25,7 @@ public class ImpersonationMiddleware
 
         if (context.Request.Headers.TryGetValue(HeaderName, out var username) && !string.IsNullOrWhiteSpace(username))
         {
-            var user = await userManager.Users.FirstOrDefaultAsync(u => u.Telegram == username.ToString());
+            var user = await userManager.Users.AsNoTracking().FirstOrDefaultAsync(u => u.Telegram == username.ToString());
             if (user is not null)
             {
                 var userClaims = await userManager.GetClaimsAsync(user);

--- a/backend/PhotoBank.BlobMigrator/Infrastructure/Migration/BlobMigrationHostedService.cs
+++ b/backend/PhotoBank.BlobMigrator/Infrastructure/Migration/BlobMigrationHostedService.cs
@@ -75,7 +75,7 @@ public sealed class BlobMigrationHostedService : IHostedService
                    OR (p.Thumbnail IS NOT NULL AND (p.S3Key_Thumbnail IS NULL OR p.S3Key_Thumbnail = ''))
                 ORDER BY p.Id
                 """, _opt.BatchSize
-            ).ToListAsync(ct);
+            ).AsNoTracking().ToListAsync(ct);
         }
 
         _log.LogInformation("Photos to process: {Count}", ids.Count);
@@ -117,13 +117,13 @@ public sealed class BlobMigrationHostedService : IHostedService
             """
             SELECT CASE WHEN p.Preview IS NOT NULL AND (p.S3Key_Preview IS NULL OR p.S3Key_Preview='') THEN 1 ELSE 0 END
             FROM Photos p WITH (NOLOCK) WHERE p.Id = {0}
-            """, id).FirstOrDefaultAsync(ct) == 1;
+            """, id).AsNoTracking().FirstOrDefaultAsync(ct) == 1;
 
         var needThumb = await db.Database.SqlQueryRaw<int>(
             """
             SELECT CASE WHEN p.Thumbnail IS NOT NULL AND (p.S3Key_Thumbnail IS NULL OR p.S3Key_Thumbnail='') THEN 1 ELSE 0 END
             FROM Photos p WITH (NOLOCK) WHERE p.Id = {0}
-            """, id).FirstOrDefaultAsync(ct) == 1;
+            """, id).AsNoTracking().FirstOrDefaultAsync(ct) == 1;
 
         if (!needPreview && !needThumb) return (false, true);
 
@@ -189,7 +189,7 @@ public sealed class BlobMigrationHostedService : IHostedService
                 WHERE f.Image IS NOT NULL AND (f.S3Key_Image IS NULL OR f.S3Key_Image = '')
                 ORDER BY f.Id
                 """, _opt.BatchSize
-            ).ToListAsync(ct);
+            ).AsNoTracking().ToListAsync(ct);
         }
 
         _log.LogInformation("Faces to process: {Count}", ids.Count);
@@ -230,7 +230,7 @@ public sealed class BlobMigrationHostedService : IHostedService
             """
             SELECT CASE WHEN f.Image IS NOT NULL AND (f.S3Key_Image IS NULL OR f.S3Key_Image='') THEN 1 ELSE 0 END
             FROM Faces f WITH (NOLOCK) WHERE f.Id = {0}
-            """, id).FirstOrDefaultAsync(ct) == 1;
+            """, id).AsNoTracking().FirstOrDefaultAsync(ct) == 1;
 
         if (!need) return (false, true);
 

--- a/backend/PhotoBank.Services/Api/PhotoService.cs
+++ b/backend/PhotoBank.Services/Api/PhotoService.cs
@@ -62,11 +62,13 @@ public class PhotoService : IPhotoService
         _cache = cache;
         _tags = new Lazy<Task<IReadOnlyList<TagDto>>>(() =>
             GetCachedAsync("tags", async () => (IReadOnlyList<TagDto>)await tagRepository.GetAll()
+                .AsNoTracking()
                 .OrderBy(p => p.Name)
                 .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
                 .ToListAsync()));
         _paths = new Lazy<Task<IReadOnlyList<PathDto>>>(() =>
             GetCachedAsync("paths", async () => (IReadOnlyList<PathDto>)await photoRepository.GetAll()
+                .AsNoTracking()
                 .ProjectTo<PathDto>(_mapper.ConfigurationProvider)
                 .Distinct()
                 .OrderBy(p => p.Path)
@@ -152,7 +154,8 @@ public class PhotoService : IPhotoService
         var photo = await _photoRepository.GetAsync(id,
             q => q.Include(p => p.Faces).ThenInclude(f => f.Person)
                    .Include(p => p.Captions)
-                   .Include(p => p.PhotoTags).ThenInclude(t => t.Tag));
+                   .Include(p => p.PhotoTags).ThenInclude(t => t.Tag)
+                   .AsNoTrackingWithIdentityResolution());
 
         return _mapper.Map<Photo, PhotoDto>(photo);
     }
@@ -160,6 +163,7 @@ public class PhotoService : IPhotoService
     public async Task<IEnumerable<PersonDto>> GetAllPersonsAsync()
     {
         return await _personRepository.GetAll()
+            .AsNoTracking()
             .OrderBy(p => p.Name)
             .ProjectTo<PersonDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
@@ -170,6 +174,7 @@ public class PhotoService : IPhotoService
     public async Task<IEnumerable<StorageDto>> GetAllStoragesAsync()
     {
         return await _storageRepository.GetAll()
+            .AsNoTracking()
             .OrderBy(p => p.Name)
             .ProjectTo<StorageDto>(_mapper.ConfigurationProvider)
             .ToListAsync();
@@ -237,6 +242,7 @@ public class PhotoService : IPhotoService
         if (id.HasValue)
         {
             hash = await _photoRepository.GetByCondition(p => p.Id == id.Value)
+                .AsNoTracking()
                 .Select(p => p.ImageHash)
                 .SingleOrDefaultAsync();
         }

--- a/backend/PhotoBank.Services/Enrichers/CategoryEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/CategoryEnricher.cs
@@ -35,11 +35,11 @@ namespace PhotoBank.Services.Enrichers
             List<Category> existing;
             try
             {
-                existing = await query.ToListAsync(cancellationToken);
+                existing = await query.AsNoTracking().ToListAsync(cancellationToken);
             }
             catch (InvalidOperationException)
             {
-                existing = query.ToList();
+                existing = query.AsNoTracking().ToList();
             }
 
             var map = existing.ToDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);

--- a/backend/PhotoBank.Services/Enrichers/ObjectPropertyEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/ObjectPropertyEnricher.cs
@@ -34,11 +34,11 @@ namespace PhotoBank.Services.Enrichers
             List<PropertyName> existing;
             try
             {
-                existing = await query.ToListAsync(cancellationToken);
+                existing = await query.AsNoTracking().ToListAsync(cancellationToken);
             }
             catch (InvalidOperationException)
             {
-                existing = query.ToList();
+                existing = query.AsNoTracking().ToList();
             }
 
             var map = existing.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);

--- a/backend/PhotoBank.Services/Enrichers/TagEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/TagEnricher.cs
@@ -35,11 +35,11 @@ namespace PhotoBank.Services.Enrichers
             List<Tag> existing;
             try
             {
-                existing = await query.ToListAsync(ct);
+                existing = await query.AsNoTracking().ToListAsync(ct);
             }
             catch (InvalidOperationException)
             {
-                existing = query.ToList();
+                existing = query.AsNoTracking().ToList();
             }
 
             var map = existing.ToDictionary(t => t.Name, StringComparer.OrdinalIgnoreCase);

--- a/backend/PhotoBank.Services/FaceServiceAws.cs
+++ b/backend/PhotoBank.Services/FaceServiceAws.cs
@@ -60,7 +60,7 @@ namespace PhotoBank.Services
                 _logger.LogCritical(e, "error");
             }
 
-            var dbPersons = await _personRepository.GetAll().ToListAsync();
+            var dbPersons = await _personRepository.GetAll().AsNoTracking().ToListAsync();
             var servicePersons = await _faceClient.ListUsersAsync(new ListUsersRequest
             {
                 CollectionId = PersonGroupId,
@@ -98,7 +98,7 @@ namespace PhotoBank.Services
 
         public async Task SyncFacesToPersonAsync()
         {
-            var dbPersonGroupFaces = await _personGroupFaceRepository.GetAll().Include(p => p.Person).ToListAsync();
+            var dbPersonGroupFaces = await _personGroupFaceRepository.GetAll().Include(p => p.Person).AsNoTracking().ToListAsync();
 
             var groupBy = dbPersonGroupFaces.GroupBy(x => new { x.PersonId }, p => new { p.FaceId, p.ExternalGuid },
                 (key, g) => new { Key = key, Faces = g.ToList() });

--- a/backend/PhotoBank.Services/PhotoProcessor.cs
+++ b/backend/PhotoBank.Services/PhotoProcessor.cs
@@ -104,6 +104,7 @@ namespace PhotoBank.Services
             var files = await _photoRepository
                 .GetAll()
                 .Include(p => p.Files)
+                .AsNoTracking()
                 .Where(p => p.StorageId == storage.Id && p.FaceIdentifyStatus == FaceIdentifyStatus.Undefined)
                 .Select(p => new PhotoFilePath
                 {
@@ -120,6 +121,7 @@ namespace PhotoBank.Services
         {
             var files = await _photoRepository
                 .GetAll()
+                .AsNoTracking()
                 .Where(p => p.StorageId == storage.Id && p.TakenDate == null)
                 .Select(p => new PhotoFilePath
                 {

--- a/backend/PhotoBank.Services/SyncService.cs
+++ b/backend/PhotoBank.Services/SyncService.cs
@@ -52,6 +52,7 @@ namespace PhotoBank.Services
             var storageFiles = await _fileRepository
                 .GetByCondition(f => f.Photo.Storage.Id == storage.Id)
                 .Include(f => f.Photo)
+                .AsNoTracking()
                 .Select(f => new
                 {
                     f.Id,


### PR DESCRIPTION
## Summary
- place `AsNoTracking` before projection for cached tag and path lookups
- move `AsNoTracking` before DTO projection when listing persons or storages
- avoid tracking when fetching image hash for duplicate detection and revert test helpers to default tracking

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: 21 failed, 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689e3dfaf5dc83289a4f24ac617aae5a