### PR TITLE
Restrict UsersController to admin role

### DIFF
--- a/backend/PhotoBank.Api/Controllers/Admin/UsersController.cs
+++ b/backend/PhotoBank.Api/Controllers/Admin/UsersController.cs
@@ -10,7 +10,7 @@ namespace PhotoBank.Api.Controllers.Admin;
 
 [Route("api/admin/[controller]")]
 [ApiController]
-[Authorize]
+[Authorize(Roles = "Admin")]
 public class UsersController(UserManager<ApplicationUser> userManager) : ControllerBase
 {
     [HttpGet]


### PR DESCRIPTION
## Summary
- require `Admin` role for admin UsersController API

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: tests hang during execution)*

------
https://chatgpt.com/codex/tasks/task_e_68a31b04503883288d7e150ca4fbfbd9