### PR TITLE
feat: persist photo filter

### DIFF
--- a/frontend/packages/frontend/src/app/store.ts
+++ b/frontend/packages/frontend/src/app/store.ts
@@ -1,9 +1,25 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, type Middleware } from '@reduxjs/toolkit';
+import { namespacedStorage } from '@photobank/shared/safeStorage';
+import { PHOTO_FILTER_STORAGE_KEY } from '@photobank/shared/constants';
 
 import metaReducer from '@/features/meta/model/metaSlice';
-import photoReducer from '@/features/photo/model/photoSlice';
+import photoReducer, {
+  setFilter,
+  resetFilter,
+} from '@/features/photo/model/photoSlice';
 import botReducer from '@/features/bot/model/botSlice';
 import authReducer from '@/features/auth/model/authSlice';
+
+const filterStore = namespacedStorage('photo');
+
+const filterMiddleware: Middleware = (storeAPI) => (next) => (action) => {
+  const result = next(action);
+  if (setFilter.match(action) || resetFilter.match(action)) {
+    const filter = storeAPI.getState().photo.filter;
+    filterStore.set(PHOTO_FILTER_STORAGE_KEY, filter);
+  }
+  return result;
+};
 
 export const store = configureStore({
   reducer: {
@@ -12,7 +28,8 @@ export const store = configureStore({
     bot: botReducer,
     auth: authReducer,
   },
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware(),
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(filterMiddleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/frontend/packages/frontend/src/features/photo/model/photoSlice.ts
+++ b/frontend/packages/frontend/src/features/photo/model/photoSlice.ts
@@ -1,14 +1,22 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import type { FilterDto } from '@photobank/shared/api/photobank';
-import { DEFAULT_PHOTO_FILTER } from '@photobank/shared/constants';
+import {
+  DEFAULT_PHOTO_FILTER,
+  PHOTO_FILTER_STORAGE_KEY,
+} from '@photobank/shared/constants';
+import { namespacedStorage } from '@photobank/shared/safeStorage';
 
 interface PhotoState {
   filter: FilterDto;
   selectedPhotos: number[];
 }
 
+const store = namespacedStorage('photo');
+
 const initialState: PhotoState = {
-  filter: { ...DEFAULT_PHOTO_FILTER },
+  filter: store.get<FilterDto>(PHOTO_FILTER_STORAGE_KEY) ?? {
+    ...DEFAULT_PHOTO_FILTER,
+  },
   selectedPhotos: [],
 };
 

--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -57,6 +57,9 @@ export const apiCredentialsNotDefinedError =
 export const METADATA_CACHE_KEY = 'photobank_metadata_cache';
 export const METADATA_CACHE_VERSION = 1;
 
+export const PHOTO_FILTER_STORAGE_VERSION = 1;
+export const PHOTO_FILTER_STORAGE_KEY = `photobank_photo_filter_v${PHOTO_FILTER_STORAGE_VERSION}`;
+
 export const MAX_VISIBLE_PERSONS_LG = 3;
 export const MAX_VISIBLE_TAGS_LG = 3;
 


### PR DESCRIPTION
## Summary
- load initial photo filter from namespaced localStorage with versioned key
- persist photo filter to localStorage on updates via store middleware

## Testing
- `pnpm test`
- `pnpm lint` *(fails: import order and hook dependency warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d41a0c8c8328b88b92ae588cac05