### PR TITLE
Fix frontend build, lint, and tests

### DIFF
--- a/frontend/packages/frontend/src/app/ErrorBoundary.tsx
+++ b/frontend/packages/frontend/src/app/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
+
 import { Button } from '@/shared/ui/button';
 
 interface Props {

--- a/frontend/packages/frontend/src/features/photo/useInfinitePhotos.ts
+++ b/frontend/packages/frontend/src/features/photo/useInfinitePhotos.ts
@@ -1,32 +1,44 @@
 import { useMemo } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { photosSearchPhotos } from '@photobank/shared/api/photobank';
-import type { FilterDto } from '@photobank/shared/api/photobank';
+import type {
+  FilterDto,
+  photosSearchPhotosResponse,
+} from '@photobank/shared/api/photobank';
+import type { PhotoItemDto } from '@photobank/shared/api/photobank/model/photoItemDto';
 
 export const useInfinitePhotos = (filter: FilterDto) => {
   const pageSize = filter.pageSize ?? 10;
 
-  const query = useInfiniteQuery({
+  const query = useInfiniteQuery<photosSearchPhotosResponse>({
     queryKey: ['photos', filter],
     initialPageParam: 1,
     queryFn: ({ pageParam }) =>
-      photosSearchPhotos({ ...filter, page: pageParam, pageSize }),
+      photosSearchPhotos({ ...filter, page: pageParam as number, pageSize }),
     getNextPageParam: (lastPage, pages) => {
-      const total = lastPage.data.totalCount ?? 0;
-      const loaded = pages.reduce(
-        (sum, p) => sum + (p.data.items?.length ?? 0),
-        0
-      );
+      const total = lastPage.status === 200 ? lastPage.data.totalCount ?? 0 : 0;
+      const loaded = pages.reduce((sum, p) => {
+        if (p.status === 200) {
+          return sum + (p.data.items?.length ?? 0);
+        }
+        return sum;
+      }, 0);
       return loaded < total ? pages.length + 1 : undefined;
     },
   });
 
   const items = useMemo(
-    () => query.data?.pages.flatMap((p) => p.data.items ?? []) ?? [],
+    () =>
+      (query.data?.pages.flatMap((p) =>
+        p.status === 200 ? p.data.items ?? [] : []
+      ) ?? []) as PhotoItemDto[],
     [query.data]
   );
 
-  const total = query.data?.pages[0]?.data.totalCount ?? 0;
+  const total =
+    query.data?.pages[0]?.status === 200
+      ? query.data.pages[0].data.totalCount ?? 0
+      : 0;
 
   return { ...query, items, total };
 };

--- a/frontend/packages/frontend/src/hooks/useInView.ts
+++ b/frontend/packages/frontend/src/hooks/useInView.ts
@@ -21,7 +21,7 @@ export function useInView<T extends Element>(
 
     observer.observe(el);
     return () => observer.disconnect();
-  }, [opts.root, opts.rootMargin, opts.threshold]);
+  }, [opts]);
 
   return [ref, inView];
 }

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, useRef, useCallback } from 'react';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
-import type { FilterDto, PhotoItemDto } from '@photobank/shared/api/photobank';
+import type { FilterDto } from '@photobank/shared/api/photobank';
+import type { PhotoItemDto } from '@photobank/shared/api/photobank/model/photoItemDto';
 import {
   photoGalleryTitle,
   filterButtonText,

--- a/frontend/packages/frontend/src/shared/lib/filter-url.ts
+++ b/frontend/packages/frontend/src/shared/lib/filter-url.ts
@@ -1,15 +1,13 @@
-import { Buffer } from 'buffer';
-import type { FormData } from '@/features/filter/lib/form-schema';
-import { formSchema } from '@/features/filter/lib/form-schema';
+import { formSchema, type FormData } from '@/features/filter/lib/form-schema';
 
 const toBase64 = (json: string) =>
   typeof window === 'undefined'
-    ? Buffer.from(json, 'utf-8').toString('base64')
+    ? globalThis.Buffer.from(json, 'utf-8').toString('base64')
     : window.btoa(json);
 
 const fromBase64 = (encoded: string) =>
   typeof window === 'undefined'
-    ? Buffer.from(encoded, 'base64').toString('utf-8')
+    ? globalThis.Buffer.from(encoded, 'base64').toString('utf-8')
     : window.atob(encoded);
 
 export const serializeFilter = (data: FormData): string => {

--- a/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
+++ b/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
@@ -85,17 +85,21 @@ describe('PhotoDetailsPage', () => {
     vi.clearAllMocks();
   });
 
-  it('renders photo details', async () => {
-    await renderPage();
-    expect(await screen.findByText('Photo Properties')).toBeTruthy();
-    expect(await screen.findByDisplayValue('Test Photo')).toBeTruthy();
-    expect((await screen.findAllByDisplayValue('1')).length).toBeGreaterThan(0);
-    expect(screen.getByLabelText('Show face boxes')).toBeTruthy();
-    const placeLink = await screen.findByRole('link', { name: /Nice place/ });
-    expect(placeLink).toBeTruthy();
-    expect(placeLink.getAttribute('href')).toContain('10,20');
-    expect(placeLink.getAttribute('rel')).toBe('noopener noreferrer');
-  });
+  it(
+    'renders photo details',
+    async () => {
+      await renderPage();
+      expect(await screen.findByText('Photo Properties')).toBeTruthy();
+      expect(await screen.findByDisplayValue('Test Photo')).toBeTruthy();
+      expect((await screen.findAllByDisplayValue('1')).length).toBeGreaterThan(0);
+      expect(screen.getByLabelText('Show face boxes')).toBeTruthy();
+      const placeLink = await screen.findByRole('link', { name: /Nice place/ });
+      expect(placeLink).toBeTruthy();
+      expect(placeLink.getAttribute('href')).toContain('10,20');
+      expect(placeLink.getAttribute('rel')).toBe('noopener noreferrer');
+    },
+    10000
+  );
 
   it('toggles face boxes visibility', async () => {
     await renderPage();

--- a/frontend/packages/shared/src/api/photobank/index.ts
+++ b/frontend/packages/shared/src/api/photobank/index.ts
@@ -7,3 +7,4 @@ export * from './storages/storages';
 export * from './tags/tags';
 export * from './users/users';
 export * from './model';
+export * from './fetcher';

--- a/frontend/packages/telegram-bot/src/api/auth.ts
+++ b/frontend/packages/telegram-bot/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { configureApi, customFetcher } from '@photobank/shared/api/photobank/fetcher';
+import { configureApi, customFetcher } from '@photobank/shared/api/photobank';
 
 configureApi(process.env.API_BASE_URL ?? '');
 
@@ -8,7 +8,7 @@ type ExchangeBody = { telegramUserId: number; username: string | null };
 
 export async function exchangeTelegramUserToken(telegramUserId: number, username?: string) {
   const body: ExchangeBody = { telegramUserId, username: username ?? null };
-  const res = await customFetcher<{ accessToken: string; expiresIn: number }>(
+  const res = await customFetcher<{ data: { accessToken: string; expiresIn: number } }>(
     '/auth/telegram/exchange',
     {
       method: 'POST',

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -54,7 +54,7 @@ const groupCommands = (lang: string) => [
 bot.use(i18n.middleware());
 bot.use(async (ctx, next) => {
   const lang = ctx.from?.language_code?.split('-')[0];
-  if (lang) ctx.i18n.locale(lang);
+  if (lang) ctx.i18n.useLocale(lang);
   await next();
 });
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 packages:
-  - 'packages/*'
+  - packages/*
+
+onlyBuiltDependencies:
+  - '@tailwindcss/oxide'
+  - esbuild
+  - msw
+  - unrs-resolver


### PR DESCRIPTION
## Summary
- fix import ordering and lint warnings
- harden hooks and API typing to satisfy tsc and build
- export fetcher utilities and adjust telegram bot for locale and auth

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a0e00ff8a483289cd2a936b1a4ad9b