### PR TITLE
Add face embedding entity and repository

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Logging;
+using System.Reflection;
 
 namespace PhotoBank.DbContext.DbContext
 {
@@ -32,6 +33,7 @@ namespace PhotoBank.DbContext.DbContext
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.ApplyConfigurationsFromAssembly(System.Reflection.Assembly.Load("PhotoBank.Services"));
             base.OnModelCreating(modelBuilder);
 
             modelBuilder.Entity<Photo>()

--- a/backend/PhotoBank.Services/FaceRecognition/Local/FaceEmbedding.cs
+++ b/backend/PhotoBank.Services/FaceRecognition/Local/FaceEmbedding.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PhotoBank.Services.FaceRecognition.Local;
+
+public class FaceEmbedding
+{
+    public int FaceId { get; set; }
+    public int PersonId { get; set; }
+    public string Model { get; set; } = "buffalo_l";
+    public byte[] Vector { get; set; } = Array.Empty<byte>();
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}
+
+public sealed class FaceEmbeddingConfiguration : IEntityTypeConfiguration<FaceEmbedding>
+{
+    public void Configure(EntityTypeBuilder<FaceEmbedding> b)
+    {
+        b.ToTable("FaceEmbeddings");
+        b.HasKey(x => x.FaceId);
+        b.Property(x => x.Vector).HasColumnType("varbinary(max)");
+        b.HasIndex(x => x.PersonId);
+    }
+}
+
+public interface IFaceEmbeddingRepository
+{
+    Task UpsertAsync(int personId, int faceId, float[] vector, string model, CancellationToken ct);
+    Task<IReadOnlyList<(int PersonId, int FaceId, float[] Vector)>> GetAllAsync(CancellationToken ct);
+}

--- a/backend/PhotoBank.Services/FaceRecognition/Local/FaceEmbeddingRepository.cs
+++ b/backend/PhotoBank.Services/FaceRecognition/Local/FaceEmbeddingRepository.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using EfDbContext = Microsoft.EntityFrameworkCore.DbContext;
+
+namespace PhotoBank.Services.FaceRecognition.Local;
+
+public sealed class FaceEmbeddingRepository : IFaceEmbeddingRepository
+{
+    private readonly EfDbContext _db;
+    public FaceEmbeddingRepository(EfDbContext db) => _db = db;
+
+    public async Task UpsertAsync(int personId, int faceId, float[] vector, string model, CancellationToken ct)
+    {
+        var bytes = MemoryMarshal.AsBytes(vector.AsSpan()).ToArray();
+        var set = _db.Set<FaceEmbedding>();
+        var entity = await set.FirstOrDefaultAsync(x => x.FaceId == faceId, ct);
+        if (entity is null)
+        {
+            entity = new FaceEmbedding { FaceId = faceId, PersonId = personId, Model = model, Vector = bytes };
+            set.Add(entity);
+        }
+        else
+        {
+            entity.PersonId = personId;
+            entity.Model = model;
+            entity.Vector = bytes;
+        }
+        await _db.SaveChangesAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<(int PersonId, int FaceId, float[] Vector)>> GetAllAsync(CancellationToken ct)
+    {
+        var rows = await _db.Set<FaceEmbedding>()
+            .AsNoTracking()
+            .Select(x => new { x.PersonId, x.FaceId, x.Vector })
+            .ToListAsync(ct);
+        return rows.Select(x => (x.PersonId, x.FaceId, MemoryMarshal.Cast<byte, float>(x.Vector.AsSpan()).ToArray())).ToList();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `FaceEmbedding` entity with EF Core configuration
- add repository for saving and retrieving face embeddings
- register configuration in `PhotoBankDbContext`

## Testing
- `~/.dotnet/dotnet test PhotoBank.Backend.sln` *(fails: MagickMissingDelegateErrorException)*

------
https://chatgpt.com/codex/tasks/task_e_689ee3ae3bc88328b672c213a9cec963