### PR TITLE
Refactor query filters with GROUP BY and add indexes

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -74,6 +74,9 @@ namespace PhotoBank.DbContext.DbContext
                 .HasIndex(t => new { t.PhotoId });
 
             modelBuilder.Entity<PhotoTag>()
+                .HasIndex(x => new { x.TagId, x.PhotoId });
+
+            modelBuilder.Entity<PhotoTag>()
                 .HasOne(pt => pt.Photo)
                 .WithMany(p => p.PhotoTags)
                 .HasForeignKey(pt => pt.PhotoId);
@@ -123,6 +126,9 @@ namespace PhotoBank.DbContext.DbContext
             modelBuilder.Entity<Face>()
                 .HasIndex(p => p.PersonId)
                 .IncludeProperties(p => p.PhotoId);
+
+            modelBuilder.Entity<Face>()
+                .HasIndex(x => new { x.PersonId, x.PhotoId });
 
             modelBuilder.Entity<Face>()
                 .HasIndex(p => new { p.PhotoId, p.Id, p.PersonId });


### PR DESCRIPTION
## Summary
- rewrite person and tag filters using join/group-by to ensure all ids are matched
- add composite indexes on PhotoTag (TagId, PhotoId) and Face (PersonId, PhotoId)

## Testing
- `dotnet test backend/PhotoBank.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a226459fbc8328bbd77b328654145d