### PR TITLE
feat(api): add face recognition service

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -9,6 +9,7 @@ using PhotoBank.DbContext.Models;
 using Microsoft.AspNetCore.Identity;
 using PhotoBank.Services;
 using PhotoBank.Api.Middleware;
+using PhotoBank.Services.FaceRecognition;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
@@ -157,6 +158,9 @@ namespace PhotoBank.Api
                     return null;
                 });
             });
+
+            builder.Services.AddFaceRecognition(builder.Configuration);
+            builder.Services.AddScoped<UnifiedFaceService>();
 
             RegisterServicesForApi.Configure(builder.Services);
             builder.Services.AddAutoMapper(cfg =>

--- a/backend/PhotoBank.Api/appsettings.json
+++ b/backend/PhotoBank.Api/appsettings.json
@@ -36,6 +36,14 @@
     "Key": "vxyuEARxN5CmairVgb8hcXd3g12wMg5mgUN643ao9Ic=",
     "Issuer": "PhotoBank.Api",
     "Audience": "PhotoBank.Api"
+  },
+  "FaceProvider": { "Default": "Local" },
+  "LocalInsightFace": {
+    "BaseUrl": "http://localhost:18081",
+    "MaxParallelism": 6,
+    "Model": "buffalo_l",
+    "FaceMatchThreshold": 0.45,
+    "TopK": 10
   }
 }
 


### PR DESCRIPTION
## Summary
- register face recognition services and unified face service
- configure default local insight face provider

## Testing
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: MagickMissingDelegateErrorException)*

------
https://chatgpt.com/codex/tasks/task_e_689ef18270d0832890ae314b15b6650a