### PR TITLE
feat: add current user abstraction

### DIFF
--- a/backend/PhotoBank.Api/AccessControl/CurrentUser.cs
+++ b/backend/PhotoBank.Api/AccessControl/CurrentUser.cs
@@ -1,0 +1,18 @@
+using System.Security.Claims;
+
+namespace PhotoBank.Api.AccessControl;
+
+public sealed class CurrentUser : ICurrentUser
+{
+    public bool IsAdmin { get; }
+    public IReadOnlySet<int> AllowedStorageIds { get; } = new HashSet<int>();
+    public IReadOnlySet<int> AllowedPersonGroupIds { get; } = new HashSet<int>();
+    public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; } = new List<(DateOnly, DateOnly)>();
+    public bool NsfwOnly { get; } = false; // поля NSFW в модели сейчас нет
+
+    public CurrentUser(IHttpContextAccessor accessor)
+    {
+        var principal = accessor.HttpContext?.User ?? throw new InvalidOperationException("No HttpContext.User");
+        IsAdmin = principal.IsInRole("Admin");
+    }
+}

--- a/backend/PhotoBank.Api/AccessControl/ICurrentUser.cs
+++ b/backend/PhotoBank.Api/AccessControl/ICurrentUser.cs
@@ -1,0 +1,10 @@
+namespace PhotoBank.Api.AccessControl;
+
+public interface ICurrentUser
+{
+    bool IsAdmin { get; }
+    IReadOnlySet<int> AllowedStorageIds { get; }
+    IReadOnlySet<int> AllowedPersonGroupIds { get; }
+    IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; }
+    bool NsfwOnly { get; } // сейчас в модели поля NSFW нет — оставлен на будущее
+}

--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -177,7 +177,7 @@ namespace PhotoBank.Api
             });
 
             builder.Services.AddScoped<IEffectiveAccessProvider, EffectiveAccessProvider>();
-            builder.Services.AddScoped<ICurrentUser, CurrentUser>();
+            builder.Services.AddScoped<PhotoBank.Api.AccessControl.ICurrentUser, PhotoBank.Api.AccessControl.CurrentUser>();
 
             var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- define `ICurrentUser` contract for API
- provide minimal `CurrentUser` implementation based on user roles
- register the `CurrentUser` service in the API

## Testing
- `dotnet build backend/PhotoBank.Backend.sln` *(fails: Failed to download NuGet packages — A task was canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68a31fd6a7608328b28d8cee2690d29a