### PR TITLE
perf(frontend): lazy-load routes with React.lazy and Suspense

### DIFF
--- a/frontend/packages/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/packages/frontend/src/routes/AppRoutes.tsx
@@ -1,35 +1,39 @@
+import { lazy, Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import RequireAuth from '@/app/RequireAuth.tsx';
 import RequireAdmin from '@/app/RequireAdmin.tsx';
-import PhotoListPage from '@/pages/list/PhotoListPage.tsx';
-import FilterPage from '@/pages/filter/FilterPage.tsx';
-import PhotoDetailsPage from '@/pages/detail/PhotoDetailsPage.tsx';
-import LoginPage from '@/pages/auth/LoginPage.tsx';
-import RegisterPage from '@/pages/auth/RegisterPage.tsx';
-import LogoutPage from '@/pages/auth/LogoutPage.tsx';
-import MyProfilePage from '@/pages/profile/MyProfilePage.tsx';
-import UsersPage from '@/pages/admin/UsersPage.tsx';
-import ServiceInfoPage from '@/pages/service/ServiceInfoPage.tsx';
-import OpenAIPage from '@/pages/openai/OpenAIPage.tsx';
+
+const PhotoListPage = lazy(() => import('@/pages/list/PhotoListPage'));
+const FilterPage = lazy(() => import('@/pages/filter/FilterPage'));
+const PhotoDetailsPage = lazy(() => import('@/pages/detail/PhotoDetailsPage'));
+const LoginPage = lazy(() => import('@/pages/auth/LoginPage'));
+const RegisterPage = lazy(() => import('@/pages/auth/RegisterPage'));
+const LogoutPage = lazy(() => import('@/pages/auth/LogoutPage'));
+const MyProfilePage = lazy(() => import('@/pages/profile/MyProfilePage'));
+const UsersPage = lazy(() => import('@/pages/admin/UsersPage'));
+const ServiceInfoPage = lazy(() => import('@/pages/service/ServiceInfoPage'));
+const OpenAIPage = lazy(() => import('@/pages/openai/OpenAIPage'));
 
 export const AppRoutes = () => (
-  <Routes>
-    <Route path="/login" element={<LoginPage />} />
-    <Route path="/register" element={<RegisterPage />} />
-    <Route path="/service" element={<ServiceInfoPage />} />
-    <Route path="/openai" element={<OpenAIPage />} />
-    <Route element={<RequireAuth />}>
-      <Route path="/" element={<Navigate to="/filter" />} />
-      <Route path="/logout" element={<LogoutPage />} />
-      <Route path="/profile" element={<MyProfilePage />} />
-      <Route path="/filter" element={<FilterPage />} />
-      <Route path="/photos" element={<PhotoListPage />} />
-      <Route path="/photos/:id" element={<PhotoDetailsPage />} />
-      <Route element={<RequireAdmin />}>
-        <Route path="/admin/users" element={<UsersPage />} />
+  <Suspense fallback={<div className="p-6 text-muted-foreground">Loading…</div>}>
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route path="/service" element={<ServiceInfoPage />} />
+      <Route path="/openai" element={<OpenAIPage />} />
+      <Route element={<RequireAuth />}>
+        <Route path="/" element={<Navigate to="/filter" />} />
+        <Route path="/logout" element={<LogoutPage />} />
+        <Route path="/profile" element={<MyProfilePage />} />
+        <Route path="/filter" element={<FilterPage />} />
+        <Route path="/photos" element={<PhotoListPage />} />
+        <Route path="/photos/:id" element={<PhotoDetailsPage />} />
+        <Route element={<RequireAdmin />}>
+          <Route path="/admin/users" element={<UsersPage />} />
+        </Route>
       </Route>
-    </Route>
-    <Route path="*" element={<Navigate to="/login" replace />} />
-  </Routes>
+      <Route path="*" element={<Navigate to="/login" replace />} />
+    </Routes>
+  </Suspense>
 );


### PR DESCRIPTION
## Summary
- lazy-load pages in AppRoutes using `React.lazy`
- wrap routing in `Suspense` with a simple loading fallback

## Testing
- `pnpm install`
- `pnpm --filter frontend build` *(fails: Cannot find name 'StorageDto', 'TagDto', 'UserWithClaimsDto', etc. in shared package)*

------
https://chatgpt.com/codex/tasks/task_e_68a0391dce088328acee4d4d04b1b6ee