### PR TITLE
feat: optimize SmartImage loading

### DIFF
--- a/frontend/packages/frontend/src/components/SmartImage.tsx
+++ b/frontend/packages/frontend/src/components/SmartImage.tsx
@@ -15,6 +15,8 @@ export type SmartImageProps = Omit<
   fetchPriority?: 'high' | 'auto' | 'low';
   decoding?: 'async' | 'auto' | 'sync';
   loading?: 'eager' | 'lazy';
+  width?: number | string;
+  height?: number | string;
 };
 
 const SmartImage = React.memo(
@@ -28,9 +30,11 @@ const SmartImage = React.memo(
         sizes,
         className,
         onLoadFull,
-        fetchPriority = 'auto',
+        fetchPriority = 'low',
         decoding = 'async',
         loading = 'lazy',
+        width,
+        height,
         ...imgProps
       },
       ref
@@ -53,6 +57,8 @@ const SmartImage = React.memo(
           <img
             src={thumbSrc}
             alt={alt}
+            width={width}
+            height={height}
             className={clsx(
               'absolute inset-0 w-full h-full object-cover transition-all duration-300',
               loaded ? 'opacity-0 blur-none scale-100' : 'opacity-100 blur-md scale-105'
@@ -65,6 +71,8 @@ const SmartImage = React.memo(
             srcSet={srcSet}
             sizes={sizes}
             alt={alt}
+            width={width}
+            height={height}
             loading={loading}
             decoding={decoding}
             fetchPriority={fetchPriority}

--- a/frontend/packages/frontend/test/SmartImage.test.tsx
+++ b/frontend/packages/frontend/test/SmartImage.test.tsx
@@ -38,4 +38,23 @@ describe('SmartImage', () => {
     expect(full.className).toMatch(/opacity-100/);
     expect(thumb.className).toMatch(/opacity-0/);
   });
+
+  it('applies performance attributes and dimensions to the full image', () => {
+    const { container } = render(
+      <SmartImage
+        alt="alt"
+        thumbSrc="thumb"
+        src="full"
+        width={640}
+        height={480}
+      />
+    );
+    const imgs = container.querySelectorAll('img');
+    const full = imgs[1];
+    expect(full.getAttribute('loading')).toBe('lazy');
+    expect(full.getAttribute('decoding')).toBe('async');
+    expect(full.getAttribute('fetchpriority')).toBe('low');
+    expect(full.getAttribute('width')).toBe('640');
+    expect(full.getAttribute('height')).toBe('480');
+  });
 });


### PR DESCRIPTION
## Summary
- ensure SmartImage full image uses lazy loading, async decoding, low fetch priority
- forward optional width/height to image tags to minimize layout shift
- test performance attributes and dimension handling

## Testing
- `pnpm -F frontend lint` (fails: There should be at least one empty line between import groups)
- `pnpm -F frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d48ac7488328a7f5ff48227b3190