### PR TITLE
feat(bot): cache photo file_ids and throttle sends

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -20,6 +20,7 @@
     "grammy": "^1.37.0",
     "lru-cache": "^11.1.0",
     "p-retry": "^6.2.1",
+    "bottleneck": "^2.19.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/frontend/packages/telegram-bot/src/cache/fileIdCache.ts
+++ b/frontend/packages/telegram-bot/src/cache/fileIdCache.ts
@@ -1,21 +1,19 @@
-import LRUCache from 'lru-cache';
+import { LRUCache } from 'lru-cache';
 
-/**
- * Simple LRU cache for mapping Photo IDs from the Photobank API to Telegram's
- * `file_id` so that we avoid uploading the same binary multiple times.  This
- * drastically reduces both latency and traffic costs.
- */
-export const fileIdCache = new LRUCache<number, string>({
-  // A few thousands of entries is enough for typical usage while keeping the
-  // memory footprint low.  The limit can be tuned later via configuration if
-  // required.
+type Key = number; // PhotoId
+type Val = string; // file_id
+
+const cache = new LRUCache<Key, Val>({
   max: 20_000,
+  ttl: 1000 * 60 * 60 * 24 * 14, // 14 дней
 });
 
-export function getCachedFileId(photoId: number): string | undefined {
-  return fileIdCache.get(photoId);
+export function getFileId(photoId: number): string | undefined {
+  return cache.get(photoId);
 }
-
-export function setCachedFileId(photoId: number, fileId: string): void {
-  fileIdCache.set(photoId, fileId);
+export function setFileId(photoId: number, fileId: string) {
+  cache.set(photoId, fileId);
+}
+export function delFileId(photoId: number) {
+  cache.delete(photoId);
 }

--- a/frontend/packages/telegram-bot/src/logger.ts
+++ b/frontend/packages/telegram-bot/src/logger.ts
@@ -1,4 +1,5 @@
 export const logger = {
   info: (...args: unknown[]) => console.log(new Date().toISOString(), ...args),
+  warn: (...args: unknown[]) => console.warn(new Date().toISOString(), ...args),
   error: (...args: unknown[]) => console.error(new Date().toISOString(), ...args),
 };

--- a/frontend/packages/telegram-bot/src/types.ts
+++ b/frontend/packages/telegram-bot/src/types.ts
@@ -1,0 +1,3 @@
+import type { PhotoItemDto as SharedPhotoItemDto } from '@photobank/shared/api/photobank';
+
+export type PhotoItemDto = SharedPhotoItemDto;

--- a/frontend/packages/telegram-bot/src/utils/limiter.ts
+++ b/frontend/packages/telegram-bot/src/utils/limiter.ts
@@ -1,0 +1,12 @@
+import Bottleneck from 'bottleneck';
+
+// Глобальный лимитер: не более 1 send в 200ms (примерно)
+export const limiter = new Bottleneck({
+  minTime: 200, // 5 ops/sec
+  maxConcurrent: 1, // последовательные отправки
+});
+
+// Обёртка для вызовов Telegram API
+export async function throttled<T>(fn: () => Promise<T>): Promise<T> {
+  return limiter.schedule(fn);
+}

--- a/frontend/packages/telegram-bot/src/utils/logger.ts
+++ b/frontend/packages/telegram-bot/src/utils/logger.ts
@@ -1,0 +1,1 @@
+export { logger } from '../logger';

--- a/frontend/packages/telegram-bot/src/utils/retry.ts
+++ b/frontend/packages/telegram-bot/src/utils/retry.ts
@@ -1,0 +1,19 @@
+export async function withTelegramRetry<T>(fn: () => Promise<T>, maxAttempts = 3): Promise<T> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await fn();
+    } catch (e: any) {
+      attempt++;
+      const code = e?.error_code;
+      const desc = e?.description ?? '';
+      if (code === 429) {
+        const match = /retry after (\d+)/i.exec(desc);
+        const wait = match ? Number(match[1]) * 1000 : Math.min(2000 * attempt, 8000);
+        await new Promise(r => setTimeout(r, wait));
+        if (attempt < maxAttempts) continue;
+      }
+      throw e;
+    }
+  }
+}

--- a/frontend/packages/telegram-bot/test/send.test.ts
+++ b/frontend/packages/telegram-bot/test/send.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sendPhotoSmart, sendAlbumSmart } from '../src/telegram/send';
+import { getFileId, setFileId, delFileId } from '../src/cache/fileIdCache';
+import type { PhotoItemDto } from '../src/types';
+import { limiter } from '../src/utils/limiter';
+
+const basePhoto: PhotoItemDto = {
+  id: 1,
+  name: 'Test',
+  takenDate: '2024-01-01',
+  previewUrl: 'http://example.com/prev.jpg',
+  originalUrl: 'http://example.com/orig.jpg',
+  storageName: 's',
+  relativePath: 'r',
+};
+
+beforeEach(() => {
+  limiter.updateSettings({ minTime: 0 });
+});
+
+describe('sendPhotoSmart', () => {
+  it('stores file_id in cache after successful send', async () => {
+    const ctx: any = {
+      chat: { id: 1 },
+      api: { sendPhoto: vi.fn().mockResolvedValue({ photo: [{ file_id: 'abc' }] }) },
+    };
+    delFileId(basePhoto.id);
+    await sendPhotoSmart(ctx, basePhoto);
+    expect(ctx.api.sendPhoto).toHaveBeenCalledTimes(1);
+    expect(getFileId(basePhoto.id)).toBe('abc');
+  });
+
+  it('invalidates cache when Telegram reports wrong file identifier', async () => {
+    const photo = { ...basePhoto, id: 2 };
+    setFileId(photo.id, 'old');
+    const err = { error_code: 400, description: 'wrong file identifier' };
+    const ctx: any = {
+      chat: { id: 1 },
+      api: {
+        sendPhoto: vi
+          .fn()
+          .mockRejectedValueOnce(err)
+          .mockResolvedValue({ photo: [{ file_id: 'new' }] }),
+      },
+    };
+    await sendPhotoSmart(ctx, photo);
+    expect(ctx.api.sendPhoto).toHaveBeenCalledTimes(2);
+    expect(getFileId(photo.id)).toBe('new');
+  });
+});
+
+describe('sendAlbumSmart', () => {
+  it('falls back to single sends when mediaGroup fails', async () => {
+    const photos: PhotoItemDto[] = [
+      { ...basePhoto, id: 10 },
+      { ...basePhoto, id: 11 },
+    ];
+    const ctx: any = {
+      chat: { id: 1 },
+      api: {
+        sendMediaGroup: vi.fn().mockRejectedValue(new Error('fail')),
+        sendPhoto: vi.fn().mockResolvedValue({ photo: [{ file_id: 'x' }] }),
+      },
+    };
+    await sendAlbumSmart(ctx, photos);
+    expect(ctx.api.sendMediaGroup).toHaveBeenCalledTimes(1);
+    expect(ctx.api.sendPhoto).toHaveBeenCalledTimes(photos.length);
+  });
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       axios:
         specifier: ^1.11.0
         version: 1.11.0
+      bottleneck:
+        specifier: ^2.19.5
+        version: 2.19.5
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
@@ -3051,6 +3054,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
@@ -9996,6 +10002,8 @@ snapshots:
   big-integer@1.6.52: {}
 
   binary-extensions@2.3.0: {}
+
+  bottleneck@2.19.5: {}
 
   bplist-creator@0.1.0:
     dependencies:


### PR DESCRIPTION
## Summary
- cache Telegram `file_id`s with TTL to avoid re-uploading photos
- throttle send operations and add retry logic for Telegram API
- support smart album sending with fallback and tests

## Testing
- `pnpm --filter @photobank/telegram-bot test test/send.test.ts`
- `pnpm --filter @photobank/telegram-bot test` *(fails: Cannot find package 'openai', 'date-fns')*

------
https://chatgpt.com/codex/tasks/task_e_689f9400cc2c832889c7f10df3e1fe55