### PR TITLE
feat: add i18n and scoped commands to Telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -4,13 +4,14 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "build": "tsc -b",
+    "build": "rimraf dist && tsc -b && cp -r src/locales dist",
     "start": "node dist/index.js",
     "test": "vitest run",
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {
     "@grammyjs/conversations": "^2.1.0",
+    "@grammyjs/i18n": "^1.1.2",
     "@grammyjs/runner": "^1.0.4",
     "@photobank/shared": "workspace:*",
     "axios": "^1.11.0",

--- a/frontend/packages/telegram-bot/src/bot.ts
+++ b/frontend/packages/telegram-bot/src/bot.ts
@@ -1,5 +1,6 @@
 import { Bot } from 'grammy';
 
 import { BOT_TOKEN } from './config';
+import type { MyContext } from './i18n';
 
-export const bot = new Bot(BOT_TOKEN);
+export const bot = new Bot<MyContext>(BOT_TOKEN);

--- a/frontend/packages/telegram-bot/src/commands/help.ts
+++ b/frontend/packages/telegram-bot/src/commands/help.ts
@@ -1,7 +1,6 @@
-import { Context } from 'grammy';
-import { helpBotMsg } from '@photobank/shared/constants';
+import type { MyContext } from '../i18n';
 
-export async function helpCommand(ctx: Context) {
-  await ctx.reply(helpBotMsg);
+export async function helpCommand(ctx: MyContext) {
+  await ctx.reply(ctx.t('help'));
 }
 

--- a/frontend/packages/telegram-bot/src/i18n.ts
+++ b/frontend/packages/telegram-bot/src/i18n.ts
@@ -1,0 +1,14 @@
+import { I18n } from '@grammyjs/i18n';
+import type { Context } from 'grammy';
+import type { I18nFlavor } from '@grammyjs/i18n';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const i18n = new I18n({
+  defaultLocale: 'en',
+  directory: resolve(__dirname, 'locales'),
+});
+
+export type MyContext = Context & I18nFlavor;

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -30,6 +30,33 @@ import { logger } from './logger';
 import { handleBotError } from './errorHandler';
 import './handlers/inline';
 import './handlers/deeplink';
+import { i18n } from './i18n';
+
+const privateCommands = (lang: string) => [
+  { command: 'start', description: i18n.t(lang, 'cmd-start') },
+  { command: 'help', description: i18n.t(lang, 'cmd-help') },
+  { command: 'thisday', description: i18n.t(lang, 'cmd-thisday') },
+  { command: 'search', description: i18n.t(lang, 'cmd-search') },
+  { command: 'ai', description: i18n.t(lang, 'cmd-ai') },
+  { command: 'profile', description: i18n.t(lang, 'cmd-profile') },
+  { command: 'subscribe', description: i18n.t(lang, 'cmd-subscribe') },
+  { command: 'tags', description: i18n.t(lang, 'cmd-tags') },
+  { command: 'persons', description: i18n.t(lang, 'cmd-persons') },
+  { command: 'storages', description: i18n.t(lang, 'cmd-storages') },
+  { command: 'upload', description: i18n.t(lang, 'cmd-upload') },
+];
+
+const groupCommands = (lang: string) => [
+  { command: 'help', description: i18n.t(lang, 'cmd-help') },
+  { command: 'thisday', description: i18n.t(lang, 'cmd-thisday') },
+];
+
+bot.use(i18n.middleware());
+bot.use(async (ctx, next) => {
+  const lang = ctx.from?.language_code?.split('-')[0];
+  if (lang) ctx.i18n.locale(lang);
+  await next();
+});
 
 bot.use(async (ctx, next) => {
   const username = ctx.from?.username ?? String(ctx.from?.id ?? '');
@@ -150,6 +177,23 @@ bot.on('message:text', withRegistered(async (ctx) => {
 
 bot.on('message:photo', withRegistered(uploadCommand));
 bot.on('message:document', withRegistered(uploadCommand));
+
+await bot.api.setMyCommands(privateCommands('en'), {
+  scope: { type: 'all_private_chats' },
+  language_code: 'en',
+});
+await bot.api.setMyCommands(privateCommands('ru'), {
+  scope: { type: 'all_private_chats' },
+  language_code: 'ru',
+});
+await bot.api.setMyCommands(groupCommands('en'), {
+  scope: { type: 'all_group_chats' },
+  language_code: 'en',
+});
+await bot.api.setMyCommands(groupCommands('ru'), {
+  scope: { type: 'all_group_chats' },
+  language_code: 'ru',
+});
 
 bot.start();
 logger.info('bot started');

--- a/frontend/packages/telegram-bot/src/locales/en.ftl
+++ b/frontend/packages/telegram-bot/src/locales/en.ftl
@@ -1,0 +1,12 @@
+help = Available commands:\n/thisday [page] – show photos of this day\n/search <caption> – search by caption\n/ai <prompt> – AI search\n/photo <id> – show photo by ID\n/profile – profile info\n/subscribe HH:MM – daily /thisday digest\n/tags [prefix] – list tags\n/storages [prefix] – list storages and paths\n/persons [prefix] – list persons\n\nAny message without command is treated as an /ai request.
+cmd-start = Start the bot
+cmd-help = Help
+cmd-thisday = Today's photos
+cmd-search = Search by caption
+cmd-ai = AI search
+cmd-profile = Profile info
+cmd-subscribe = Subscribe to daily /thisday
+cmd-tags = List tags
+cmd-persons = List persons
+cmd-storages = List storages
+cmd-upload = Upload files

--- a/frontend/packages/telegram-bot/src/locales/ru.ftl
+++ b/frontend/packages/telegram-bot/src/locales/ru.ftl
@@ -1,0 +1,12 @@
+help = Доступные команды:\n/thisday [страница] – показать фото этого дня\n/search <caption> – поиск по подписи\n/ai <prompt> – поиск с помощью ИИ\n/photo <id> – показать фото по идентификатору\n/profile – информация о профиле\n/subscribe HH:MM – ежедневная рассылка /thisday\n/tags [prefix] – список тегов\n/storages [prefix] – список хранилищ и путей\n/persons [prefix] – список персон\n\nЛюбое сообщение без команды обрабатывается как запрос /ai.
+cmd-start = Запустить бота
+cmd-help = Помощь
+cmd-thisday = Фото этого дня
+cmd-search = Поиск по подписи
+cmd-ai = Поиск с помощью ИИ
+cmd-profile = Информация о профиле
+cmd-subscribe = Подписка на ежедневное /thisday
+cmd-tags = Список тегов
+cmd-persons = Список персон
+cmd-storages = Список хранилищ
+cmd-upload = Загрузка файлов

--- a/frontend/packages/telegram-bot/test/helpCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/helpCommand.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { helpCommand } from '../src/commands/help';
-import { helpBotMsg } from '@photobank/shared/constants';
+import { i18n } from '../src/i18n';
 
 describe('helpCommand', () => {
-  it('replies with help message', async () => {
-    const ctx = { reply: vi.fn() } as any;
+  it('replies with localized help message', async () => {
+    const ctx = { reply: vi.fn(), t: (key: string) => i18n.t('en', key) } as any;
     await helpCommand(ctx);
-    expect(ctx.reply).toHaveBeenCalledWith(helpBotMsg);
+    expect(ctx.reply).toHaveBeenCalledWith(i18n.t('en', 'help'));
   });
 });
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
       '@grammyjs/conversations':
         specifier: ^2.1.0
         version: 2.1.0(grammy@1.37.0)
+      '@grammyjs/i18n':
+        specifier: ^1.1.2
+        version: 1.1.2(grammy@1.37.0)
       '@grammyjs/runner':
         specifier: ^1.0.4
         version: 1.0.4
@@ -1029,6 +1032,12 @@ packages:
   '@date-fns/tz@1.2.0':
     resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
 
+  '@deno/shim-deno-test@0.5.0':
+    resolution: {integrity: sha512-4nMhecpGlPi0cSzT67L+Tm+GOJqvuk8gqHBziqcUQOarnuIax1z96/gJHCSIz2Z0zhxE6Rzwb3IZXPtFh51j+w==}
+
+  '@deno/shim-deno@0.18.2':
+    resolution: {integrity: sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA==}
+
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
@@ -1330,6 +1339,14 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@fluent/bundle@0.17.1':
+    resolution: {integrity: sha512-CRFNT9QcSFAeFDneTF59eyv3JXFGhIIN4boUO2y22YmsuuKLyDk+N1I/NQUYz9Ab63e6V7T6vItoZIG/2oOOuw==}
+    engines: {node: '>=12.0.0', npm: '>=7.0.0'}
+
+  '@fluent/langneg@0.6.2':
+    resolution: {integrity: sha512-YF4gZ4sLYRQfctpUR2uhb5UyPUYY5n/bi3OaED/Q4awKjPjlaF8tInO3uja7pnLQcmLTURkZL7L9zxv2Z5NDwg==}
+    engines: {node: '>=12.0.0', npm: '>=7.0.0'}
+
   '@gerrit0/mini-shiki@3.9.2':
     resolution: {integrity: sha512-Tvsj+AOO4Z8xLRJK900WkyfxHsZQu+Zm1//oT1w443PO6RiYMoq/4NGOhaNuZoUMYsjKIAPVQ6eOFMddj6yphQ==}
 
@@ -1338,6 +1355,12 @@ packages:
     engines: {node: ^12.20.0 || >=14.13.1}
     peerDependencies:
       grammy: ^1.20.1
+
+  '@grammyjs/i18n@1.1.2':
+    resolution: {integrity: sha512-PcK06mxuDDZjxdZ5HywBhr+erEITsR816KP4DNIDDds1jpA45pfz/nS9FdZmzF8H6lMyPix3mV5WL1rT4q+BuA==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      grammy: ^1.10.0
 
   '@grammyjs/runner@1.0.4':
     resolution: {integrity: sha512-77IE+2Gg0UHa9MNZ8wsculxJpzUDcHTrMg7OLbKoQ8jWKFxX78sdxRBwL+FK3NvHZ15YnXsnxesV43xgbOhteA==}
@@ -4432,6 +4455,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -6700,6 +6727,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -7594,6 +7626,13 @@ snapshots:
 
   '@date-fns/tz@1.2.0': {}
 
+  '@deno/shim-deno-test@0.5.0': {}
+
+  '@deno/shim-deno@0.18.2':
+    dependencies:
+      '@deno/shim-deno-test': 0.5.0
+      which: 4.0.0
+
   '@egjs/hammerjs@2.0.17':
     dependencies:
       '@types/hammerjs': 2.0.46
@@ -8004,6 +8043,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@fluent/bundle@0.17.1': {}
+
+  '@fluent/langneg@0.6.2': {}
+
   '@gerrit0/mini-shiki@3.9.2':
     dependencies:
       '@shikijs/engine-oniguruma': 3.9.2
@@ -8014,6 +8057,13 @@ snapshots:
 
   '@grammyjs/conversations@2.1.0(grammy@1.37.0)':
     dependencies:
+      grammy: 1.37.0
+
+  '@grammyjs/i18n@1.1.2(grammy@1.37.0)':
+    dependencies:
+      '@deno/shim-deno': 0.18.2
+      '@fluent/bundle': 0.17.1
+      '@fluent/langneg': 0.6.2
       grammy: 1.37.0
 
   '@grammyjs/runner@1.0.4':
@@ -9726,7 +9776,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.1.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.1.0)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
+      vitest: 3.2.4(@types/node@24.1.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.1.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11548,6 +11598,8 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isexe@3.1.1: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -14278,6 +14330,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.1
 
   why-is-node-running@2.3.0:
     dependencies:


### PR DESCRIPTION
## Summary
- add @grammyjs/i18n with English and Russian locales
- register localized bot commands for private and group scopes
- localize /help command and copy locales on build

## Testing
- `pnpm --filter telegram-bot lint`
- `pnpm --filter telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_68a0dce1353883288593d59bd67223c9