### PR TITLE
feat: add smart image loader

### DIFF
--- a/frontend/packages/frontend/index.html
+++ b/frontend/packages/frontend/index.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8"/>
     <link href="/vite.svg" rel="icon" type="image/svg+xml"/>
+    <link rel="preconnect" href="%VITE_IMAGE_BASE_URL%" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Vite + React + TS</title>
-</head>
+  </head>
 <body class="debug-screens">
 <div id="root"></div>
 <script src="src/main.tsx" type="module"></script>

--- a/frontend/packages/frontend/src/components/SmartImage.tsx
+++ b/frontend/packages/frontend/src/components/SmartImage.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import clsx from 'clsx';
+
+export type SmartImageProps = Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  'src' | 'srcSet' | 'sizes' | 'loading' | 'decoding' | 'fetchPriority'
+> & {
+  alt: string;
+  thumbSrc: string;
+  src: string;
+  srcSet?: string;
+  sizes?: string;
+  className?: string;
+  onLoadFull?: () => void;
+  fetchPriority?: 'high' | 'auto' | 'low';
+  decoding?: 'async' | 'auto' | 'sync';
+  loading?: 'eager' | 'lazy';
+};
+
+const SmartImage = React.memo(
+  React.forwardRef<HTMLImageElement, SmartImageProps>(
+    (
+      {
+        alt,
+        thumbSrc,
+        src,
+        srcSet,
+        sizes,
+        className,
+        onLoadFull,
+        fetchPriority = 'auto',
+        decoding = 'async',
+        loading = 'lazy',
+        ...imgProps
+      },
+      ref
+    ) => {
+      const [loaded, setLoaded] = useState(false);
+
+      const handleLoad = useCallback(() => {
+        requestAnimationFrame(() => {
+          setLoaded(true);
+          onLoadFull?.();
+        });
+      }, [onLoadFull]);
+
+      useEffect(() => {
+        setLoaded(false);
+      }, [src, srcSet]);
+
+      return (
+        <div className={clsx('relative overflow-hidden', className)}>
+          <img
+            src={thumbSrc}
+            alt={alt}
+            className={clsx(
+              'absolute inset-0 w-full h-full object-cover transition-all duration-300',
+              loaded ? 'opacity-0 blur-none scale-100' : 'opacity-100 blur-md scale-105'
+            )}
+            aria-hidden={loaded}
+          />
+          <img
+            ref={ref}
+            src={src}
+            srcSet={srcSet}
+            sizes={sizes}
+            alt={alt}
+            loading={loading}
+            decoding={decoding}
+            fetchPriority={fetchPriority}
+            onLoad={handleLoad}
+            className={clsx(
+              'w-full h-full object-cover transition-opacity duration-300',
+              loaded ? 'opacity-100' : 'opacity-0'
+            )}
+            {...imgProps}
+          />
+        </div>
+      );
+    }
+  )
+);
+
+export default SmartImage;

--- a/frontend/packages/frontend/src/features/viewer/ImageCanvas.tsx
+++ b/frontend/packages/frontend/src/features/viewer/ImageCanvas.tsx
@@ -1,12 +1,15 @@
 import { useRef, useState, useEffect } from 'react';
+import SmartImage from '@/components/SmartImage';
 
 interface Props {
+  thumbSrc: string;
   src: string;
   alt?: string;
+  fetchPriority?: 'high' | 'auto' | 'low';
   onLoaded?: (w: number, h: number) => void;
 }
 
-const ImageCanvas = ({ src, alt, onLoaded }: Props) => {
+const ImageCanvas = ({ thumbSrc, src, alt, fetchPriority, onLoaded }: Props) => {
   const imgRef = useRef<HTMLImageElement>(null);
   const [scale, setScale] = useState(1);
   const [translate, setTranslate] = useState({ x: 0, y: 0 });
@@ -48,11 +51,14 @@ const ImageCanvas = ({ src, alt, onLoaded }: Props) => {
   };
 
   return (
-    <img
+    <SmartImage
       ref={imgRef}
+      thumbSrc={thumbSrc}
       src={src}
-      alt={alt}
-      onLoad={() => {
+      alt={alt || ''}
+      loading="eager"
+      fetchPriority={fetchPriority}
+      onLoadFull={() => {
         const img = imgRef.current;
         if (img) onLoaded?.(img.naturalWidth, img.naturalHeight);
       }}

--- a/frontend/packages/frontend/src/features/viewer/Lightbox.tsx
+++ b/frontend/packages/frontend/src/features/viewer/Lightbox.tsx
@@ -51,7 +51,12 @@ const Lightbox = () => {
             exit={{ opacity: 0 }}
             className="max-w-full max-h-full"
           >
-            <ImageCanvas src={item.src} alt={item.title} />
+            <ImageCanvas
+              thumbSrc={item.preview}
+              src={item.original}
+              alt={item.title}
+              fetchPriority="high"
+            />
           </motion.div>
         </AnimatePresence>
       </DialogContent>

--- a/frontend/packages/frontend/src/features/viewer/prefetch.ts
+++ b/frontend/packages/frontend/src/features/viewer/prefetch.ts
@@ -1,4 +1,5 @@
 import type { ViewerItem } from './state';
+import { prefetch } from '@/hooks/useImagePrefetch';
 
 export const prefetchAround = (
   items: ViewerItem[],
@@ -7,7 +8,7 @@ export const prefetchAround = (
 ) => {
   for (let i = Math.max(0, index - radius); i <= Math.min(items.length - 1, index + radius); i++) {
     if (i === index) continue;
-    const img = new Image();
-    img.src = items[i].src;
+    prefetch(items[i].preview);
+    prefetch(items[i].original);
   }
 };

--- a/frontend/packages/frontend/src/features/viewer/state.ts
+++ b/frontend/packages/frontend/src/features/viewer/state.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 
-export interface ViewerItem { id: number; src: string; thumb?: string; title?: string; }
+export interface ViewerItem {
+  id: number;
+  preview: string;
+  original: string;
+  title?: string;
+}
 
 interface ViewerState {
   isOpen: boolean;

--- a/frontend/packages/frontend/src/hooks/useImagePrefetch.ts
+++ b/frontend/packages/frontend/src/hooks/useImagePrefetch.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+
+export function prefetch(src: string): Promise<void> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = img.onerror = () => resolve();
+    img.src = src;
+  });
+}
+
+export function usePrefetchOnHover(srcs: string[]) {
+  const handler = useCallback(() => {
+    srcs.forEach((s) => {
+      if (s) prefetch(s);
+    });
+  }, [srcs]);
+
+  return {
+    onMouseEnter: handler,
+    onFocus: handler,
+  } as const;
+}

--- a/frontend/packages/frontend/src/hooks/useInView.ts
+++ b/frontend/packages/frontend/src/hooks/useInView.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useInView<T extends Element>(
+  opts: IntersectionObserverInit = {
+    rootMargin: '400px 0px',
+    threshold: 0.01,
+  }
+): [React.RefObject<T>, boolean] {
+  const ref = useRef<T>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]) {
+        setInView(entries[0].isIntersecting);
+      }
+    }, opts);
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [opts.root, opts.rootMargin, opts.threshold]);
+
+  return [ref, inView];
+}

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
@@ -12,8 +12,10 @@ import { Badge } from '@/shared/ui/badge';
 import PhotoFlags from '@/components/PhotoFlags';
 import MetadataBadgeList from '@/components/MetadataBadgeList';
 
-import PhotoPreview from './PhotoPreview';
+import SmartImage from '@/components/SmartImage';
 import { memo, useMemo, useEvent } from 'react';
+import { useInView } from '@/hooks/useInView';
+import { usePrefetchOnHover } from '@/hooks/useImagePrefetch';
 
 export type PhotoListItemDesktopProps = {
   photo: PhotoItemDto;
@@ -50,10 +52,28 @@ const PhotoListItemDesktop = ({
     [photo.storageName, photo.relativePath]
   );
 
+  const [ref, inView] = useInView<HTMLDivElement>();
+  const prefetchHandlers = usePrefetchOnHover([
+    photo.originalUrl ?? '',
+  ]);
+
+  const base = photo.previewUrl;
+  const srcSet = base
+    ? [
+        `${base}?w=480 480w`,
+        `${base}?w=960 960w`,
+        `${base}?w=1440 1440w`,
+      ].join(', ')
+    : undefined;
+  const sizes = base
+    ? '(max-width: 640px) 480px, (max-width: 1024px) 960px, 1440px'
+    : undefined;
+
   return (
     <Card
       className="p-4 mb-3 hover:shadow-md transition-shadow cursor-pointer"
       onClick={handleClick}
+      {...prefetchHandlers}
     >
       <div className="grid grid-cols-12 gap-4 items-center">
         <div className="col-span-1">
@@ -63,11 +83,18 @@ const PhotoListItemDesktop = ({
         </div>
 
         <div className="col-span-2">
-          <PhotoPreview
-            thumbnail={photo.thumbnail}
-            alt={photo.name}
-            className="w-16 h-16"
-          />
+          <div ref={ref} className="w-16 h-16">
+            {inView && (
+              <SmartImage
+                alt={photo.name}
+                thumbSrc={photo.thumbnailUrl ?? ''}
+                src={photo.previewUrl ?? ''}
+                srcSet={srcSet}
+                sizes={sizes}
+                className="w-full h-full rounded-lg"
+              />
+            )}
+          </div>
         </div>
 
         <div className="col-span-2">

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -51,8 +51,8 @@ const PhotoListPage = () => {
     () =>
       photos.map((p) => ({
         id: p.id,
-        src: `data:image/jpeg;base64,${p.thumbnail}`,
-        thumb: `data:image/jpeg;base64,${p.thumbnail}`,
+        preview: p.previewUrl!,
+        original: p.originalUrl!,
         title: p.name,
       })),
     [photos]

--- a/frontend/packages/frontend/test/SmartImage.test.tsx
+++ b/frontend/packages/frontend/test/SmartImage.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import SmartImage from '@/components/SmartImage';
+import { vi } from 'vitest';
+
+describe('SmartImage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    vi.stubGlobal(
+      'Image',
+      class {
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        set src(_v: string) {
+          this.onload && this.onload();
+        }
+      } as any
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fades in full image after load', () => {
+    const { container } = render(
+      <SmartImage alt="alt" thumbSrc="thumb" src="full" />
+    );
+    const imgs = container.querySelectorAll('img');
+    const thumb = imgs[0];
+    const full = imgs[1];
+    expect(thumb.className).toMatch(/opacity-100/);
+    expect(full.className).toMatch(/opacity-0/);
+    fireEvent.load(full);
+    expect(full.className).toMatch(/opacity-100/);
+    expect(thumb.className).toMatch(/opacity-0/);
+  });
+});

--- a/frontend/packages/frontend/test/useInView.test.tsx
+++ b/frontend/packages/frontend/test/useInView.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, act } from '@testing-library/react';
+import { useInView } from '@/hooks/useInView';
+import { vi } from 'vitest';
+import React from 'react';
+
+describe('useInView', () => {
+  it('updates when element enters view', () => {
+    let cb: (entries: IntersectionObserverEntry[]) => void = () => {};
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    const Original = (globalThis as any).IntersectionObserver;
+    class IO {
+      constructor(callback: any) {
+        cb = callback;
+      }
+      observe = observe;
+      disconnect = disconnect;
+    }
+    // @ts-ignore
+    (globalThis as any).IntersectionObserver = IO;
+
+    const Test = () => {
+      const [ref, inView] = useInView<HTMLDivElement>();
+      return <div ref={ref}>{inView ? 'in' : 'out'}</div>;
+    };
+
+    render(<Test />);
+    expect(screen.getByText('out')).toBeInTheDocument();
+    act(() => {
+      cb([{ isIntersecting: true } as IntersectionObserverEntry]);
+    });
+    expect(screen.getByText('in')).toBeInTheDocument();
+
+    (globalThis as any).IntersectionObserver = Original;
+  });
+});

--- a/frontend/packages/frontend/test/viewer/Lightbox.test.tsx
+++ b/frontend/packages/frontend/test/viewer/Lightbox.test.tsx
@@ -7,9 +7,9 @@ describe('Lightbox', () => {
   it('navigates and closes', async () => {
     render(<Lightbox />);
     const items = [
-      { id: 1, src: 'a', title: 'a' },
-      { id: 2, src: 'b', title: 'b' },
-      { id: 3, src: 'c', title: 'c' },
+      { id: 1, preview: 'a_p', original: 'a', title: 'a' },
+      { id: 2, preview: 'b_p', original: 'b', title: 'b' },
+      { id: 3, preview: 'c_p', original: 'c', title: 'c' },
     ];
     useViewer.getState().open(items, 1);
     expect(screen.getByAltText('b')).toBeInTheDocument();

--- a/frontend/packages/frontend/test/viewer/prefetch.test.ts
+++ b/frontend/packages/frontend/test/viewer/prefetch.test.ts
@@ -3,9 +3,9 @@ import { prefetchAround } from '@/features/viewer/prefetch';
 describe('prefetchAround', () => {
   it('loads adjacent images', () => {
     const items = [
-      { id: 1, src: 'a' },
-      { id: 2, src: 'b' },
-      { id: 3, src: 'c' },
+      { id: 1, preview: 'a_p', original: 'a_o' },
+      { id: 2, preview: 'b_p', original: 'b_o' },
+      { id: 3, preview: 'c_p', original: 'c_o' },
     ];
     const loaded: string[] = [];
     // @ts-ignore
@@ -15,8 +15,11 @@ describe('prefetchAround', () => {
       }
     };
     prefetchAround(items, 1);
-    expect(loaded).toContain('a');
-    expect(loaded).toContain('c');
-    expect(loaded).not.toContain('b');
+    expect(loaded).toContain('a_p');
+    expect(loaded).toContain('a_o');
+    expect(loaded).toContain('c_p');
+    expect(loaded).toContain('c_o');
+    expect(loaded).not.toContain('b_p');
+    expect(loaded).not.toContain('b_o');
   });
 });

--- a/frontend/packages/shared/src/api/photobank/model/photoItemDto.ts
+++ b/frontend/packages/shared/src/api/photobank/model/photoItemDto.ts
@@ -9,7 +9,10 @@ import type { PersonItemDto } from './personItemDto';
 
 export interface PhotoItemDto {
   id: number;
-  thumbnail: string;
+  thumbnail?: string;
+  thumbnailUrl?: string;
+  previewUrl?: string;
+  originalUrl?: string;
   /** @minLength 1 */
   name: string;
   /** @nullable */

--- a/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
+++ b/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
@@ -123,7 +123,10 @@ export interface PhotoDto {
 
 export interface PhotoItemDto {
   id: number;
-  thumbnail: string;
+  thumbnail?: string;
+  thumbnailUrl?: string;
+  previewUrl?: string;
+  originalUrl?: string;
   /** @minLength 1 */
   name: string;
   /** @nullable */


### PR DESCRIPTION
## Summary
- add SmartImage component for blurred placeholders and cross-fade
- lazy-load images with `useInView` and hover prefetch
- upgrade viewer to prioritize and prefetch images

## Testing
- `pnpm -w -r run typecheck` *(fails: None of the selected packages has a "typecheck" script)*
- `pnpm -w -r run lint` *(fails: ESLint errors in generated shared files)*
- `pnpm exec vitest run test/SmartImage.test.tsx test/useInView.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689f6ca1b22483288af2392807f60e38