### PR TITLE
fix: safe import-meta env access in shared logger

### DIFF
--- a/frontend/packages/shared/src/utils/logger.ts
+++ b/frontend/packages/shared/src/utils/logger.ts
@@ -2,7 +2,8 @@ const isDev =
   // node / jest / vite build
   (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') ||
   // browser vite
-  (typeof import.meta !== 'undefined' && import.meta.env?.DEV === true);
+  (typeof import.meta !== 'undefined' &&
+    (import.meta as { env?: { DEV?: boolean } }).env?.DEV === true);
 export const logger = {
   debug: (...a: unknown[]) => { if (isDev) console.debug(...a); },
   warn:  (...a: unknown[]) => { if (isDev) console.warn(...a);  },


### PR DESCRIPTION
## Summary
- handle import.meta.env access in shared logger for tsc build

## Testing
- `pnpm --filter @photobank/shared lint`
- `pnpm --filter @photobank/shared build`
- `pnpm --filter @photobank/shared test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a9eee80c8328a63aab056020ab31