### PR TITLE
feat(bot): add file id cache and send utilities

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -12,11 +12,15 @@
   },
   "dependencies": {
     "@grammyjs/conversations": "^2.1.0",
+    "@grammyjs/runner": "^1.0.4",
     "@photobank/shared": "workspace:*",
     "axios": "^1.11.0",
     "fetch-blob": "^4.0.0",
     "dotenv": "^17.2.1",
-    "grammy": "^1.37.0"
+    "grammy": "^1.37.0",
+    "lru-cache": "^11.1.0",
+    "p-retry": "^6.2.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "ts-node-dev": "^2.0.0",

--- a/frontend/packages/telegram-bot/src/cache/fileIdCache.ts
+++ b/frontend/packages/telegram-bot/src/cache/fileIdCache.ts
@@ -1,0 +1,21 @@
+import LRUCache from 'lru-cache';
+
+/**
+ * Simple LRU cache for mapping Photo IDs from the Photobank API to Telegram's
+ * `file_id` so that we avoid uploading the same binary multiple times.  This
+ * drastically reduces both latency and traffic costs.
+ */
+export const fileIdCache = new LRUCache<number, string>({
+  // A few thousands of entries is enough for typical usage while keeping the
+  // memory footprint low.  The limit can be tuned later via configuration if
+  // required.
+  max: 20_000,
+});
+
+export function getCachedFileId(photoId: number): string | undefined {
+  return fileIdCache.get(photoId);
+}
+
+export function setCachedFileId(photoId: number, fileId: string): void {
+  fileIdCache.set(photoId, fileId);
+}

--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -1,0 +1,76 @@
+import type { Context, InputMediaPhoto } from 'grammy';
+import type { PhotoItemDto } from '@photobank/shared/api/photobank';
+import { formatDate } from '@photobank/shared/format';
+
+import { getCachedFileId, setCachedFileId } from '../cache/fileIdCache';
+import { getTagName } from '../dictionaries';
+
+function buildCaption(photo: PhotoItemDto): string {
+  const parts: string[] = [];
+  parts.push(`📸 <b>${photo.name}</b>`);
+  if (photo.takenDate) {
+    parts.push(`📅 ${formatDate(photo.takenDate)}`);
+  }
+  if (photo.tags?.length) {
+    const tags = photo.tags
+      .map(t => getTagName(t.tagId))
+      .filter(Boolean)
+      .join(', ');
+    if (tags) parts.push(`🏷️ ${tags}`);
+  }
+  return parts.join('\n');
+}
+
+export async function sendPhotoSmart(ctx: Context, photo: PhotoItemDto) {
+  const caption = buildCaption(photo);
+  const cached = getCachedFileId(photo.id);
+  if (cached) {
+    return ctx.replyWithPhoto(cached, { caption, parse_mode: 'HTML' });
+  }
+  const msg = await ctx.replyWithPhoto({ url: photo.previewUrl ?? photo.originalUrl ?? '' }, {
+    caption,
+    parse_mode: 'HTML',
+  });
+  const fileId = msg.photo?.[msg.photo.length - 1]?.file_id;
+  if (fileId) setCachedFileId(photo.id, fileId);
+  return msg;
+}
+
+export async function sendAlbumSmart(ctx: Context, photos: PhotoItemDto[]) {
+  const chunks: PhotoItemDto[][] = [];
+  for (let i = 0; i < photos.length; i += 10) {
+    chunks.push(photos.slice(i, i + 10));
+  }
+
+  for (const chunk of chunks) {
+    const media: InputMediaPhoto[] = chunk.map(photo => {
+      const caption = buildCaption(photo);
+      const cached = getCachedFileId(photo.id);
+      if (cached) {
+        return { type: 'photo', media: cached, caption, parse_mode: 'HTML' } as InputMediaPhoto;
+      }
+      return {
+        type: 'photo',
+        media: photo.previewUrl ?? photo.originalUrl ?? '',
+        caption,
+        parse_mode: 'HTML',
+      } as InputMediaPhoto;
+    });
+
+    try {
+      const res = await ctx.replyWithMediaGroup(media);
+      res.forEach((msg, idx) => {
+        const fileId = msg.photo?.[msg.photo.length - 1]?.file_id;
+        if (fileId) setCachedFileId(chunk[idx].id, fileId);
+      });
+    } catch {
+      for (const [idx, m] of media.entries()) {
+        const msg = await ctx.replyWithPhoto(m.media, { caption: m.caption, parse_mode: 'HTML' });
+        const fileId = msg.photo?.[msg.photo.length - 1]?.file_id;
+        if (fileId) setCachedFileId(chunk[idx].id, fileId);
+      }
+    }
+
+    await new Promise(r => setTimeout(r, 100));
+  }
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
       '@grammyjs/conversations':
         specifier: ^2.1.0
         version: 2.1.0(grammy@1.37.0)
+      '@grammyjs/runner':
+        specifier: ^1.0.4
+        version: 1.0.4
       '@photobank/shared':
         specifier: workspace:*
         version: link:../shared
@@ -340,6 +343,15 @@ importers:
       grammy:
         specifier: ^1.37.0
         version: 1.37.0
+      lru-cache:
+        specifier: ^11.1.0
+        version: 11.1.0
+      p-retry:
+        specifier: ^6.2.1
+        version: 6.2.1
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       ts-node-dev:
         specifier: ^2.0.0
@@ -1311,6 +1323,10 @@ packages:
     engines: {node: ^12.20.0 || >=14.13.1}
     peerDependencies:
       grammy: ^1.20.1
+
+  '@grammyjs/runner@1.0.4':
+    resolution: {integrity: sha512-77IE+2Gg0UHa9MNZ8wsculxJpzUDcHTrMg7OLbKoQ8jWKFxX78sdxRBwL+FK3NvHZ15YnXsnxesV43xgbOhteA==}
+    engines: {node: '>=12.20.0 || >=14.13.1'}
 
   '@grammyjs/types@3.21.0':
     resolution: {integrity: sha512-IMj0EpmglPCICuyfGRx4ENKPSuzS2xMSoPgSPzHC6FtnWKDEmJLBP/GbPv/h3TAeb27txqxm/BUld+gbJk6ccQ==}
@@ -2509,6 +2525,9 @@ packages:
 
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
+
+  '@types/retry@0.12.2':
+    resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -4294,6 +4313,10 @@ packages:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
 
+  is-network-error@1.1.0:
+    resolution: {integrity: sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==}
+    engines: {node: '>=16'}
+
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
@@ -5253,6 +5276,10 @@ packages:
     resolution: {integrity: sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==}
     engines: {node: '>=18'}
 
+  p-retry@6.2.1:
+    resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
+    engines: {node: '>=16.17'}
+
   p-timeout@6.1.4:
     resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
     engines: {node: '>=14.16'}
@@ -5730,6 +5757,10 @@ packages:
   restore-cursor@2.0.0:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -6748,6 +6779,9 @@ packages:
   yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.0.17:
     resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
@@ -7920,6 +7954,10 @@ snapshots:
   '@grammyjs/conversations@2.1.0(grammy@1.37.0)':
     dependencies:
       grammy: 1.37.0
+
+  '@grammyjs/runner@1.0.4':
+    dependencies:
+      abort-controller: 3.0.0
 
   '@grammyjs/types@3.21.0': {}
 
@@ -9331,6 +9369,8 @@ snapshots:
   '@types/react@19.1.8':
     dependencies:
       csstype: 3.1.3
+
+  '@types/retry@0.12.2': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -11352,6 +11392,8 @@ snapshots:
 
   is-negative-zero@2.0.3: {}
 
+  is-network-error@1.1.0: {}
+
   is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
@@ -12614,6 +12656,12 @@ snapshots:
       eventemitter3: 5.0.1
       p-timeout: 6.1.4
 
+  p-retry@6.2.1:
+    dependencies:
+      '@types/retry': 0.12.2
+      is-network-error: 1.1.0
+      retry: 0.13.1
+
   p-timeout@6.1.4: {}
 
   p-try@2.2.0: {}
@@ -13085,6 +13133,8 @@ snapshots:
     dependencies:
       onetime: 2.0.1
       signal-exit: 3.0.7
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -14221,6 +14271,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.2: {}
+
+  zod@3.25.76: {}
 
   zod@4.0.17: {}
 


### PR DESCRIPTION
## Summary
- add smart file ID LRU cache for Telegram uploads
- implement helpers to send cached photos and batched albums
- add grammy runner, p-retry, zod, and lru-cache deps

## Testing
- `pnpm -r --filter telegram-bot install`
- `pnpm -r --filter telegram-bot test` *(fails: Cannot find package 'openai', 'date-fns', '@tanstack/react-query')*


------
https://chatgpt.com/codex/tasks/task_e_689f734e6f48832892968f343a85783f