### PR TITLE
Use compiled EF query for photo retrieval

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/CompiledQueries.cs
+++ b/backend/PhotoBank.DbContext/DbContext/CompiledQueries.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using PhotoBank.DbContext.Models;
+using System.Linq;
+
+namespace PhotoBank.DbContext.DbContext;
+
+public static class CompiledQueries
+{
+    public static readonly Func<PhotoBankDbContext, int, Task<Photo?>> PhotoById =
+        EF.CompileAsyncQuery((PhotoBankDbContext db, int id) =>
+            db.Photos.AsNoTracking()
+                .Include(p => p.PhotoTags).ThenInclude(t => t.Tag)
+                .Include(p => p.Faces).ThenInclude(f => f.Person)
+                .Include(p => p.Captions)
+                .FirstOrDefault(p => p.Id == id));
+}

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -42,7 +42,9 @@ namespace PhotoBank.UnitTests.Services
             var services = new ServiceCollection();
             services.AddDbContext<PhotoBankDbContext>(o => o.UseInMemoryDatabase(dbName));
             var provider = services.BuildServiceProvider();
+            var context = provider.GetRequiredService<PhotoBankDbContext>();
             return new PhotoService(
+                context,
                 new Repository<Photo>(provider),
                 new Repository<Person>(provider),
                 new Repository<Face>(provider),

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -45,6 +45,7 @@ namespace PhotoBank.UnitTests.Services
             await context.SaveChangesAsync();
 
             var service = new PhotoService(
+                context,
                 new Repository<Photo>(provider),
                 new Repository<Person>(provider),
                 new Repository<Face>(provider),
@@ -79,6 +80,7 @@ namespace PhotoBank.UnitTests.Services
             await context.SaveChangesAsync();
 
             var service = new PhotoService(
+                context,
                 new Repository<Photo>(provider),
                 new Repository<Person>(provider),
                 new Repository<Face>(provider),
@@ -117,6 +119,7 @@ namespace PhotoBank.UnitTests.Services
             await context.SaveChangesAsync();
 
             var service = new PhotoService(
+                context,
                 new Repository<Photo>(provider),
                 new Repository<Person>(provider),
                 new Repository<Face>(provider),


### PR DESCRIPTION
## Summary
- add CompiledQueries with precompiled PhotoById lookup
- use CompiledQueries.PhotoById in PhotoService
- adjust unit tests for new PhotoService constructor

## Testing
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: NoEncodeDelegateForThisImageFormat `XC`)*

------
https://chatgpt.com/codex/tasks/task_e_689e4750d0cc8328a4d41f30d76188cd