### PR TITLE
feat: add azure and aws face providers

### DIFF
--- a/backend/PhotoBank.Services/FaceRecognition/ServiceCollectionExtensions.cs
+++ b/backend/PhotoBank.Services/FaceRecognition/ServiceCollectionExtensions.cs
@@ -1,7 +1,13 @@
 using System;
+using Amazon;
+using Amazon.Rekognition;
+using Microsoft.Azure.CognitiveServices.Vision.Face;
+using Microsoft.Azure.CognitiveServices.Vision.Face.Models;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using PhotoBank.Services.FaceRecognition.Abstractions;
+using PhotoBank.Services.FaceRecognition.Aws;
+using PhotoBank.Services.FaceRecognition.Azure;
 using PhotoBank.Services.FaceRecognition.Local;
 
 namespace PhotoBank.Services.FaceRecognition;
@@ -12,11 +18,27 @@ public static class ServiceCollectionExtensions
     {
         services.Configure<FaceProviderOptions>(cfg.GetSection("FaceProvider"));
         services.Configure<LocalInsightFaceOptions>(cfg.GetSection("LocalInsightFace"));
+        services.Configure<RekognitionOptions>(cfg.GetSection("AwsRekognition"));
+        services.Configure<AzureFaceOptions>(cfg.GetSection("AzureFace"));
 
         services.AddHttpClient<ILocalInsightFaceClient, LocalInsightFaceHttpClient>();
         services.AddScoped<IFaceEmbeddingRepository, FaceEmbeddingRepository>();
 
+        services.AddSingleton<AmazonRekognitionClient>(_ =>
+        {
+            return new AmazonRekognitionClient(RegionEndpoint.EUNorth1);
+        });
+
+        services.AddSingleton<IFaceClient>(sp =>
+        {
+            var o = sp.GetRequiredService<Microsoft.Extensions.Options.IOptions<AzureFaceOptions>>().Value;
+            var client = new FaceClient(new ApiKeyServiceClientCredentials(o.Key)) { Endpoint = o.Endpoint };
+            return client;
+        });
+
         services.AddScoped<LocalInsightFaceProvider>(); // IFaceProvider Local
+        services.AddScoped<AzureFaceProvider>();
+        services.AddScoped<AwsFaceProvider>();
 
         services.AddScoped<IFaceProviderFactory, FaceProviderFactory>();
         services.AddScoped(provider =>
@@ -47,8 +69,8 @@ public sealed class FaceProviderFactory : IFaceProviderFactory
         => (kind ?? _opts.Default) switch
         {
             Abstractions.FaceProviderKind.Local => _sp.GetRequiredService<LocalInsightFaceProvider>(),
-            // Abstractions.FaceProviderKind.Azure => _sp.GetRequiredService<AzureFaceProvider>(),
-            // Abstractions.FaceProviderKind.Aws => _sp.GetRequiredService<AwsFaceProvider>(),
+            Abstractions.FaceProviderKind.Azure => _sp.GetRequiredService<AzureFaceProvider>(),
+            Abstractions.FaceProviderKind.Aws   => _sp.GetRequiredService<AwsFaceProvider>(),
             _ => _sp.GetRequiredService<LocalInsightFaceProvider>()
         };
 }


### PR DESCRIPTION
## Summary
- register AWS Rekognition and Azure Face service clients
- wire up AwsFaceProvider and AzureFaceProvider in factory

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: MagickMissingDelegateErrorException)*

------
https://chatgpt.com/codex/tasks/task_e_689f024e73608328b0dacf157d6ad7d7