### PR TITLE
Add face recognition DI options and registration

### DIFF
--- a/backend/PhotoBank.Services/FaceRecognition/FaceProviderOptions.cs
+++ b/backend/PhotoBank.Services/FaceRecognition/FaceProviderOptions.cs
@@ -1,0 +1,6 @@
+namespace PhotoBank.Services.FaceRecognition;
+
+public sealed class FaceProviderOptions
+{
+    public Abstractions.FaceProviderKind Default { get; init; } = Abstractions.FaceProviderKind.Local;
+}

--- a/backend/PhotoBank.Services/FaceRecognition/Local/LocalInsightFaceOptions.cs
+++ b/backend/PhotoBank.Services/FaceRecognition/Local/LocalInsightFaceOptions.cs
@@ -1,0 +1,10 @@
+namespace PhotoBank.Services.FaceRecognition.Local;
+
+public sealed class LocalInsightFaceOptions
+{
+    public string BaseUrl { get; init; } = "http://localhost:18081";
+    public int MaxParallelism { get; init; } = 6;
+    public string Model { get; init; } = "buffalo_l";
+    public float FaceMatchThreshold { get; init; } = 0.45f; // косинус
+    public int TopK { get; init; } = 10;
+}

--- a/backend/PhotoBank.Services/FaceRecognition/ServiceCollectionExtensions.cs
+++ b/backend/PhotoBank.Services/FaceRecognition/ServiceCollectionExtensions.cs
@@ -1,0 +1,54 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using PhotoBank.Services.FaceRecognition.Abstractions;
+using PhotoBank.Services.FaceRecognition.Local;
+
+namespace PhotoBank.Services.FaceRecognition;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddFaceRecognition(this IServiceCollection services, IConfiguration cfg)
+    {
+        services.Configure<FaceProviderOptions>(cfg.GetSection("FaceProvider"));
+        services.Configure<LocalInsightFaceOptions>(cfg.GetSection("LocalInsightFace"));
+
+        services.AddHttpClient<ILocalInsightFaceClient, LocalInsightFaceHttpClient>();
+        services.AddScoped<IFaceEmbeddingRepository, FaceEmbeddingRepository>();
+
+        services.AddScoped<LocalInsightFaceProvider>(); // IFaceProvider Local
+
+        services.AddScoped<IFaceProviderFactory, FaceProviderFactory>();
+        services.AddScoped(provider =>
+        {
+            var factory = provider.GetRequiredService<IFaceProviderFactory>();
+            return factory.Get(); // UnifiedFaceService в следующем шаге
+        });
+
+        return services;
+    }
+}
+
+public interface IFaceProviderFactory
+{
+    IFaceProvider Get(Abstractions.FaceProviderKind? kind = null);
+}
+
+public sealed class FaceProviderFactory : IFaceProviderFactory
+{
+    private readonly IServiceProvider _sp;
+    private readonly FaceProviderOptions _opts;
+    public FaceProviderFactory(IServiceProvider sp, Microsoft.Extensions.Options.IOptions<FaceProviderOptions> opts)
+    {
+        _sp = sp; _opts = opts.Value;
+    }
+
+    public IFaceProvider Get(Abstractions.FaceProviderKind? kind = null)
+        => (kind ?? _opts.Default) switch
+        {
+            Abstractions.FaceProviderKind.Local => _sp.GetRequiredService<LocalInsightFaceProvider>(),
+            // Abstractions.FaceProviderKind.Azure => _sp.GetRequiredService<AzureFaceProvider>(),
+            // Abstractions.FaceProviderKind.Aws => _sp.GetRequiredService<AwsFaceProvider>(),
+            _ => _sp.GetRequiredService<LocalInsightFaceProvider>()
+        };
+}


### PR DESCRIPTION
## Summary
- add options for face provider selection and local InsightFace
- provide service collection extension with factory for selecting provider

## Testing
- `dotnet build backend/PhotoBank.Services/PhotoBank.Services.csproj` *(fails: LocalInsightFaceProvider, ILocalInsightFaceClient missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ee719bf6483289fb144080cb6360f