### PR TITLE
Add indexes and soft delete filter for large tables

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -55,6 +55,9 @@ namespace PhotoBank.DbContext.DbContext
             modelBuilder.Entity<Photo>()
                 .HasIndex(p => new { p.IsRacyContent });
 
+            modelBuilder.Entity<Photo>()
+                .HasIndex(p => new { p.StorageId, p.TakenDate });
+
             modelBuilder.Entity<PhotoTag>()
                 .HasKey(t => new { t.PhotoId, t.TagId });
 
@@ -97,12 +100,12 @@ namespace PhotoBank.DbContext.DbContext
                 .HasOne(t => t.Face)
                 .WithOne(t => t.PersonGroupFace);
 
-            modelBuilder.Entity<File>()
-                .HasIndex(p => new { p.Name });
-
-            modelBuilder.Entity<File>()
-                .HasIndex(p => new { p.Name, p.PhotoId })
-                .IsUnique();
+            modelBuilder.Entity<File>(e =>
+            {
+                e.HasQueryFilter(f => !f.IsDeleted);
+                e.HasIndex(p => p.Name);
+                e.HasIndex(p => new { p.Name, p.PhotoId }).IsUnique();
+            });
 
             modelBuilder.Entity<Face>()
                 .HasIndex(p => p.IdentityStatus)
@@ -124,6 +127,13 @@ namespace PhotoBank.DbContext.DbContext
             modelBuilder.Entity<Photo>()
                 .HasIndex(p => p.StorageId)
                 .IncludeProperties(p => p.RelativePath);
+
+            modelBuilder.Entity<Tag>(e =>
+            {
+                e.HasIndex(x => x.Name)
+                    .HasDatabaseName("IX_Tag_Name")
+                    .IsClustered(false);
+            });
 
             modelBuilder.Entity<Enricher>()
                 .HasIndex(u => u.Name)


### PR DESCRIPTION
## Summary
- index Photo by StorageId and TakenDate for faster sorting and filtering
- enforce soft-delete behavior on File with a query filter and indexes
- support prefix searches on Tag names via non-clustered index

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689e455cadb88328993ad28d511a8530