### PR TITLE
feat(frontend): enable MSW in dev using generated handlers

### DIFF
--- a/frontend/packages/frontend/package.json
+++ b/frontend/packages/frontend/package.json
@@ -81,6 +81,7 @@
     "eslint-plugin-unused-imports": "^4.1.4",
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",
+    "msw": "^2.10.5",
     "prettier": "^3.6.2",
     "tailwindcss-debug-screens": "^3.0.1",
     "tw-animate-css": "^1.3.6",

--- a/frontend/packages/frontend/src/main.tsx
+++ b/frontend/packages/frontend/src/main.tsx
@@ -11,11 +11,16 @@ import App from './app/App.tsx';
 
 import './index.css';
 
-function start() {
+async function start() {
   configureApi(API_BASE_URL);
 
-   
-  ReactDOM.createRoot(document.getElementById('root')!).render(
+  if (import.meta.env.DEV) {
+    const { worker } = await import('./mocks/browser');
+    await worker.start({ onUnhandledRequest: 'bypass' });
+  }
+
+  const root = document.getElementById('root')!;
+  ReactDOM.createRoot(root).render(
     <QueryProvider>
       <Provider store={store}>
         <BrowserRouter>

--- a/frontend/packages/frontend/src/mocks/browser.ts
+++ b/frontend/packages/frontend/src/mocks/browser.ts
@@ -1,0 +1,20 @@
+import { setupWorker } from 'msw';
+import { handlers as authHandlers } from '@photobank/shared/api/photobank/auth/auth.msw';
+import { handlers as facesHandlers } from '@photobank/shared/api/photobank/faces/faces.msw';
+import { handlers as photosHandlers } from '@photobank/shared/api/photobank/photos/photos.msw';
+import { handlers as personsHandlers } from '@photobank/shared/api/photobank/persons/persons.msw';
+import { handlers as tagsHandlers } from '@photobank/shared/api/photobank/tags/tags.msw';
+import { handlers as usersHandlers } from '@photobank/shared/api/photobank/users/users.msw';
+import { handlers as pathsHandlers } from '@photobank/shared/api/photobank/paths/paths.msw';
+import { handlers as storagesHandlers } from '@photobank/shared/api/photobank/storages/storages.msw';
+
+export const worker = setupWorker(
+  ...authHandlers,
+  ...facesHandlers,
+  ...photosHandlers,
+  ...personsHandlers,
+  ...tagsHandlers,
+  ...usersHandlers,
+  ...pathsHandlers,
+  ...storagesHandlers,
+);

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
+      msw:
+        specifier: ^2.10.5
+        version: 2.10.5(@types/node@24.1.0)(typescript@5.8.3)
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -9696,7 +9699,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.1.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.1.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@24.1.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -12403,7 +12406,6 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   msw@2.10.5(@types/node@24.1.0)(typescript@5.9.2):
     dependencies:


### PR DESCRIPTION
## Summary
- add msw worker that combines generated handlers
- start msw in development mode
- include msw as dev dependency

## Testing
- `pnpm -F @photobank/frontend test` *(fails: Failed to resolve import "@tanstack/react-query" from "../shared/src/api/photobank/auth/auth.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68a029e2124c832885dfd04d637790da