### PR TITLE
refactor: async/await and problem details handling

### DIFF
--- a/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
+++ b/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import * as Api from '@photobank/shared/api/photobank';
 import type { PathDto, PersonDto, StorageDto, TagDto } from '@photobank/shared/api/photobank';
+import { unwrapOrThrow } from '@/shared/httpUtils';
 import {
   METADATA_CACHE_KEY,
   METADATA_CACHE_VERSION,
@@ -63,14 +64,14 @@ const initialState: MetadataState = {
     error: undefined,
 };
 
-export const loadMetadata = createAsyncThunk('metadata/load', async () => {
+export const loadMetadata = createAsyncThunk('metadata/load', async (_, { signal }) => {
     const fromCache = loadFromCache();
     if (fromCache) return fromCache;
 
-    const storages: StorageDto[] = await Api.storagesGetAll().then((r) => r.data);
-    const tags: TagDto[] = await Api.tagsGetAll().then((r) => r.data);
-    const persons: PersonDto[] = await Api.personsGetAll().then((r) => r.data);
-    const paths: PathDto[] = await Api.pathsGetAll().then((r) => r.data);
+    const storages: StorageDto[] = await unwrapOrThrow(Api.storagesGetAll({ signal }));
+    const tags: TagDto[] = await unwrapOrThrow(Api.tagsGetAll({ signal }));
+    const persons: PersonDto[] = await unwrapOrThrow(Api.personsGetAll({ signal }));
+    const paths: PathDto[] = await unwrapOrThrow(Api.pathsGetAll({ signal }));
 
     const result: MetadataPayload = {
         tags,

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -136,11 +136,12 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
             setPlaceName('');
             return;
         }
-        let cancelled = false;
-        getPlaceByGeoPoint(photo.location).then((name) => {
-            if (!cancelled) setPlaceName(name);
-        });
-        return () => { cancelled = true; };
+        const controller = new AbortController();
+        (async () => {
+            const name = await getPlaceByGeoPoint(photo.location);
+            if (!controller.signal.aborted) setPlaceName(name);
+        })();
+        return () => { controller.abort(); };
     }, [photo?.location]);
 
     const calculateFacePosition = (faceBox: FaceBoxDto) => {

--- a/frontend/packages/frontend/src/shared/api.ts
+++ b/frontend/packages/frontend/src/shared/api.ts
@@ -1,65 +1,191 @@
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
 import * as Api from '@photobank/shared/api/photobank';
-
-import { orvalQuery, orvalMutation } from './orvalAdapter';
+import { unwrapOrThrow } from './httpUtils';
+import type { ProblemDetailsError } from '@photobank/shared/types/problem';
 
 export const photobankApi = createApi({
   reducerPath: 'photobankApi',
-  baseQuery: fakeBaseQuery<{ status: number; data?: unknown; problem?: unknown }>(),
+  baseQuery: fakeBaseQuery<ProblemDetailsError>(),
   endpoints: (build) => ({
-    login: build.mutation<Api.LoginResponseDto, Api.LoginRequestDto>({
-      queryFn: orvalMutation((body, opt) => Api.authLogin(body, opt).then((r) => r.data)),
+    login: build.mutation<Api.LoginResponseDto, Api.LoginRequestDto, ProblemDetailsError>({
+      queryFn: async (body, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.authLogin(body, { signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    getPhotoById: build.query<Api.PhotoDto, number>({
-      queryFn: orvalQuery((id, opt) => Api.getApiPhotos(id, opt).then((r) => r.data)),
+    getPhotoById: build.query<Api.PhotoDto, number, ProblemDetailsError>({
+      queryFn: async (id, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.getApiPhotos(id, { signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    register: build.mutation<null, Api.RegisterRequestDto>({
-      queryFn: orvalMutation((body, opt) => Api.authRegister(body, opt).then((r) => r.data)),
+    register: build.mutation<null, Api.RegisterRequestDto, ProblemDetailsError>({
+      queryFn: async (body, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.authRegister(body, { signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    getUser: build.query<Api.UserDto, void>({
-      queryFn: orvalQuery((_arg, opt) => Api.authGetUser(opt).then((r) => r.data)),
+    getUser: build.query<Api.UserDto, void, ProblemDetailsError>({
+      queryFn: async (_arg, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.authGetUser({ signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    updateUser: build.mutation<null, Api.UpdateUserDto>({
-      queryFn: orvalMutation((body, opt) => Api.authUpdateUser(body, opt).then((r) => r.data)),
+    updateUser: build.mutation<null, Api.UpdateUserDto, ProblemDetailsError>({
+      queryFn: async (body, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.authUpdateUser(body, { signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    getUserClaims: build.query<Api.ClaimDto[], void>({
-      queryFn: orvalQuery((_arg, opt) => Api.authGetUserClaims(opt).then((r) => r.data)),
+    getUserClaims: build.query<Api.ClaimDto[], void, ProblemDetailsError>({
+      queryFn: async (_arg, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.authGetUserClaims({ signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    getUserRoles: build.query<Api.RoleDto[], void>({
-      queryFn: orvalQuery((_arg, opt) => Api.authGetUserRoles(opt).then((r) => r.data)),
+    getUserRoles: build.query<Api.RoleDto[], void, ProblemDetailsError>({
+      queryFn: async (_arg, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.authGetUserRoles({ signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    searchPhotos: build.mutation<Api.PageResponseOfPhotoItemDto, Api.FilterDto>({
-      queryFn: orvalMutation((body, opt) => Api.postApiPhotosSearch(body, opt).then((r) => r.data)),
+    searchPhotos: build.mutation<Api.PageResponseOfPhotoItemDto, Api.FilterDto, ProblemDetailsError>({
+      queryFn: async (body, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.postApiPhotosSearch(body, { signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    uploadPhotos: build.mutation<null, Api.PhotosUploadBody>({
-      queryFn: orvalMutation((body, opt) => Api.photosUpload(body, opt).then((r) => r.data)),
+    uploadPhotos: build.mutation<null, Api.PhotosUploadBody, ProblemDetailsError>({
+      queryFn: async (body, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.photosUpload(body, { signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    getDuplicatePhotos: build.query<Api.PhotoItemDto[], Api.PhotosGetDuplicatesParams | void>({
-      queryFn: orvalQuery((params, opt) => Api.photosGetDuplicates(params, opt).then((r) => r.data)),
+    getDuplicatePhotos: build.query<Api.PhotoItemDto[], Api.PhotosGetDuplicatesParams | void, ProblemDetailsError>({
+      queryFn: async (params, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.photosGetDuplicates(params, { signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    getPersons: build.query<Api.PersonDto[], void>({
-      queryFn: orvalQuery((_arg, opt) => Api.personsGetAll(opt).then((r) => r.data)),
+    getPersons: build.query<Api.PersonDto[], void, ProblemDetailsError>({
+      queryFn: async (_arg, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.personsGetAll({ signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    updateFace: build.mutation<null, Api.UpdateFaceDto>({
-      queryFn: orvalMutation((body, opt) => Api.facesUpdate(body, opt).then((r) => r.data)),
+    updateFace: build.mutation<null, Api.UpdateFaceDto, ProblemDetailsError>({
+      queryFn: async (body, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.facesUpdate(body, { signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    getAdminUsers: build.query<Api.UserWithClaimsDto[], void>({
-      queryFn: orvalQuery((_arg, opt) => Api.usersGetAll(opt).then((r) => r.data)),
+    getAdminUsers: build.query<Api.UserWithClaimsDto[], void, ProblemDetailsError>({
+      queryFn: async (_arg, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.usersGetAll({ signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    updateAdminUser: build.mutation<null, { id: string; data: Api.UpdateUserDto }>({
-      queryFn: orvalMutation(({ id, data }, opt) => Api.usersUpdate(id, data, opt).then((r) => r.data)),
+    updateAdminUser: build.mutation<null, { id: string; data: Api.UpdateUserDto }, ProblemDetailsError>({
+      queryFn: async ({ id, data }, api) => {
+        try {
+          const res = await unwrapOrThrow(Api.usersUpdate(id, data, { signal: api.signal }));
+          return { data: res };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    setUserClaims: build.mutation<null, { id: string; data: Api.ClaimDto[] }>({
-      queryFn: orvalMutation(({ id, data }, opt) => Api.usersSetClaims(id, data, opt).then((r) => r.data)),
+    setUserClaims: build.mutation<null, { id: string; data: Api.ClaimDto[] }, ProblemDetailsError>({
+      queryFn: async ({ id, data }, api) => {
+          try {
+            const res = await unwrapOrThrow(Api.usersSetClaims(id, data, { signal: api.signal }));
+            return { data: res };
+          } catch (err) {
+            return { error: err as ProblemDetailsError };
+          }
+      },
     }),
-    getStorages: build.query<Api.StorageDto[], void>({
-      queryFn: orvalQuery((_arg, opt) => Api.storagesGetAll(opt).then((r) => r.data)),
+    getStorages: build.query<Api.StorageDto[], void, ProblemDetailsError>({
+      queryFn: async (_arg, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.storagesGetAll({ signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    getTags: build.query<Api.TagDto[], void>({
-      queryFn: orvalQuery((_arg, opt) => Api.tagsGetAll(opt).then((r) => r.data)),
+    getTags: build.query<Api.TagDto[], void, ProblemDetailsError>({
+      queryFn: async (_arg, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.tagsGetAll({ signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
-    getPaths: build.query<Api.PathDto[], void>({
-      queryFn: orvalQuery((_arg, opt) => Api.pathsGetAll(opt).then((r) => r.data)),
+    getPaths: build.query<Api.PathDto[], void, ProblemDetailsError>({
+      queryFn: async (_arg, api) => {
+        try {
+          const data = await unwrapOrThrow(Api.pathsGetAll({ signal: api.signal }));
+          return { data };
+        } catch (err) {
+          return { error: err as ProblemDetailsError };
+        }
+      },
     }),
   }),
 });

--- a/frontend/packages/frontend/src/shared/httpUtils.ts
+++ b/frontend/packages/frontend/src/shared/httpUtils.ts
@@ -1,0 +1,14 @@
+import { ProblemDetailsError, isProblemDetails, type ProblemDetails } from '@photobank/shared/types/problem';
+
+export async function unwrapOrThrow<T>(promise: Promise<{ data: T }>): Promise<T> {
+  try {
+    const res = await promise;
+    return res.data;
+  } catch (err: unknown) {
+    const maybeProblem: unknown = (err as any)?.problem ?? (err as any)?.response?.data ?? err;
+    if (isProblemDetails(maybeProblem)) {
+      throw new ProblemDetailsError(maybeProblem as ProblemDetails);
+    }
+    throw err;
+  }
+}

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -17,6 +17,11 @@
     "./ai": {
       "types": "./dist/ai/index.d.ts",
       "import": "./dist/ai/index.js"
+    },
+    "./types/problem": {
+      "types": "./dist/types/problem.d.ts",
+      "import": "./dist/types/problem.js",
+      "default": "./dist/types/problem.js"
     }
   },
   "main": "./dist/index.js",

--- a/frontend/packages/shared/src/types/problem.ts
+++ b/frontend/packages/shared/src/types/problem.ts
@@ -1,0 +1,26 @@
+export interface ProblemDetails {
+  title: string;
+  status: number;
+  detail: string;
+  type?: string;
+  instance?: string;
+  [key: string]: unknown;
+}
+
+export class ProblemDetailsError extends Error {
+  problem: ProblemDetails;
+  constructor(problem: ProblemDetails) {
+    super(problem.title);
+    this.problem = problem;
+  }
+}
+
+export const isProblemDetails = (value: unknown): value is ProblemDetails => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'title' in value &&
+    'status' in value &&
+    'detail' in value
+  );
+};


### PR DESCRIPTION
## Summary
- add RFC 7807 `ProblemDetails` types and error class
- introduce `unwrapOrThrow` helper and refactor RTK Query endpoints to async/await
- update pages and meta metadata slice to await RTK calls with abort support

## Testing
- `pnpm -w -r run typecheck` *(fails: None of the selected packages has a "typecheck" script)*
- `pnpm -w -r run lint` *(fails: 31 problems)*
- `pnpm -w -r run test` *(fails: 1 failed test)*

------
https://chatgpt.com/codex/tasks/task_e_689f50cbb0f88328b81a45f402f3a082