### PR TITLE
chore(frontend): remove CRA start script and update architecture

### DIFF
--- a/frontend/architecture.md
+++ b/frontend/architecture.md
@@ -1,6 +1,6 @@
 # PhotoBank — Frontend Architecture (Short)
 
-> Target: `packages/frontend` (React 18, Vite, Vitest, RTL, Redux Toolkit, shadcn/ui, pnpm monorepo)
+> Target: `packages/frontend` (React 19, React Query 5, Vite, Vitest, RTL, Redux Toolkit, shadcn/ui, pnpm monorepo)
 
 ## Принципы
 - Модульность и переиспользуемость.
@@ -9,7 +9,9 @@
 - Тестируемость и предсказуемость.
 
 ## Потоки данных
-- Redux Toolkit: slices, selectors, hooks в `features/*/model/`.
+- React Query 5: серверное состояние, поиск — через `useInfiniteQuery`.
+- filter ↔ URL, персист в `localStorage`.
+- Redux Toolkit только для auth/meta/filter: slices, selectors, hooks в `features/*/model/`.
 - DTO из `@photobank/shared`.
 - Нормализация данных: `x ?? []`, `y ?? ''` вместо `undefined`.
 

--- a/frontend/packages/frontend/package.json
+++ b/frontend/packages/frontend/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "HOST=0.0.0.0 react-scripts start",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",


### PR DESCRIPTION
## Summary
- drop unused CRA start script from frontend package
- document React 19 & React Query 5 architecture: search via useInfiniteQuery, filter synced with URL & localStorage, Redux only for auth/meta/filter

## Testing
- `pnpm -C frontend --filter @photobank/frontend lint`
- `pnpm -C frontend --filter @photobank/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c1d8ddd48328a9f8203b52d156db