### PR TITLE
feat: add provider fields to person models

### DIFF
--- a/backend/PhotoBank.DbContext/Models/Person.cs
+++ b/backend/PhotoBank.DbContext/Models/Person.cs
@@ -10,6 +10,8 @@ namespace PhotoBank.DbContext.Models
         [Required]
         public string Name { get; set; }
         public DateTime? DateOfBirth { get; set; }
+        public string? Provider { get; set; }  // "Azure" | "Aws" | "Local"
+        public string? ExternalId { get; set; } // строковый внешний ID провайдера
         public Guid ExternalGuid { get; set; }
         public IEnumerable<PersonGroupFace> PersonGroupFaces { get; set; }
         public IEnumerable<Face> Faces { get; set; }

--- a/backend/PhotoBank.DbContext/Models/PersonGroupFace.cs
+++ b/backend/PhotoBank.DbContext/Models/PersonGroupFace.cs
@@ -11,6 +11,8 @@ namespace PhotoBank.DbContext.Models
         public int FaceId { get; set; }
         public Person Person { get; set; }
         public Face Face { get; set; }
+        public string? Provider { get; set; }
+        public string? ExternalId { get; set; } // вместо Guid для AWS/Local, Azure можно сохранять ToString()
         public Guid ExternalGuid { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- add Provider and ExternalId fields to Person and PersonGroupFace models

## Testing
- `dotnet build backend/PhotoBank.DbContext/PhotoBank.DbContext.csproj`
- `dotnet test backend/PhotoBank.sln` *(fails: workloads maui-tizen wasm-tools missing)*
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build` *(terminated after hanging)*

------
https://chatgpt.com/codex/tasks/task_e_689edfb32ff8832891c561fa0f39b617