### PR TITLE
fix: address build and lint issues

### DIFF
--- a/frontend/packages/frontend/package.json
+++ b/frontend/packages/frontend/package.json
@@ -7,7 +7,7 @@
     "start": "HOST=0.0.0.0 react-scripts start",
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint src --ext .ts,.tsx",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,scss,html,json}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "preview": "vite preview",

--- a/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
+++ b/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
@@ -28,7 +28,7 @@ import {Input} from '@/shared/ui/input';
 
 const formSchema = z.object({
   phoneNumber: z.string().optional(),
-  telegram: z.string().optional(),
+  telegramUserId: z.string().optional(),
 });
 
 type FormData = z.infer<typeof formSchema>;
@@ -45,18 +45,28 @@ export default function MyProfilePage() {
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
-    defaultValues: { phoneNumber: '', telegram: '' },
+    defaultValues: { phoneNumber: '', telegramUserId: '' },
   });
 
   useEffect(() => {
     if (user) {
-      form.reset({ phoneNumber: user.phoneNumber ?? '', telegram: user.telegram ?? '' });
+      form.reset({
+        phoneNumber: user.phoneNumber ?? '',
+        telegramUserId: user.telegramUserId ? String(user.telegramUserId) : '',
+      });
     }
   }, [user, form]);
 
   const onSubmit = async (data: FormData) => {
     try {
-      await updateUser({ data });
+      await updateUser({
+        data: {
+          phoneNumber: data.phoneNumber,
+          telegramUserId: data.telegramUserId
+            ? Number(data.telegramUserId)
+            : undefined,
+        },
+      });
       navigate('/filter');
     } catch (e) {
       logger.error(e);
@@ -94,7 +104,7 @@ export default function MyProfilePage() {
               />
               <FormField
                 control={form.control}
-                name="telegram"
+                name="telegramUserId"
                 render={({field}) => (
                   <FormItem>
                     <FormLabel>{telegramLabel}</FormLabel>

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "lint": "eslint src --ext .ts"
+    "lint": "eslint \"src/**/*.ts\""
   },
   "dependencies": {
     "@tanstack/react-query": "^5.85.3",

--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -12,7 +12,7 @@ export async function sendPersonsPage(
   await sendNamedItemsPage({
     ctx,
     command: "persons",
-      fetchAll: () => getAllPersons(),
+    fetchAll: () => Promise.resolve(getAllPersons()),
     prefix,
     page,
     edit,

--- a/frontend/packages/telegram-bot/src/commands/tags.ts
+++ b/frontend/packages/telegram-bot/src/commands/tags.ts
@@ -12,7 +12,7 @@ export async function sendTagsPage(
   await sendNamedItemsPage({
     ctx,
     command: "tags",
-      fetchAll: () => getAllTags(),
+    fetchAll: () => Promise.resolve(getAllTags()),
     prefix,
     page,
     edit,

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -51,38 +51,40 @@ bot.on('inline_query', async (ctx) => {
 
     const nextOffset = items.length === PAGE_SIZE ? String(offset + PAGE_SIZE) : '';
 
-      await ctx.answerInlineQuery(
-        results,
-        {
-          is_personal: true,
-          cache_time: 5,
-          next_offset: nextOffset,
-          switch_pm_text: undefined,
-          switch_pm_parameter: undefined,
-        } satisfies Parameters<typeof ctx.answerInlineQuery>[1],
-      );
+    await ctx.answerInlineQuery(
+      results,
+      {
+        is_personal: true,
+        cache_time: 5,
+        next_offset: nextOffset,
+      } satisfies Parameters<typeof ctx.answerInlineQuery>[1],
+    );
   } catch (e) {
-      if (e instanceof ProblemDetailsError && e.problem.status === 403) {
-        await ctx.answerInlineQuery(
-          [],
-          {
-            is_personal: true,
-            cache_time: 0,
-            switch_pm_text: 'Привяжите аккаунт, чтобы искать фото',
-            switch_pm_parameter: 'link',
-          } satisfies Parameters<typeof ctx.answerInlineQuery>[1],
-        );
-        return;
-      }
-      logger.warn('inline_query error', e);
+    if (e instanceof ProblemDetailsError && e.problem.status === 403) {
       await ctx.answerInlineQuery(
         [],
         {
           is_personal: true,
           cache_time: 0,
-          switch_pm_text: 'Не удалось выполнить поиск (повторить?)',
-          switch_pm_parameter: 'help',
+          button: {
+            text: 'Привяжите аккаунт, чтобы искать фото',
+            start_parameter: 'link',
+          },
         } satisfies Parameters<typeof ctx.answerInlineQuery>[1],
       );
+      return;
     }
+    logger.warn('inline_query error', e);
+    await ctx.answerInlineQuery(
+      [],
+      {
+        is_personal: true,
+        cache_time: 0,
+        button: {
+          text: 'Не удалось выполнить поиск (повторить?)',
+          start_parameter: 'help',
+        },
+      } satisfies Parameters<typeof ctx.answerInlineQuery>[1],
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- fix Telegram inline handler to use new button syntax
- ensure person and tag commands return promises
- align profile page with API telegramUserId
- restrict lint scripts to TypeScript files

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a0ad5d80d083288f5d63a2a9f91bb9