### PR TITLE
feat: add shared format utilities and list columns

### DIFF
--- a/frontend/packages/frontend/src/components/EmptyState.tsx
+++ b/frontend/packages/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,15 @@
+import { memo } from 'react';
+import { ImageOff } from 'lucide-react';
+
+interface EmptyStateProps {
+  text: string;
+}
+
+const EmptyState = ({ text }: EmptyStateProps) => (
+  <div className="flex flex-col items-center justify-center py-10 text-muted-foreground">
+    <ImageOff className="w-12 h-12 mb-4" aria-hidden="true" />
+    <p>{text}</p>
+  </div>
+);
+
+export default memo(EmptyState);

--- a/frontend/packages/frontend/src/components/formatters/Chips.tsx
+++ b/frontend/packages/frontend/src/components/formatters/Chips.tsx
@@ -1,0 +1,40 @@
+import { memo, useCallback, useMemo } from 'react';
+import { formatList } from '@photobank/shared/format';
+import { Badge } from '@/shared/ui/badge';
+
+interface ChipsProps {
+  items: string[];
+  max?: number;
+  onClickItem?: (value: string) => void;
+}
+
+const ChipsComponent = ({ items, max, onClickItem }: ChipsProps) => {
+  const handleClick = useCallback(
+    (value: string) => {
+      onClickItem?.(value);
+    },
+    [onClickItem]
+  );
+
+  const list = useMemo(() => formatList(items, max), [items, max]);
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {list.visible.map((item) => (
+        <Badge
+          key={item}
+          variant="secondary"
+          className="text-xs"
+          onClick={onClickItem ? () => handleClick(item) : undefined}
+        >
+          {item}
+        </Badge>
+      ))}
+      {list.hidden > 0 && (
+        <Badge variant="outline" className="text-xs">+{list.hidden}</Badge>
+      )}
+    </div>
+  );
+};
+
+export default memo(ChipsComponent);

--- a/frontend/packages/frontend/src/components/formatters/FlagIcon.tsx
+++ b/frontend/packages/frontend/src/components/formatters/FlagIcon.tsx
@@ -1,0 +1,14 @@
+import { Check, X } from 'lucide-react';
+import { memo } from 'react';
+
+interface FlagIconProps {
+  value: boolean | null | undefined;
+}
+
+const FlagIcon = ({ value }: FlagIconProps) => {
+  const Icon = value ? Check : X;
+  const label = value ? 'Yes' : 'No';
+  return <Icon aria-label={label} className="w-4 h-4" />;
+};
+
+export default memo(FlagIcon);

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
@@ -1,5 +1,6 @@
 import { Calendar, User, Tag } from 'lucide-react';
-import { formatDate, firstNWords } from '@photobank/shared';
+import { firstNWords } from '@photobank/shared';
+import { formatDate } from '@photobank/shared/format';
 import type { PhotoItemDto } from '@photobank/shared/api/photobank';
 import {
   MAX_VISIBLE_PERSONS_LG,

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -14,11 +14,11 @@ import { useAppDispatch, useAppSelector } from '@/app/hook.ts';
 import { setLastResult } from '@/features/photo/model/photoSlice.ts';
 import PhotoDetailsModal from '@/components/PhotoDetailsModal';
 
-import PhotoListItemDesktop from './PhotoListItemDesktop';
 import PhotoListItemMobile from './PhotoListItemMobile';
 import VirtualPhotoList from './VirtualPhotoList';
-import PhotoListHeader from './PhotoListHeader';
 import PhotoListItemSkeleton from './PhotoListItemSkeleton';
+import EmptyState from '@/components/EmptyState';
+import { photoColumns } from './columns';
 
 const PhotoListPage = () => {
   const dispatch = useAppDispatch();
@@ -58,15 +58,22 @@ const PhotoListPage = () => {
   const loading = isLoading && photos.length === 0;
 
   const renderPhotoRow = useCallback(
-    (photo: PhotoItemDto) => (
-      <PhotoListItemDesktop
-        photo={photo}
-        personsMap={personsMap}
-        tagsMap={tagsMap}
-        onClick={() => handleOpenDetails(photo.id)}
-      />
-    ),
-    [personsMap, tagsMap, handleOpenDetails]
+    (photo: PhotoItemDto) => {
+      const handleClick = () => handleOpenDetails(photo.id);
+      return (
+        <div
+          className="grid grid-cols-12 gap-2 px-4 py-2 cursor-pointer hover:bg-muted/50"
+          onClick={handleClick}
+        >
+          {photoColumns.map((c) => (
+            <div key={c.id} className={c.width}>
+              {c.render(photo)}
+            </div>
+          ))}
+        </div>
+      );
+    },
+    [handleOpenDetails]
   );
 
   const renderSkeletonRow = useCallback(
@@ -134,13 +141,21 @@ const PhotoListPage = () => {
         <div className="p-6">
           {/* Desktop/Tablet View */}
           <div className="hidden lg:block">
-            <PhotoListHeader />
+            <div className="grid grid-cols-12 gap-4 mb-4 px-4 py-2 bg-muted/50 rounded-lg font-medium text-sm">
+              {photoColumns.map((c) => (
+                <div key={c.id} className={c.width}>
+                  {c.header}
+                </div>
+              ))}
+            </div>
             {loading ? (
               <VirtualPhotoList
                 photos={skeletonPhotos}
                 parentRef={scrollAreaRef}
                 renderRow={renderSkeletonRow}
               />
+            ) : photos.length === 0 ? (
+              <EmptyState text="No photos" />
             ) : (
               <VirtualPhotoList
                 photos={photos}
@@ -157,15 +172,19 @@ const PhotoListPage = () => {
                 ? skeletonPhotos.slice(0, 6).map((p) => (
                     <PhotoListItemSkeleton key={p.id} />
                   ))
-                : photos.map((photo) => (
-                    <PhotoListItemMobile
-                      key={photo.id}
-                      photo={photo}
-                      personsMap={personsMap}
-                      tagsMap={tagsMap}
-                      onClick={() => handleOpenDetails(photo.id)}
-                    />
-                  ))}
+                : photos.length === 0 ? (
+                    <EmptyState text="No photos" />
+                  ) : (
+                    photos.map((photo) => (
+                      <PhotoListItemMobile
+                        key={photo.id}
+                        photo={photo}
+                        personsMap={personsMap}
+                        tagsMap={tagsMap}
+                        onClick={() => handleOpenDetails(photo.id)}
+                      />
+                    ))
+                  )}
             </div>
           </div>
           {photos.length < total && (

--- a/frontend/packages/frontend/src/pages/list/PreviewCell.tsx
+++ b/frontend/packages/frontend/src/pages/list/PreviewCell.tsx
@@ -1,0 +1,4 @@
+import { memo } from 'react';
+import PhotoPreview from './PhotoPreview';
+
+export default memo(PhotoPreview);

--- a/frontend/packages/frontend/src/pages/list/RowActions.tsx
+++ b/frontend/packages/frontend/src/pages/list/RowActions.tsx
@@ -1,0 +1,24 @@
+import { memo, useCallback } from 'react';
+import { MoreHorizontal } from 'lucide-react';
+import { Button } from '@/shared/ui/button';
+
+interface RowActionsProps {
+  id: number;
+  onOpen?: (id: number) => void;
+}
+
+const RowActions = ({ id, onOpen }: RowActionsProps) => {
+  const handleClick = useCallback(() => onOpen?.(id), [onOpen, id]);
+  return (
+    <Button
+      aria-label="More actions"
+      variant="ghost"
+      size="icon"
+      onClick={handleClick}
+    >
+      <MoreHorizontal className="w-4 h-4" />
+    </Button>
+  );
+};
+
+export default memo(RowActions);

--- a/frontend/packages/frontend/src/pages/list/columns.tsx
+++ b/frontend/packages/frontend/src/pages/list/columns.tsx
@@ -1,0 +1,70 @@
+import type { PhotoItemDto } from '@photobank/shared/api/photobank';
+import { formatDate } from '@photobank/shared/format';
+import {
+  colDateLabel,
+  colFlagsLabel,
+  colIdLabel,
+  colNameLabel,
+  colPreviewLabel,
+  colStorageLabel,
+  colDetailsLabel,
+} from '@photobank/shared/constants';
+import FlagIcon from '@/components/formatters/FlagIcon';
+import PreviewCell from './PreviewCell';
+import RowActions from './RowActions';
+
+export interface Column<T> {
+  id: string;
+  header: string;
+  width?: string;
+  render: (row: T) => React.ReactNode;
+  sortAccessor?: (row: T) => string | number;
+  hide?: boolean;
+}
+
+export const photoColumns: Column<PhotoItemDto>[] = [
+  {
+    id: 'id',
+    header: colIdLabel,
+    width: 'col-span-1',
+    render: (r) => r.id,
+  },
+  {
+    id: 'preview',
+    header: colPreviewLabel,
+    width: 'col-span-2',
+    render: (r) => (
+      <PreviewCell thumbnail={r.thumbnail} alt={r.name} className="w-16 h-16" />
+    ),
+  },
+  {
+    id: 'name',
+    header: colNameLabel,
+    width: 'col-span-2',
+    render: (r) => <span className="truncate">{r.name}</span>,
+  },
+  {
+    id: 'date',
+    header: colDateLabel,
+    width: 'col-span-1',
+    render: (r) => formatDate(r.takenDate),
+  },
+  {
+    id: 'storage',
+    header: colStorageLabel,
+    width: 'col-span-2',
+    render: (r) => r.storageName,
+  },
+  {
+    id: 'flags',
+    header: colFlagsLabel,
+    width: 'col-span-1',
+    render: (r) => <FlagIcon value={r.isBW} />,
+  },
+  {
+    id: 'details',
+    header: colDetailsLabel,
+    width: 'col-span-3',
+    render: (r) => <RowActions id={r.id} />,
+  },
+];

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -32,6 +32,11 @@
       "types": "./dist/utils/logger.d.ts",
       "import": "./dist/utils/logger.js",
       "default": "./dist/utils/logger.js"
+    },
+    "./format": {
+      "types": "./dist/format/index.d.ts",
+      "import": "./dist/format/index.js",
+      "default": "./dist/format/index.js"
     }
   },
   "main": "./dist/index.js",

--- a/frontend/packages/shared/src/format/index.ts
+++ b/frontend/packages/shared/src/format/index.ts
@@ -1,0 +1,89 @@
+export type DateInput = string | number | Date | null | undefined;
+
+const locale =
+  typeof navigator !== 'undefined' && navigator.language
+    ? navigator.language
+    : 'en-US';
+
+const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
+const numberFormatterCache = new Map<string, Intl.NumberFormat>();
+
+function getDateFormatter(opts?: Intl.DateTimeFormatOptions) {
+  const key = JSON.stringify(opts ?? {});
+  let fmt = dateFormatterCache.get(key);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat(locale, opts);
+    dateFormatterCache.set(key, fmt);
+  }
+  return fmt;
+}
+
+function getNumberFormatter(opts?: Intl.NumberFormatOptions) {
+  const key = JSON.stringify(opts ?? {});
+  let fmt = numberFormatterCache.get(key);
+  if (!fmt) {
+    fmt = new Intl.NumberFormat(locale, opts);
+    numberFormatterCache.set(key, fmt);
+  }
+  return fmt;
+}
+
+export function formatDate(
+  d: DateInput,
+  opts?: Intl.DateTimeFormatOptions
+): string {
+  if (d === null || d === undefined) return '';
+  const date = typeof d === 'string' || typeof d === 'number' ? new Date(d) : d;
+  if (!date || isNaN(date.getTime())) return '';
+  return getDateFormatter(opts).format(date);
+}
+
+export function formatDateTime(d: DateInput): string {
+  return formatDate(d, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).replace(',', '');
+}
+
+export function formatBytes(n?: number | null): string {
+  if (n === null || n === undefined || isNaN(n)) return '';
+  const units = ['B', 'kB', 'MB', 'GB', 'TB'];
+  let value = n;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  const fmt = getNumberFormatter({
+    maximumFractionDigits: value < 10 ? 1 : 0,
+  });
+  return `${fmt.format(value)} ${units[unitIndex]}`;
+}
+
+export function formatDuration(ms?: number | null): string {
+  if (ms === null || ms === undefined || ms < 0) return '';
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts: string[] = [];
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  if (!hours && !minutes) parts.push(`${seconds}s`);
+  return parts.join(' ');
+}
+
+export function formatBool(v: boolean | null | undefined): string {
+  return v ? 'Yes' : 'No';
+}
+
+export function formatList(values: string[], max?: number) {
+  const limit = max ?? values.length;
+  const visible = values.slice(0, limit);
+  const hidden = values.length - visible.length;
+  return { visible, hidden };
+}

--- a/frontend/packages/shared/test/format.test.ts
+++ b/frontend/packages/shared/test/format.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatDate,
+  formatDateTime,
+  formatBytes,
+  formatDuration,
+  formatBool,
+  formatList,
+} from '../src/format';
+
+const locale = 'en-US';
+
+describe('format module', () => {
+  it('formats date', () => {
+    const d = new Date('2024-01-02T03:04:05Z');
+    const expected = new Intl.DateTimeFormat(locale).format(d);
+    expect(formatDate(d)).toBe(expected);
+  });
+
+  it('formats date time', () => {
+    const d = new Date('2024-01-02T03:04:05Z');
+    const expected = new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+      .format(d)
+      .replace(',', '');
+    expect(formatDateTime(d)).toBe(expected);
+  });
+
+  it('formats bytes', () => {
+    expect(formatBytes(1_048_576)).toBe('1 MB');
+    expect(formatBytes(1_500_000)).toBe('1.4 MB');
+  });
+
+  it('formats duration', () => {
+    expect(formatDuration(3600_000 + 23 * 60_000)).toBe('1h 23m');
+    expect(formatDuration(42_000)).toBe('42s');
+  });
+
+  it('formats boolean', () => {
+    expect(formatBool(true)).toBe('Yes');
+    expect(formatBool(false)).toBe('No');
+    expect(formatBool(null)).toBe('No');
+  });
+
+  it('formats list', () => {
+    expect(formatList(['a', 'b', 'c', 'd'], 2)).toEqual({
+      visible: ['a', 'b'],
+      hidden: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared `@photobank/shared/format` helpers for dates, bytes and more
- introduce memoized flag icons, chip list and column config
- render photo list rows via declarative column definitions

## Testing
- `pnpm -w -r run typecheck` *(fails: None of the selected packages has a "typecheck" script)*
- `pnpm -w -r run lint` *(fails: lint errors in existing shared package)*
- `pnpm --filter @photobank/shared test test/format.test.ts`
- `pnpm -w -r --filter frontend run dev`


------
https://chatgpt.com/codex/tasks/task_e_689f5e015e0c8328a0bf36bd9e10c993