### PR TITLE
feat: support inline photo search

### DIFF
--- a/frontend/packages/telegram-bot/src/bot.ts
+++ b/frontend/packages/telegram-bot/src/bot.ts
@@ -1,0 +1,4 @@
+import { Bot } from 'grammy';
+import { BOT_TOKEN } from './config';
+
+export const bot = new Bot(BOT_TOKEN);

--- a/frontend/packages/telegram-bot/src/handlers/deeplink.ts
+++ b/frontend/packages/telegram-bot/src/handlers/deeplink.ts
@@ -1,0 +1,18 @@
+import { bot } from '../bot';
+
+bot.on('message', async (ctx, next) => {
+  const text = ctx.message?.text ?? '';
+  const m = /^\/start(?:\s+(\S+))?/.exec(text);
+  if (m) {
+    const param = m[1];
+    if (param === 'link') {
+      await ctx.reply('Ваш Telegram не привязан. Напишите администратору для привязки.');
+      return;
+    }
+    if (param === 'help') {
+      await ctx.reply('Пример запроса в inline‑режиме: @имябота котики, @имябота дата:2024');
+      return;
+    }
+  }
+  return next();
+});

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -1,0 +1,69 @@
+import type { InlineQueryResult, InlineQueryResultPhoto } from 'grammy/types';
+import { formatDate } from '@photobank/shared/format';
+import { ProblemDetailsError } from '@photobank/shared/types/problem';
+
+import { bot } from '../bot';
+import { ensureUserAccessToken } from '../auth';
+import { searchPhotos } from '../services/photo';
+import { getTagName } from '../dictionaries';
+import { logger } from '../logger';
+
+const PAGE_SIZE = 20;
+
+bot.on('inline_query', async (ctx) => {
+  const q = (ctx.inlineQuery.query || '').trim();
+  const offset = Number(ctx.inlineQuery.offset || '0') || 0;
+
+  try {
+    await ensureUserAccessToken(ctx);
+
+    const resp = await searchPhotos(ctx, {
+      caption: q,
+      skip: offset,
+      top: PAGE_SIZE,
+    });
+
+    const items = resp.data.photos ?? resp.data.items ?? resp.data ?? [];
+    const results: InlineQueryResult[] = items.map((p): InlineQueryResultPhoto => ({
+      type: 'photo',
+      id: String(p.id),
+      photo_url: p.previewUrl ?? p.originalUrl ?? '',
+      thumb_url: p.thumbnailUrl ?? p.previewUrl ?? p.originalUrl ?? '',
+      title: p.name ?? `#${p.id}`,
+      description: [
+        formatDate(p.takenDate),
+        (p.tags ?? []).slice(0, 3).map(t => getTagName(t.tagId)).join(', '),
+      ]
+        .filter(Boolean)
+        .join(' • '),
+      caption: `${p.name ?? ''}\n${formatDate(p.takenDate) ?? ''}`.trim(),
+    }));
+
+    const nextOffset = items.length === PAGE_SIZE ? String(offset + PAGE_SIZE) : '';
+
+    await ctx.answerInlineQuery(results, {
+      is_personal: true,
+      cache_time: 5,
+      next_offset: nextOffset,
+      switch_pm_text: undefined,
+      switch_pm_parameter: undefined,
+    });
+  } catch (e) {
+    if (e instanceof ProblemDetailsError && e.status === 403) {
+      await ctx.answerInlineQuery([], {
+        is_personal: true,
+        cache_time: 0,
+        switch_pm_text: 'Привяжите аккаунт, чтобы искать фото',
+        switch_pm_parameter: 'link',
+      });
+      return;
+    }
+    logger.warn('inline_query error', e);
+    await ctx.answerInlineQuery([], {
+      is_personal: true,
+      cache_time: 0,
+      switch_pm_text: 'Не удалось выполнить поиск (повторить?)',
+      switch_pm_parameter: 'help',
+    });
+  }
+});

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -1,4 +1,3 @@
-import { Bot } from "grammy";
 import { configureAzureOpenAI } from "@photobank/shared/ai/openai";
 import {
   captionMissingMsg,
@@ -7,12 +6,12 @@ import {
 
 import { loadDictionaries, setDictionariesUser } from "./dictionaries";
 import {
-  BOT_TOKEN,
   AZURE_OPENAI_ENDPOINT,
   AZURE_OPENAI_KEY,
   AZURE_OPENAI_DEPLOYMENT,
   AZURE_OPENAI_API_VERSION,
 } from "./config";
+import { bot } from './bot';
 import { sendThisDayPage, thisDayCommand } from "./commands/thisday";
 import { captionCache } from "./photo";
 import { sendSearchPage, searchCommand } from "./commands/search";
@@ -29,8 +28,8 @@ import { uploadCommand } from "./commands/upload";
 import { withRegistered } from './registration';
 import { logger } from './logger';
 import { handleBotError } from './errorHandler';
-
-const bot = new Bot(BOT_TOKEN);
+import './handlers/inline';
+import './handlers/deeplink';
 
 bot.use(async (ctx, next) => {
   const username = ctx.from?.username ?? String(ctx.from?.id ?? '');

--- a/frontend/packages/telegram-bot/src/services/dictionary.ts
+++ b/frontend/packages/telegram-bot/src/services/dictionary.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'grammy';
+
 import { getPaths } from '../api/photobank/paths/paths';
 import { getPersons } from '../api/photobank/persons/persons';
 import { getStorages } from '../api/photobank/storages/storages';

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'grammy';
 import type { FilterDto } from '@photobank/shared/api/photobank';
+
 import { getPhotos } from '../api/photobank/photos/photos';
 import { handleServiceError } from '../errorHandler';
 


### PR DESCRIPTION
## Summary
- handle Telegram inline photo search with pagination and soft errors
- add deep-link handler for account linking help
- expose bot instance for handler registration

## Testing
- `pnpm --filter telegram-bot lint` *(fails: There should be no empty line within import group)*
- `pnpm --filter telegram-bot test` *(fails: Cannot find package '@tanstack/react-query')*

------
https://chatgpt.com/codex/tasks/task_e_689f90df09588328a97ad21046bcfe89