### PR TITLE
refactor: remove lastResult from photo slice

### DIFF
--- a/frontend/packages/frontend/src/features/photo/model/photoSlice.ts
+++ b/frontend/packages/frontend/src/features/photo/model/photoSlice.ts
@@ -1,20 +1,15 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import type {
-  FilterDto,
-  PhotoItemDto,
-} from '@photobank/shared/api/photobank';
+import type { FilterDto } from '@photobank/shared/api/photobank';
 import { DEFAULT_PHOTO_FILTER } from '@photobank/shared/constants';
 
 interface PhotoState {
   filter: FilterDto;
   selectedPhotos: number[];
-  lastResult: PhotoItemDto[];
 }
 
 const initialState: PhotoState = {
   filter: { ...DEFAULT_PHOTO_FILTER },
   selectedPhotos: [],
-  lastResult: [],
 };
 
 const photoSlice = createSlice({
@@ -40,9 +35,6 @@ const photoSlice = createSlice({
         (id) => id !== action.payload
       );
     },
-    setLastResult(state, action: PayloadAction<PhotoItemDto[]>) {
-      state.lastResult = action.payload;
-    },
   },
 });
 
@@ -52,7 +44,6 @@ export const {
   setSelectedPhotos,
   addSelectedPhoto,
   removeSelectedPhoto,
-  setLastResult,
 } = photoSlice.actions;
 
 export default photoSlice.reducer;

--- a/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -5,10 +5,10 @@ import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { useEffect } from 'react';
 import { DEFAULT_FORM_VALUES, filterFormTitle, applyFiltersButton, loadingText } from '@photobank/shared/constants';
 import * as Api from '@photobank/shared/api/photobank/photos/photos';
-import type { FilterDto, PhotoItemDto } from '@photobank/shared/api/photobank';
+import type { FilterDto } from '@photobank/shared/api/photobank';
 
 import { useAppDispatch, useAppSelector } from '@/app/hook';
-import { setFilter, setLastResult } from '@/features/photo/model/photoSlice';
+import { setFilter } from '@/features/photo/model/photoSlice';
 import { loadMetadata } from '@/features/meta/model/metaSlice';
 import { Button } from '@/shared/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/card';
@@ -19,8 +19,6 @@ import { serializeFilter, deserializeFilter } from '@/shared/lib/filter-url';
 
 // Infer FormData type from formSchema to ensure compatibility
 type FormData = z.infer<typeof formSchema>;
-type PhotosPage = { items?: PhotoItemDto[]; totalCount?: number };
-
 function FilterPage() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
@@ -106,10 +104,8 @@ function FilterPage() {
     searchPhotos.mutate(
       { data: filter },
       {
-        onSuccess: (page) => {
-          const photos = (page.data as PhotosPage).items ?? [];
+        onSuccess: () => {
           dispatch(setFilter(filter));
-          dispatch(setLastResult(photos));
           navigate(`/photos?filter=${encodeURIComponent(encoded)}`);
         },
         onError: () => {

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -9,7 +9,7 @@ import {
 
 import { useInfinitePhotos } from '@/features/photo/useInfinitePhotos';
 import { useAppDispatch, useAppSelector } from '@/app/hook';
-import { setLastResult, setFilter } from '@/features/photo/model/photoSlice';
+import { setFilter } from '@/features/photo/model/photoSlice';
 import { useViewer } from '@/features/viewer/state';
 import { pushPhotoId, readPhotoId, clearPhotoId } from '@/features/viewer/urlSync';
 import EmptyState from '@/components/EmptyState';
@@ -161,10 +161,6 @@ const PhotoListPage = () => {
     (_photo: PhotoItemDto) => <PhotoListItemSkeleton />,
     []
   );
-
-  useEffect(() => {
-    dispatch(setLastResult(photos));
-  }, [photos, dispatch]);
 
   useEffect(() => {
     const id = readPhotoId(location.search);

--- a/frontend/packages/frontend/test/FilterPage.test.tsx
+++ b/frontend/packages/frontend/test/FilterPage.test.tsx
@@ -31,7 +31,7 @@ const renderPage = async (preloaded: any) => {
     reducer: { metadata: metaReducer, photo: photoReducer },
     preloadedState: {
       metadata: { ...initialMeta, ...preloaded },
-      photo: { filter: { ...DEFAULT_PHOTO_FILTER }, selectedPhotos: [], lastResult: [] },
+      photo: { filter: { ...DEFAULT_PHOTO_FILTER }, selectedPhotos: [] },
     },
   });
 

--- a/frontend/packages/frontend/test/photoSlice.test.ts
+++ b/frontend/packages/frontend/test/photoSlice.test.ts
@@ -4,7 +4,6 @@ import reducer, {
   removeSelectedPhoto,
   setFilter,
   resetFilter,
-  setLastResult,
 } from '../src/features/photo/model/photoSlice';
 import { DEFAULT_PHOTO_FILTER } from '@photobank/shared/constants';
 
@@ -24,12 +23,6 @@ describe('photoSlice', () => {
     expect(state.selectedPhotos).toEqual([1, 2]);
     state = reducer(state, removeSelectedPhoto(1));
     expect(state.selectedPhotos).toEqual([2]);
-  });
-
-  it('updates last result', () => {
-    const photos = [{ id: 5 } as any];
-    const state = reducer(undefined, setLastResult(photos));
-    expect(state.lastResult).toBe(photos);
   });
 });
 


### PR DESCRIPTION
## Summary
- remove unused `lastResult` state and action from photo slice
- clean up pages and tests to stop writing/reading `lastResult`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0cf3e6bc8832884959a6123b1788c