### PR TITLE
Sync filter state with URL query params

### DIFF
--- a/frontend/packages/frontend/src/shared/lib/filter-url.ts
+++ b/frontend/packages/frontend/src/shared/lib/filter-url.ts
@@ -1,0 +1,28 @@
+import { Buffer } from 'buffer';
+import type { FormData } from '@/features/filter/lib/form-schema';
+import { formSchema } from '@/features/filter/lib/form-schema';
+
+const toBase64 = (json: string) =>
+  typeof window === 'undefined'
+    ? Buffer.from(json, 'utf-8').toString('base64')
+    : window.btoa(json);
+
+const fromBase64 = (encoded: string) =>
+  typeof window === 'undefined'
+    ? Buffer.from(encoded, 'base64').toString('utf-8')
+    : window.atob(encoded);
+
+export const serializeFilter = (data: FormData): string => {
+  const json = JSON.stringify(data);
+  return toBase64(json);
+};
+
+export const deserializeFilter = (value: string): FormData | null => {
+  try {
+    const json = fromBase64(value);
+    const parsed = formSchema.parse(JSON.parse(json));
+    return parsed;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- Encode and decode filter settings to base64 for sharing in URLs
- Hydrate filter from URL query on filter and list pages
- Persist selected filters in photo list navigation

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0cafe5e30832898f3507783421fc2