### PR TITLE
chore: regenerate API with orval

### DIFF
--- a/frontend/packages/shared/src/api/photobank/auth/auth.msw.ts
+++ b/frontend/packages/shared/src/api/photobank/auth/auth.msw.ts
@@ -19,11 +19,11 @@ export const getAuthLoginResponseMock = (overrideResponse: Partial< LoginRespons
 
 export const getAuthGetUserResponseMock = (overrideResponse: Partial< UserDto > = {}): UserDto => ({email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), ...overrideResponse})
 
+export const getAuthTelegramExchangeResponseMock = (overrideResponse: Partial< TelegramExchangeResponse > = {}): TelegramExchangeResponse => ({accessToken: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), expiresIn: faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), undefined]), ...overrideResponse})
+
 export const getAuthGetUserClaimsResponseMock = (): ClaimDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})))
 
 export const getAuthGetUserRolesResponseMock = (): RoleDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({name: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined])})))
-
-export const getAuthTelegramExchangeResponseMock = (overrideResponse: Partial< TelegramExchangeResponse > = {}): TelegramExchangeResponse => ({accessToken: faker.string.alpha({length: {min: 10, max: 20}}), expiresIn: faker.number.int({min: undefined, max: undefined}), ...overrideResponse})
 
 
 export const getAuthLoginMockHandler = (overrideResponse?: LoginResponseDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<LoginResponseDto> | LoginResponseDto)) => {
@@ -70,6 +70,18 @@ export const getAuthUpdateUserMockHandler = (overrideResponse?: null | ((info: P
   })
 }
 
+export const getAuthTelegramExchangeMockHandler = (overrideResponse?: TelegramExchangeResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<TelegramExchangeResponse> | TelegramExchangeResponse)) => {
+  return http.post('/api/auth/telegram/exchange', async (info) => {await delay(1000);
+  
+    return new HttpResponse(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getAuthTelegramExchangeResponseMock(),
+      { status: 200,
+        headers: { 'Content-Type': 'text/plain' }
+      })
+  })
+}
+
 export const getAuthGetUserClaimsMockHandler = (overrideResponse?: ClaimDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<ClaimDto[]> | ClaimDto[])) => {
   return http.get('/api/auth/claims', async (info) => {await delay(1000);
   
@@ -93,24 +105,12 @@ export const getAuthGetUserRolesMockHandler = (overrideResponse?: RoleDto[] | ((
       })
   })
 }
-
-export const getAuthTelegramExchangeMockHandler = (overrideResponse?: TelegramExchangeResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<TelegramExchangeResponse> | TelegramExchangeResponse)) => {
-  return http.post('/api/auth/telegram/exchange', async (info) => {await delay(1000);
-  
-    return new HttpResponse(overrideResponse !== undefined
-    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
-    : getAuthTelegramExchangeResponseMock(),
-      { status: 200,
-        headers: { 'Content-Type': 'text/plain' }
-      })
-  })
-}
 export const getAuthMock = () => [
   getAuthLoginMockHandler(),
   getAuthRegisterMockHandler(),
   getAuthGetUserMockHandler(),
   getAuthUpdateUserMockHandler(),
+  getAuthTelegramExchangeMockHandler(),
   getAuthGetUserClaimsMockHandler(),
-  getAuthGetUserRolesMockHandler(),
-  getAuthTelegramExchangeMockHandler()
+  getAuthGetUserRolesMockHandler()
 ]

--- a/frontend/packages/shared/src/api/photobank/auth/auth.ts
+++ b/frontend/packages/shared/src/api/photobank/auth/auth.ts
@@ -359,6 +359,92 @@ const {mutation: mutationOptions} = options ?
 
       return useMutation(mutationOptions );
     }
+    export type authTelegramExchangeResponse200 = {
+  data: TelegramExchangeResponse
+  status: 200
+}
+
+export type authTelegramExchangeResponse401 = {
+  data: ProblemDetails
+  status: 401
+}
+
+export type authTelegramExchangeResponse403 = {
+  data: ProblemDetails
+  status: 403
+}
+    
+export type authTelegramExchangeResponseComposite = authTelegramExchangeResponse200 | authTelegramExchangeResponse401 | authTelegramExchangeResponse403;
+    
+export type authTelegramExchangeResponse = authTelegramExchangeResponseComposite & {
+  headers: Headers;
+}
+
+export const getAuthTelegramExchangeUrl = () => {
+
+
+  
+
+  return `/auth/telegram/exchange`
+}
+
+export const authTelegramExchange = async (telegramExchangeRequest: TelegramExchangeRequest, options?: RequestInit): Promise<authTelegramExchangeResponse> => {
+  
+  return customFetcher<authTelegramExchangeResponse>(getAuthTelegramExchangeUrl(),
+  {      
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      telegramExchangeRequest,)
+  }
+);}
+
+
+
+
+export const getAuthTelegramExchangeMutationOptions = <TError = ProblemDetails | ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof authTelegramExchange>>, TError,{data: TelegramExchangeRequest}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof authTelegramExchange>>, TError,{data: TelegramExchangeRequest}, TContext> => {
+
+const mutationKey = ['authTelegramExchange'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof authTelegramExchange>>, {data: TelegramExchangeRequest}> = (props) => {
+          const {data} = props ?? {};
+
+          return  authTelegramExchange(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type AuthTelegramExchangeMutationResult = NonNullable<Awaited<ReturnType<typeof authTelegramExchange>>>
+    export type AuthTelegramExchangeMutationBody = TelegramExchangeRequest
+    export type AuthTelegramExchangeMutationError = ProblemDetails | ProblemDetails
+
+    export const useAuthTelegramExchange = <TError = ProblemDetails | ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof authTelegramExchange>>, TError,{data: TelegramExchangeRequest}, TContext>, }
+ ): UseMutationResult<
+        Awaited<ReturnType<typeof authTelegramExchange>>,
+        TError,
+        {data: TelegramExchangeRequest},
+        TContext
+      > => {
+
+      const mutationOptions = getAuthTelegramExchangeMutationOptions(options);
+
+      return useMutation(mutationOptions );
+    }
     export type authGetUserClaimsResponse200 = {
   data: ClaimDto[]
   status: 200
@@ -511,90 +597,3 @@ export function useAuthGetUserRoles<TData = Awaited<ReturnType<typeof authGetUse
 
 
 
-export type authTelegramExchangeResponse200 = {
-  data: TelegramExchangeResponse
-  status: 200
-}
-
-export type authTelegramExchangeResponse401 = {
-  data: ProblemDetails
-  status: 401
-}
-
-export type authTelegramExchangeResponse403 = {
-  data: ProblemDetails
-  status: 403
-}
-    
-export type authTelegramExchangeResponseComposite = authTelegramExchangeResponse200 | authTelegramExchangeResponse401 | authTelegramExchangeResponse403;
-    
-export type authTelegramExchangeResponse = authTelegramExchangeResponseComposite & {
-  headers: Headers;
-}
-
-export const getAuthTelegramExchangeUrl = () => {
-
-
-  
-
-  return `/auth/telegram/exchange`
-}
-
-export const authTelegramExchange = async (telegramExchangeRequest: TelegramExchangeRequest, options?: RequestInit): Promise<authTelegramExchangeResponse> => {
-  
-  return customFetcher<authTelegramExchangeResponse>(getAuthTelegramExchangeUrl(),
-  {      
-    ...options,
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-    body: JSON.stringify(
-      telegramExchangeRequest,)
-  }
-);}
-
-
-
-
-export const getAuthTelegramExchangeMutationOptions = <TError = ProblemDetails | ProblemDetails,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof authTelegramExchange>>, TError,{data: TelegramExchangeRequest}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof authTelegramExchange>>, TError,{data: TelegramExchangeRequest}, TContext> => {
-
-const mutationKey = ['authTelegramExchange'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof authTelegramExchange>>, {data: TelegramExchangeRequest}> = (props) => {
-          const {data} = props ?? {};
-
-          return  authTelegramExchange(data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type AuthTelegramExchangeMutationResult = NonNullable<Awaited<ReturnType<typeof authTelegramExchange>>>
-    export type AuthTelegramExchangeMutationBody = TelegramExchangeRequest
-    export type AuthTelegramExchangeMutationError = ProblemDetails | ProblemDetails
-
-    export const useAuthTelegramExchange = <TError = ProblemDetails | ProblemDetails,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof authTelegramExchange>>, TError,{data: TelegramExchangeRequest}, TContext>, }
- ): UseMutationResult<
-        Awaited<ReturnType<typeof authTelegramExchange>>,
-        TError,
-        {data: TelegramExchangeRequest},
-        TContext
-      > => {
-
-      const mutationOptions = getAuthTelegramExchangeMutationOptions(options);
-
-      return useMutation(mutationOptions );
-    }
-    

--- a/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
+++ b/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
@@ -54,7 +54,6 @@ export interface FilterDto {
   takenDateFrom?: string | null;
   /** @nullable */
   takenDateTo?: string | null;
-  /** @nullable */
   thisDay?: ThisDayDto;
   /** @nullable */
   persons?: number[] | null;
@@ -62,11 +61,6 @@ export interface FilterDto {
   tags?: number[] | null;
   /** @nullable */
   orderBy?: string | null;
-}
-
-export interface ThisDayDto {
-  day: number;
-  month: number;
 }
 
 export interface GeoPointDto {
@@ -184,17 +178,6 @@ export interface RoleDto {
   claims?: ClaimDto[] | null;
 }
 
-export interface TelegramExchangeRequest {
-  telegramUserId: number;
-  /** @nullable */
-  username?: string | null;
-}
-
-export interface TelegramExchangeResponse {
-  accessToken: string;
-  expiresIn: number;
-}
-
 export interface StorageDto {
   id: number;
   /** @minLength 1 */
@@ -209,6 +192,23 @@ export interface TagDto {
 
 export interface TagItemDto {
   tagId: number;
+}
+
+export interface TelegramExchangeRequest {
+  telegramUserId?: number;
+  /** @nullable */
+  username?: string | null;
+}
+
+export interface TelegramExchangeResponse {
+  /** @nullable */
+  accessToken?: string | null;
+  expiresIn?: number;
+}
+
+export interface ThisDayDto {
+  day?: number;
+  month?: number;
 }
 
 export interface UpdateFaceDto {

--- a/frontend/packages/telegram-bot/src/api/photobank/auth/auth.msw.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/auth/auth.msw.ts
@@ -19,11 +19,11 @@ export const getAuthLoginResponseMock = (overrideResponse: Partial< LoginRespons
 
 export const getAuthGetUserResponseMock = (overrideResponse: Partial< UserDto > = {}): UserDto => ({email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), ...overrideResponse})
 
+export const getAuthTelegramExchangeResponseMock = (overrideResponse: Partial< TelegramExchangeResponse > = {}): TelegramExchangeResponse => ({accessToken: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), expiresIn: faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), undefined]), ...overrideResponse})
+
 export const getAuthGetUserClaimsResponseMock = (): ClaimDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})))
 
 export const getAuthGetUserRolesResponseMock = (): RoleDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({name: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined])})))
-
-export const getAuthTelegramExchangeResponseMock = (overrideResponse: Partial< TelegramExchangeResponse > = {}): TelegramExchangeResponse => ({accessToken: faker.string.alpha({length: {min: 10, max: 20}}), expiresIn: faker.number.int({min: undefined, max: undefined}), ...overrideResponse})
 
 
 export const getAuthLoginMockHandler = (overrideResponse?: LoginResponseDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<LoginResponseDto> | LoginResponseDto)) => {
@@ -70,6 +70,18 @@ export const getAuthUpdateUserMockHandler = (overrideResponse?: null | ((info: P
   })
 }
 
+export const getAuthTelegramExchangeMockHandler = (overrideResponse?: TelegramExchangeResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<TelegramExchangeResponse> | TelegramExchangeResponse)) => {
+  return http.post('/api/auth/telegram/exchange', async (info) => {await delay(1000);
+  
+    return new HttpResponse(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getAuthTelegramExchangeResponseMock(),
+      { status: 200,
+        headers: { 'Content-Type': 'text/plain' }
+      })
+  })
+}
+
 export const getAuthGetUserClaimsMockHandler = (overrideResponse?: ClaimDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<ClaimDto[]> | ClaimDto[])) => {
   return http.get('/api/auth/claims', async (info) => {await delay(1000);
   
@@ -93,23 +105,11 @@ export const getAuthGetUserRolesMockHandler = (overrideResponse?: RoleDto[] | ((
       })
   })
 }
-
-export const getAuthTelegramExchangeMockHandler = (overrideResponse?: TelegramExchangeResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<TelegramExchangeResponse> | TelegramExchangeResponse)) => {
-  return http.post('/api/auth/telegram/exchange', async (info) => {await delay(1000);
-  
-    return new HttpResponse(overrideResponse !== undefined
-    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
-    : getAuthTelegramExchangeResponseMock(),
-      { status: 200,
-        headers: { 'Content-Type': 'text/plain' }
-      })
-  })
-}
 export const getAuthMock = () => [
   getAuthLoginMockHandler(),
   getAuthRegisterMockHandler(),
   getAuthGetUserMockHandler(),
   getAuthUpdateUserMockHandler(),
+  getAuthTelegramExchangeMockHandler(),
   getAuthGetUserClaimsMockHandler(),
-  getAuthGetUserRolesMockHandler(),
-  getAuthTelegramExchangeMockHandler()]
+  getAuthGetUserRolesMockHandler()]

--- a/frontend/packages/telegram-bot/src/api/photobank/auth/auth.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/auth/auth.ts
@@ -61,6 +61,16 @@ const authLogin = (
     },
       options);
     }
+  const authTelegramExchange = (
+    telegramExchangeRequest: TelegramExchangeRequest,
+ options?: SecondParameter<typeof photobankAxios>,) => {
+      return photobankAxios<TelegramExchangeResponse>(
+      {url: `/auth/telegram/exchange`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: telegramExchangeRequest
+    },
+      options);
+    }
   const authGetUserClaims = (
     
  options?: SecondParameter<typeof photobankAxios>,) => {
@@ -77,17 +87,7 @@ const authLogin = (
     },
       options);
     }
-  const authTelegramExchange = (
-    telegramExchangeRequest: TelegramExchangeRequest,
- options?: SecondParameter<typeof photobankAxios>,) => {
-      return photobankAxios<TelegramExchangeResponse>(
-      {url: `/auth/telegram/exchange`, method: 'POST',
-      headers: {'Content-Type': 'application/json', },
-      data: telegramExchangeRequest
-    },
-      options);
-    }
-  return {authLogin,authRegister,authGetUser,authUpdateUser,authGetUserClaims,authGetUserRoles,authTelegramExchange}};
+  return {authLogin,authRegister,authGetUser,authUpdateUser,authTelegramExchange,authGetUserClaims,authGetUserRoles}};
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -97,6 +97,6 @@ export type AuthLoginResult = NonNullable<Awaited<ReturnType<ReturnType<typeof g
 export type AuthRegisterResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authRegister']>>>
 export type AuthGetUserResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authGetUser']>>>
 export type AuthUpdateUserResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authUpdateUser']>>>
+export type AuthTelegramExchangeResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authTelegramExchange']>>>
 export type AuthGetUserClaimsResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authGetUserClaims']>>>
 export type AuthGetUserRolesResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authGetUserRoles']>>>
-export type AuthTelegramExchangeResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authTelegramExchange']>>>

--- a/frontend/packages/telegram-bot/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
@@ -54,7 +54,6 @@ export interface FilterDto {
   takenDateFrom?: string | null;
   /** @nullable */
   takenDateTo?: string | null;
-  /** @nullable */
   thisDay?: ThisDayDto;
   /** @nullable */
   persons?: number[] | null;
@@ -62,11 +61,6 @@ export interface FilterDto {
   tags?: number[] | null;
   /** @nullable */
   orderBy?: string | null;
-}
-
-export interface ThisDayDto {
-  day: number;
-  month: number;
 }
 
 export interface GeoPointDto {
@@ -184,17 +178,6 @@ export interface RoleDto {
   claims?: ClaimDto[] | null;
 }
 
-export interface TelegramExchangeRequest {
-  telegramUserId: number;
-  /** @nullable */
-  username?: string | null;
-}
-
-export interface TelegramExchangeResponse {
-  accessToken: string;
-  expiresIn: number;
-}
-
 export interface StorageDto {
   id: number;
   /** @minLength 1 */
@@ -209,6 +192,23 @@ export interface TagDto {
 
 export interface TagItemDto {
   tagId: number;
+}
+
+export interface TelegramExchangeRequest {
+  telegramUserId?: number;
+  /** @nullable */
+  username?: string | null;
+}
+
+export interface TelegramExchangeResponse {
+  /** @nullable */
+  accessToken?: string | null;
+  expiresIn?: number;
+}
+
+export interface ThisDayDto {
+  day?: number;
+  month?: number;
 }
 
 export interface UpdateFaceDto {


### PR DESCRIPTION
## Summary
- regenerate shared API client
- regenerate Telegram bot API client

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a19ed19dd48328848760e7a9a75598