### PR TITLE
test(frontend): enable MSW server for tests with shared handlers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   "packageManager": "pnpm@10.14.0",
   "devDependencies": {
     "@eslint/js": "^9.31.0",
+    "@faker-js/faker": "^9.9.0",
     "@types/object-hash": "^3.0.6",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",

--- a/frontend/packages/frontend/src/mocks/browser.ts
+++ b/frontend/packages/frontend/src/mocks/browser.ts
@@ -1,20 +1,4 @@
 import { setupWorker } from 'msw';
-import { handlers as authHandlers } from '@photobank/shared/api/photobank/auth/auth.msw';
-import { handlers as facesHandlers } from '@photobank/shared/api/photobank/faces/faces.msw';
-import { handlers as photosHandlers } from '@photobank/shared/api/photobank/photos/photos.msw';
-import { handlers as personsHandlers } from '@photobank/shared/api/photobank/persons/persons.msw';
-import { handlers as tagsHandlers } from '@photobank/shared/api/photobank/tags/tags.msw';
-import { handlers as usersHandlers } from '@photobank/shared/api/photobank/users/users.msw';
-import { handlers as pathsHandlers } from '@photobank/shared/api/photobank/paths/paths.msw';
-import { handlers as storagesHandlers } from '@photobank/shared/api/photobank/storages/storages.msw';
+import { handlers } from './handlers';
 
-export const worker = setupWorker(
-  ...authHandlers,
-  ...facesHandlers,
-  ...photosHandlers,
-  ...personsHandlers,
-  ...tagsHandlers,
-  ...usersHandlers,
-  ...pathsHandlers,
-  ...storagesHandlers,
-);
+export const worker = setupWorker(...handlers);

--- a/frontend/packages/frontend/src/mocks/handlers.ts
+++ b/frontend/packages/frontend/src/mocks/handlers.ts
@@ -1,0 +1,19 @@
+import { getAuthMock } from '@photobank/shared/api/photobank/auth/auth.msw';
+import { getFacesMock } from '@photobank/shared/api/photobank/faces/faces.msw';
+import { getPhotosMock } from '@photobank/shared/api/photobank/photos/photos.msw';
+import { getPersonsMock } from '@photobank/shared/api/photobank/persons/persons.msw';
+import { getTagsMock } from '@photobank/shared/api/photobank/tags/tags.msw';
+import { getUsersMock } from '@photobank/shared/api/photobank/users/users.msw';
+import { getPathsMock } from '@photobank/shared/api/photobank/paths/paths.msw';
+import { getStoragesMock } from '@photobank/shared/api/photobank/storages/storages.msw';
+
+export const handlers = [
+  ...getAuthMock(),
+  ...getFacesMock(),
+  ...getPhotosMock(),
+  ...getPersonsMock(),
+  ...getTagsMock(),
+  ...getUsersMock(),
+  ...getPathsMock(),
+  ...getStoragesMock(),
+];

--- a/frontend/packages/frontend/test-setup.ts
+++ b/frontend/packages/frontend/test-setup.ts
@@ -1,3 +1,6 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './src/mocks/handlers';
+
 import '@testing-library/jest-dom/vitest';
 
 class ResizeObserver {
@@ -37,3 +40,8 @@ Object.defineProperty(globalThis, 'HTMLCanvasElement', {
     getContext() { return null; }
   },
 });
+
+const server = setupServer(...handlers);
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.31.0
         version: 9.31.0
+      '@faker-js/faker':
+        specifier: ^9.9.0
+        version: 9.9.0
       '@types/object-hash':
         specifier: ^3.0.6
         version: 3.0.6
@@ -186,6 +189,9 @@ importers:
       '@eslint/js':
         specifier: ^9.31.0
         version: 9.31.0
+      '@faker-js/faker':
+        specifier: ^9.9.0
+        version: 9.9.0
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -9699,7 +9705,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.1.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@24.1.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.1.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:


### PR DESCRIPTION
## Summary
- aggregate MSW handlers from shared API and expose them to the frontend
- spin up an MSW server in tests and share handler list with browser worker
- add @faker-js/faker to dev deps for mock generation

## Testing
- `pnpm --filter @photobank/frontend test` *(fails: Cannot read properties of null (reading 'useContext'))*

------
https://chatgpt.com/codex/tasks/task_e_68a02f4721b88328b53a776d47bc7eb7