### PR TITLE
Adjust service lifetimes for repository and photo services

### DIFF
--- a/backend/PhotoBank.Services/RegisterServicesForApi.cs
+++ b/backend/PhotoBank.Services/RegisterServicesForApi.cs
@@ -9,10 +9,10 @@ namespace PhotoBank.Services
         public static void Configure(IServiceCollection services)
         {
             services.AddMemoryCache();
-            services.AddTransient(typeof(IRepository<>), typeof(Repository<>));
-            services.AddTransient<IPhotoService, PhotoService>();
-            services.AddTransient<ITokenService, TokenService>();
-            services.AddTransient<IImageService, ImageService>();
+            services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
+            services.AddScoped<IPhotoService, PhotoService>();
+            services.AddSingleton<ITokenService, TokenService>();
+            services.AddSingleton<IImageService, ImageService>();
         }
     }
 }


### PR DESCRIPTION
## Summary
- scope repository and photo service registrations per request
- convert token and image services to singletons for stateless use

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: MagickMissingDelegateErrorException: NoEncodeDelegateForThisImageFormat `XC`)*

------
https://chatgpt.com/codex/tasks/task_e_68a210b433048328aae54bcf870527af