### PR TITLE
Remove photos search mutation from filter page

### DIFF
--- a/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -5,7 +5,6 @@ import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { useEffect } from 'react';
 import { DEFAULT_FORM_VALUES } from '@photobank/shared/constants';
 import { useTranslation } from 'react-i18next';
-import * as Api from '@photobank/shared/api/photobank/photos/photos';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 
 import { useAppDispatch, useAppSelector } from '@/app/hook';
@@ -28,7 +27,6 @@ function FilterPage() {
   const savedFilter = useAppSelector((state) => state.photo.filter);
   const loaded = useAppSelector((s) => s.metadata.loaded);
   const loading = useAppSelector((s) => s.metadata.loading);
-  const searchPhotos = Api.usePhotosSearchPhotos();
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -104,18 +102,8 @@ function FilterPage() {
 
     const encoded = serializeFilter(data);
 
-    searchPhotos.mutate(
-      { data: filter },
-      {
-        onSuccess: () => {
-          dispatch(setFilter(filter));
-          navigate(`/photos?filter=${encodeURIComponent(encoded)}`);
-        },
-        onError: () => {
-          // handle error if needed
-        },
-      }
-    );
+    dispatch(setFilter(filter));
+    navigate(`/photos?filter=${encodeURIComponent(encoded)}`);
   };
 
   if (!loaded) {

--- a/frontend/packages/telegram-bot/src/commands/ai.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.ts
@@ -1,8 +1,8 @@
-import type { MyContext } from '../i18n';
 import { parseQueryWithOpenAI } from '@photobank/shared/ai/openai';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 import { getFilterHash } from '@photobank/shared/index';
 
+import type { MyContext } from '../i18n';
 import {
   findBestPersonId,
   findBestTagId,

--- a/frontend/packages/telegram-bot/src/commands/helpers.ts
+++ b/frontend/packages/telegram-bot/src/commands/helpers.ts
@@ -1,6 +1,6 @@
 import { InlineKeyboard } from "grammy";
-import type { MyContext } from "../i18n";
 
+import type { MyContext } from "../i18n";
 import { logger } from "../logger";
 
 export const PAGE_SIZE = 10;

--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -1,5 +1,4 @@
 import type { MyContext } from "../i18n";
-
 import { getAllPersons } from '../dictionaries';
 import { parsePrefix, sendNamedItemsPage } from "./helpers";
 

--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -1,8 +1,8 @@
 import { InlineKeyboard } from 'grammy';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 import { firstNWords } from '@photobank/shared/index';
-import type { MyContext } from '../i18n';
 
+import type { MyContext } from '../i18n';
 import { searchPhotos } from '../services/photo';
 import { handleCommandError } from '../errorHandler';
 import { captionCache, currentPagePhotos, deletePhotoMessage } from '../photo';

--- a/frontend/packages/telegram-bot/src/commands/profile.ts
+++ b/frontend/packages/telegram-bot/src/commands/profile.ts
@@ -1,5 +1,4 @@
 import type { MyContext } from "../i18n";
-
 import { getUser, getUserRoles, getUserClaims } from "../services/auth";
 import { handleCommandError } from "../errorHandler";
 

--- a/frontend/packages/telegram-bot/src/commands/search.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.ts
@@ -1,5 +1,4 @@
 import type { MyContext } from "../i18n";
-
 import { sendPhotosPage } from "./photosPage";
 
 function parseCaption(text?: string): string {

--- a/frontend/packages/telegram-bot/src/commands/storages.ts
+++ b/frontend/packages/telegram-bot/src/commands/storages.ts
@@ -1,5 +1,4 @@
 import type { MyContext } from '../i18n';
-
 import { getAllStoragesWithPaths } from '../dictionaries';
 import { parsePrefix, sendNamedItemsPage } from './helpers';
 

--- a/frontend/packages/telegram-bot/src/commands/subscribe.ts
+++ b/frontend/packages/telegram-bot/src/commands/subscribe.ts
@@ -1,9 +1,9 @@
-import { Bot } from "grammy";
-import type { MyContext } from "../i18n";
-import { i18n } from "../i18n";
+import { Bot } from 'grammy';
 
-import { sendThisDayPage } from "./thisday";
-import { updateUser } from "../services/auth";
+import { updateUser } from '../services/auth';
+import type { MyContext } from '../i18n';
+import { i18n } from '../i18n';
+import { sendThisDayPage } from './thisday';
 
 export const subscriptions = new Map<number, { time: string; locale: string }>();
 
@@ -42,7 +42,7 @@ export function initSubscriptionScheduler(bot: Bot) {
             message: { text: "/thisday" },
             reply: (text: string, opts?: Record<string, unknown>) => bot.api.sendMessage(chatId, text, opts),
             t: (key: string, params?: Record<string, unknown>) => i18n.t(info.locale, key, params),
-            i18n: { locale: () => info.locale } as any,
+            i18n: { locale: () => info.locale } as unknown as MyContext['i18n'],
           } as unknown as MyContext;
           await sendThisDayPage(ctxLike, 1);
         }

--- a/frontend/packages/telegram-bot/src/commands/tags.ts
+++ b/frontend/packages/telegram-bot/src/commands/tags.ts
@@ -1,7 +1,6 @@
-import type { MyContext } from "../i18n";
-
+import type { MyContext } from '../i18n';
 import { getAllTags } from '../dictionaries';
-import { parsePrefix, sendNamedItemsPage } from "./helpers";
+import { parsePrefix, sendNamedItemsPage } from './helpers';
 
 export async function sendTagsPage(
   ctx: MyContext,

--- a/frontend/packages/telegram-bot/src/commands/thisday.ts
+++ b/frontend/packages/telegram-bot/src/commands/thisday.ts
@@ -1,6 +1,5 @@
-import type { MyContext } from "../i18n";
-
-import { sendPhotosPage } from "./photosPage";
+import type { MyContext } from '../i18n';
+import { sendPhotosPage } from './photosPage';
 
 function parsePage(text?: string): number {
     if (!text) return 1;

--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -1,11 +1,11 @@
-import type { MyContext } from '../i18n';
 import axios from 'axios';
 import { uploadStorageName } from '@photobank/shared/constants';
 
-import { uploadPhotos } from '../services/photo';
-import { handleCommandError } from '../errorHandler';
 import { BOT_TOKEN } from '../config';
 import { getStorageId } from '../dictionaries';
+import { handleCommandError } from '../errorHandler';
+import type { MyContext } from '../i18n';
+import { uploadPhotos } from '../services/photo';
 
 async function fetchFile(ctx: MyContext, fileId: string, fileName: string) {
   const file = await ctx.api.getFile(fileId);

--- a/frontend/packages/telegram-bot/src/dictionaries.ts
+++ b/frontend/packages/telegram-bot/src/dictionaries.ts
@@ -3,9 +3,9 @@ import type {
   StorageDto,
   TagDto,
 } from '@photobank/shared/api/photobank';
-import type { MyContext } from './i18n';
-import { i18n } from './i18n';
 
+import { i18n } from './i18n';
+import type { MyContext } from './i18n';
 import {
   fetchPaths,
   fetchPersons,

--- a/frontend/packages/telegram-bot/src/errorHandler.ts
+++ b/frontend/packages/telegram-bot/src/errorHandler.ts
@@ -1,8 +1,8 @@
 import { BotError, Context } from 'grammy';
 import { apiErrorMsg } from '@photobank/shared/constants';
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
-import type { MyContext } from './i18n';
 
+import type { MyContext } from './i18n';
 import { logger } from './logger';
 
 export function handleBotError(err: BotError<Context>) {

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -1,9 +1,9 @@
-import { InputFile, InlineKeyboard } from "grammy";
-import type { PhotoDto } from "@photobank/shared/api/photobank";
-import type { MyContext } from "./i18n";
+import { InputFile, InlineKeyboard } from 'grammy';
+import type { PhotoDto } from '@photobank/shared/api/photobank';
 
-import { getPhoto } from "./services/photo";
-import { formatPhotoMessage } from "./formatPhotoMessage";
+import { formatPhotoMessage } from './formatPhotoMessage';
+import type { MyContext } from './i18n';
+import { getPhoto } from './services/photo';
 
 export const photoMessages = new Map<number, number>();
 export const currentPagePhotos = new Map<number, { page: number; ids: number[] }>();

--- a/frontend/packages/telegram-bot/src/registration.ts
+++ b/frontend/packages/telegram-bot/src/registration.ts
@@ -1,7 +1,7 @@
-import type { MyContext } from './i18n';
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
 import { ensureUserAccessToken } from './auth';
+import type { MyContext } from './i18n';
 
 export async function ensureRegistered(ctx: MyContext): Promise<boolean> {
   try {


### PR DESCRIPTION
## Summary
- simplify filter submission by dispatching filter and navigating without search mutation
- fix import order and type issues across telegram-bot package to satisfy lint

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dc07c3d48328a3fe39a6b58f6067