### PR TITLE
Enforce global authentication policy

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Identity;
 using PhotoBank.Services;
 using PhotoBank.Services.FaceRecognition;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.AspNetCore.Diagnostics;
@@ -107,7 +108,12 @@ namespace PhotoBank.Api
                 };
             });
 
-            builder.Services.AddAuthorization();
+            builder.Services.AddAuthorization(options =>
+            {
+                options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .Build();
+            });
             builder.Services.Configure<RouteOptions>(options =>
             {
                 options.LowercaseUrls = true;


### PR DESCRIPTION
## Summary
- require authentication by default through a fallback authorization policy

## Testing
- `dotnet build backend/PhotoBank.Api/PhotoBank.Api.csproj`
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-restore` *(fails: build canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68a31b9e6ed0832883e3595c4de29af7