### PR TITLE
Use photo id as key in virtual list

### DIFF
--- a/frontend/packages/frontend/src/pages/list/VirtualPhotoList.tsx
+++ b/frontend/packages/frontend/src/pages/list/VirtualPhotoList.tsx
@@ -42,7 +42,7 @@ const VirtualPhotoList = ({
         const photo = photos[item.index];
         return (
           <div
-            key={photo?.id ?? item.index}
+            key={photo.id}
             ref={virtualizer.measureElement}
             style={{
               position: 'absolute',


### PR DESCRIPTION
## Summary
- use photo ID as the React key when rendering virtual photo list rows

## Testing
- `pnpm --filter @photobank/frontend lint` *(fails: This assertion is unnecessary since the receiver accepts the original type of the expression)*
- `pnpm --filter @photobank/frontend test` *(fails: Failed to resolve import "@tanstack/react-query" from "../shared/src/api/photobank/auth/auth.ts".)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d4da7aec8328bee86dfd73545857