### PR TITLE
Enforce authenticated access by default

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -115,7 +115,12 @@ namespace PhotoBank.Api
             });
 
 
-            builder.Services.AddAuthorization();
+            builder.Services.AddAuthorization(options =>
+            {
+                options.FallbackPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .Build();
+            });
 
             builder.Services.Configure<RouteOptions>(options =>
             {


### PR DESCRIPTION
## Summary
- require authentication by default for all API endpoints

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: MagickMissingDelegateErrorException)*

------
https://chatgpt.com/codex/tasks/task_e_68a31d23f3148328a9613e247b40caad