### PR TITLE
chore(telegram-bot): exclude mocks from tsc

### DIFF
--- a/frontend/packages/telegram-bot/tsconfig.json
+++ b/frontend/packages/telegram-bot/tsconfig.json
@@ -10,5 +10,12 @@
     "types": ["vitest/globals"]
   },
   "references": [{ "path": "../shared" }],
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.msw.ts",
+    "src/**/__mocks__/**",
+    "src/**/*.mock.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- exclude tests and mock files from TypeScript compilation for telegram bot

## Testing
- `pnpm -C frontend/packages/telegram-bot run build` (fails: Cannot find module '@photobank/shared/constants')
- `ls -la frontend/packages/telegram-bot/dist`


------
https://chatgpt.com/codex/tasks/task_e_68a073519ac88328a4231d32f7ee0a7f