### PR TITLE
Configure face recognition providers

### DIFF
--- a/backend/PhotoBank.Api/appsettings.json
+++ b/backend/PhotoBank.Api/appsettings.json
@@ -44,6 +44,23 @@
     "Model": "buffalo_l",
     "FaceMatchThreshold": 0.45,
     "TopK": 10
+  },
+
+  "AwsRekognition": {
+    "CollectionId": "my-circle-person-group",
+    "MaxParallelism": 6,
+    "FaceMatchThreshold": 90.0,
+    "QualityFilter": "AUTO"
+  },
+
+  "AzureFace": {
+    "Endpoint": "https://<your-face-endpoint>.cognitiveservices.azure.com/",
+    "Key": "<your-key>",
+    "PersonGroupId": "my-circle-person-group",
+    "RecognitionModel": "recognition_04",
+    "DetectionModel": "detection_01",
+    "IdentifyChunkSize": 10,
+    "TrainTimeoutSeconds": 300
   }
 }
 


### PR DESCRIPTION
## Summary
- add AWS Rekognition and Azure Face configuration options
- set default face provider to Local

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: ImageMagick.MagickMissingDelegateErrorException NoEncodeDelegateForThisImageFormat `XC`)*

------
https://chatgpt.com/codex/tasks/task_e_689f03fe2e98832882f1f457f088e30f