### PR TITLE
feat(frontend): add error boundary and shimmer fallback

### DIFF
--- a/frontend/packages/frontend/src/app/ErrorBoundary.tsx
+++ b/frontend/packages/frontend/src/app/ErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { Button } from '@/shared/ui/button';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  public state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="p-6 space-y-4">
+          <p className="text-muted-foreground">Произошла ошибка.</p>
+          <Button onClick={this.handleRetry}>Повторить</Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+

--- a/frontend/packages/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/packages/frontend/src/routes/AppRoutes.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 
 import RequireAuth from '@/app/RequireAuth';
 import RequireAdmin from '@/app/RequireAdmin';
+import ErrorBoundary from '@/app/ErrorBoundary';
 
 const PhotoListPage = lazy(() => import('@/pages/list/PhotoListPage'));
 const FilterPage = lazy(() => import('@/pages/filter/FilterPage'));
@@ -16,24 +17,35 @@ const ServiceInfoPage = lazy(() => import('@/pages/service/ServiceInfoPage'));
 const OpenAIPage = lazy(() => import('@/pages/openai/OpenAIPage'));
 
 export const AppRoutes = () => (
-  <Suspense fallback={<div className="p-6 text-muted-foreground">Loading…</div>}>
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/register" element={<RegisterPage />} />
-      <Route path="/service" element={<ServiceInfoPage />} />
-      <Route path="/openai" element={<OpenAIPage />} />
-      <Route element={<RequireAuth />}>
-        <Route path="/" element={<Navigate to="/filter" />} />
-        <Route path="/logout" element={<LogoutPage />} />
-        <Route path="/profile" element={<MyProfilePage />} />
-        <Route path="/filter" element={<FilterPage />} />
-        <Route path="/photos" element={<PhotoListPage />} />
-        <Route path="/photos/:id" element={<PhotoDetailsPage />} />
-        <Route element={<RequireAdmin />}>
-          <Route path="/admin/users" element={<UsersPage />} />
+  <Suspense
+    fallback={
+      <div className="p-6 space-y-4 animate-pulse">
+        <div className="h-4 w-1/3 rounded bg-muted" />
+        <div className="h-4 w-full rounded bg-muted" />
+        <div className="h-4 w-full rounded bg-muted" />
+      </div>
+    }
+  >
+    <ErrorBoundary>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/service" element={<ServiceInfoPage />} />
+        <Route path="/openai" element={<OpenAIPage />} />
+        <Route element={<RequireAuth />}>
+          <Route path="/" element={<Navigate to="/filter" />} />
+          <Route path="/logout" element={<LogoutPage />} />
+          <Route path="/profile" element={<MyProfilePage />} />
+          <Route path="/filter" element={<FilterPage />} />
+          <Route path="/photos" element={<PhotoListPage />} />
+          <Route path="/photos/:id" element={<PhotoDetailsPage />} />
+          <Route element={<RequireAdmin />}>
+            <Route path="/admin/users" element={<UsersPage />} />
+          </Route>
         </Route>
-      </Route>
-      <Route path="*" element={<Navigate to="/login" replace />} />
-    </Routes>
+        <Route path="*" element={<Navigate to="/login" replace />} />
+      </Routes>
+    </ErrorBoundary>
   </Suspense>
 );
+


### PR DESCRIPTION
## Summary
- add reusable error boundary with retry action
- wrap routes with error boundary and show shimmer for suspense

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d4dedeb48328988f36ed305bed5e