### PR TITLE
fix: build telegram bot

### DIFF
--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -18,6 +18,21 @@
       "types": "./dist/ai/index.d.ts",
       "import": "./dist/ai/index.js"
     },
+    "./ai/*": {
+      "types": "./dist/ai/*.d.ts",
+      "import": "./dist/ai/*.js",
+      "default": "./dist/ai/*.js"
+    },
+    "./constants": {
+      "types": "./dist/constants.d.ts",
+      "import": "./dist/constants.js",
+      "default": "./dist/constants.js"
+    },
+    "./index": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
     "./types/problem": {
       "types": "./dist/types/problem.d.ts",
       "import": "./dist/types/problem.js",

--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -b",
     "start": "node dist/index.js",
     "test": "vitest run"
   },

--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -12,12 +12,12 @@ export async function sendPersonsPage(
   await sendNamedItemsPage({
     ctx,
     command: "persons",
-    fetchAll: () => getAllPersons(),
+    fetchAll: async () => getAllPersons(),
     prefix,
     page,
     edit,
     errorMsg: "🚫 Не удалось получить список персон.",
-    filter: (p: { id: number }) => p.id >= 1,
+    filter: (p) => p.id >= 1,
   });
 }
 

--- a/frontend/packages/telegram-bot/src/commands/profile.ts
+++ b/frontend/packages/telegram-bot/src/commands/profile.ts
@@ -14,10 +14,10 @@ import { handleCommandError } from "../errorHandler";
 export async function profileCommand(ctx: Context) {
     const username = ctx.from?.username ?? String(ctx.from?.id ?? "");
     try {
-        await getUser();
+        await getUser(ctx);
         const [rolesRes, claimsRes] = await Promise.all([
-            getUserRoles(),
-            getUserClaims(),
+            getUserRoles(ctx),
+            getUserClaims(ctx),
         ]);
         const roles = rolesRes.data;
         const claims = claimsRes.data;

--- a/frontend/packages/telegram-bot/src/commands/tags.ts
+++ b/frontend/packages/telegram-bot/src/commands/tags.ts
@@ -12,7 +12,7 @@ export async function sendTagsPage(
   await sendNamedItemsPage({
     ctx,
     command: "tags",
-    fetchAll: () => getAllTags(),
+    fetchAll: async () => getAllTags(),
     prefix,
     page,
     edit,

--- a/frontend/packages/telegram-bot/src/errorHandler.ts
+++ b/frontend/packages/telegram-bot/src/errorHandler.ts
@@ -11,7 +11,7 @@ export function handleBotError(err: BotError<Context>) {
 }
 
 export async function handleCommandError(ctx: Context, error: unknown) {
-  if (error instanceof ProblemDetailsError && error.status === 403) {
+  if (error instanceof ProblemDetailsError && error.problem.status === 403) {
     await ctx.reply(
       'Ваш Telegram не привязан к аккаунту PhotoBank. Обратитесь к администратору.',
     );

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -23,12 +23,13 @@ bot.on('inline_query', async (ctx) => {
       top: PAGE_SIZE,
     });
 
-    const items = resp.data.photos ?? resp.data.items ?? resp.data ?? [];
+    const data: any = resp.data as any;
+    const items = data.photos ?? data.items ?? resp.data ?? [];
     const results: InlineQueryResult[] = items.map((p): InlineQueryResultPhoto => ({
       type: 'photo',
       id: String(p.id),
       photo_url: p.previewUrl ?? p.originalUrl ?? '',
-      thumb_url: p.thumbnailUrl ?? p.previewUrl ?? p.originalUrl ?? '',
+      thumbnail_url: p.thumbnailUrl ?? p.previewUrl ?? p.originalUrl ?? '',
       title: p.name ?? `#${p.id}`,
       description: [
         formatDate(p.takenDate),
@@ -41,29 +42,38 @@ bot.on('inline_query', async (ctx) => {
 
     const nextOffset = items.length === PAGE_SIZE ? String(offset + PAGE_SIZE) : '';
 
-    await ctx.answerInlineQuery(results, {
-      is_personal: true,
-      cache_time: 5,
-      next_offset: nextOffset,
-      switch_pm_text: undefined,
-      switch_pm_parameter: undefined,
-    });
-  } catch (e) {
-    if (e instanceof ProblemDetailsError && e.status === 403) {
-      await ctx.answerInlineQuery([], {
+    await ctx.answerInlineQuery(
+      results,
+      {
         is_personal: true,
-        cache_time: 0,
-        switch_pm_text: 'Привяжите аккаунт, чтобы искать фото',
-        switch_pm_parameter: 'link',
-      });
+        cache_time: 5,
+        next_offset: nextOffset,
+        switch_pm_text: undefined,
+        switch_pm_parameter: undefined,
+      } as any,
+    );
+  } catch (e) {
+    if (e instanceof ProblemDetailsError && e.problem.status === 403) {
+      await ctx.answerInlineQuery(
+        [],
+        {
+          is_personal: true,
+          cache_time: 0,
+          switch_pm_text: 'Привяжите аккаунт, чтобы искать фото',
+          switch_pm_parameter: 'link',
+        } as any,
+      );
       return;
     }
     logger.warn('inline_query error', e);
-    await ctx.answerInlineQuery([], {
-      is_personal: true,
-      cache_time: 0,
-      switch_pm_text: 'Не удалось выполнить поиск (повторить?)',
-      switch_pm_parameter: 'help',
-    });
+    await ctx.answerInlineQuery(
+      [],
+      {
+        is_personal: true,
+        cache_time: 0,
+        switch_pm_text: 'Не удалось выполнить поиск (повторить?)',
+        switch_pm_parameter: 'help',
+      } as any,
+    );
   }
 });

--- a/frontend/packages/telegram-bot/src/registration.ts
+++ b/frontend/packages/telegram-bot/src/registration.ts
@@ -9,7 +9,7 @@ export async function ensureRegistered(ctx: Context): Promise<boolean> {
     await ensureUserAccessToken(ctx);
     return true;
   } catch (err) {
-    if (err instanceof ProblemDetailsError && err.status === 403) {
+    if (err instanceof ProblemDetailsError && err.problem.status === 403) {
       await ctx.reply(
         'Ваш Telegram не привязан к аккаунту PhotoBank. Обратитесь к администратору.',
       );

--- a/frontend/packages/telegram-bot/src/services/auth.ts
+++ b/frontend/packages/telegram-bot/src/services/auth.ts
@@ -1,0 +1,27 @@
+import type { Context } from 'grammy';
+import {
+  authGetUser,
+  authGetUserRoles,
+  authGetUserClaims,
+  type authGetUserResponse,
+  type authGetUserRolesResponse,
+  type authGetUserClaimsResponse,
+} from '@photobank/shared/api/photobank';
+import { ensureUserAccessToken } from '../auth';
+
+async function authorized<T>(ctx: Context, fn: (options?: RequestInit) => Promise<T>): Promise<T> {
+  const token = await ensureUserAccessToken(ctx);
+  return fn({ headers: { Authorization: `Bearer ${token}` } });
+}
+
+export function getUser(ctx: Context): Promise<authGetUserResponse> {
+  return authorized(ctx, authGetUser);
+}
+
+export function getUserRoles(ctx: Context): Promise<authGetUserRolesResponse> {
+  return authorized(ctx, authGetUserRoles);
+}
+
+export function getUserClaims(ctx: Context): Promise<authGetUserClaimsResponse> {
+  return authorized(ctx, authGetUserClaims);
+}

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -34,7 +34,7 @@ export async function uploadPhotos(
   options: { files: UploadFile[]; storageId: number; path: string },
 ) {
   const { files, storageId, path } = options;
-  const blobs = files.map(({ data, name }) => new File([data], name));
+  const blobs = files.map(({ data, name }) => new File([data as BlobPart], name));
   try {
     return await photosUpload({ files: blobs, storageId, path }, ctx);
   } catch (err) {


### PR DESCRIPTION
## Summary
- expose shared constants and AI utilities for bot consumption
- ensure telegram-bot builds its dependency graph and resolves types
- add auth service helpers and clean up command handlers

## Testing
- `pnpm --filter telegram-bot build`
- `pnpm --filter telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_68a085b419c88328b8b4c7b5f8e4974a