### PR TITLE
Rename NSFW access flag to CanSeeNsfw

### DIFF
--- a/backend/PhotoBank.Api/AccessControl/CurrentUser.cs
+++ b/backend/PhotoBank.Api/AccessControl/CurrentUser.cs
@@ -8,11 +8,13 @@ public sealed class CurrentUser : ICurrentUser
     public IReadOnlySet<int> AllowedStorageIds { get; } = new HashSet<int>();
     public IReadOnlySet<int> AllowedPersonGroupIds { get; } = new HashSet<int>();
     public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; } = new List<(DateOnly, DateOnly)>();
-    public bool NsfwOnly { get; } = false; // поля NSFW в модели сейчас нет
+    public bool CanSeeNsfw { get; } = false; // по умолчанию запрещено
 
     public CurrentUser(IHttpContextAccessor accessor)
     {
         var principal = accessor.HttpContext?.User ?? throw new InvalidOperationException("No HttpContext.User");
         IsAdmin = principal.IsInRole("Admin");
+        // если у вас уже есть реальный провайдер разрешений — тут подхватите флаг
+        // CanSeeNsfw = ...;
     }
 }

--- a/backend/PhotoBank.Api/AccessControl/ICurrentUser.cs
+++ b/backend/PhotoBank.Api/AccessControl/ICurrentUser.cs
@@ -6,5 +6,5 @@ public interface ICurrentUser
     IReadOnlySet<int> AllowedStorageIds { get; }
     IReadOnlySet<int> AllowedPersonGroupIds { get; }
     IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; }
-    bool NsfwOnly { get; } // сейчас в модели поля NSFW нет — оставлен на будущее
+    bool CanSeeNsfw { get; } // разрешено видеть Adult/Racy
 }

--- a/backend/PhotoBank.DbContext/AccessControl/AccessProfileEntities.cs
+++ b/backend/PhotoBank.DbContext/AccessControl/AccessProfileEntities.cs
@@ -14,7 +14,7 @@ public class AccessProfile
     [MaxLength(512)]
     public string? Description { get; set; }
 
-    public bool Flags_NsfwOnly { get; set; }
+    public bool Flags_CanSeeNsfw { get; set; }
 
     public ICollection<AccessProfileStorageAllow> Storages { get; set; } = [];
     public ICollection<AccessProfilePersonGroupAllow> PersonGroups { get; set; } = [];

--- a/backend/PhotoBank.DbContext/AccessControl/ICurrentUser.cs
+++ b/backend/PhotoBank.DbContext/AccessControl/ICurrentUser.cs
@@ -10,5 +10,5 @@ public interface ICurrentUser
     IReadOnlySet<int> AllowedStorageIds { get; }
     IReadOnlySet<int> AllowedPersonGroupIds { get; }
     IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; }
-    bool NsfwOnly { get; }
+    bool CanSeeNsfw { get; }
 }

--- a/backend/PhotoBank.DbContext/AccessControlMigrations/20250818094611_AddAccessControl.Designer.cs
+++ b/backend/PhotoBank.DbContext/AccessControlMigrations/20250818094611_AddAccessControl.Designer.cs
@@ -37,7 +37,7 @@ namespace PhotoBank.DbContext.AccessControlMigrations
                         .HasMaxLength(512)
                         .HasColumnType("nvarchar(512)");
 
-                    b.Property<bool>("Flags_NsfwOnly")
+                    b.Property<bool>("Flags_CanSeeNsfw")
                         .HasColumnType("bit");
 
                     b.Property<string>("Name")

--- a/backend/PhotoBank.DbContext/AccessControlMigrations/20250818094611_AddAccessControl.cs
+++ b/backend/PhotoBank.DbContext/AccessControlMigrations/20250818094611_AddAccessControl.cs
@@ -19,7 +19,7 @@ namespace PhotoBank.DbContext.AccessControlMigrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: true),
                     Description = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
-                    Flags_NsfwOnly = table.Column<bool>(type: "bit", nullable: false)
+                    Flags_CanSeeNsfw = table.Column<bool>(type: "bit", nullable: false)
                 },
                 constraints: table =>
                 {

--- a/backend/PhotoBank.DbContext/AccessControlMigrations/AccessControlDbContextModelSnapshot.cs
+++ b/backend/PhotoBank.DbContext/AccessControlMigrations/AccessControlDbContextModelSnapshot.cs
@@ -34,7 +34,7 @@ namespace PhotoBank.DbContext.AccessControlMigrations
                         .HasMaxLength(512)
                         .HasColumnType("nvarchar(512)");
 
-                    b.Property<bool>("Flags_NsfwOnly")
+                    b.Property<bool>("Flags_CanSeeNsfw")
                         .HasColumnType("bit");
 
                     b.Property<string>("Name")

--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -171,7 +171,7 @@ namespace PhotoBank.DbContext.DbContext
             var storages = _user.AllowedStorageIds?.ToHashSet() ?? new HashSet<int>();
             var groups = _user.AllowedPersonGroupIds?.ToHashSet() ?? new HashSet<int>();
             var ranges = _user.AllowedDateRanges?.ToList() ?? new List<(DateOnly From, DateOnly To)>();
-            var nsfwOnly = _user.NsfwOnly;
+            var canSeeNsfw = _user.CanSeeNsfw;
 
             modelBuilder.Entity<Photo>().HasQueryFilter(p =>
                 isAdmin ||
@@ -185,7 +185,7 @@ namespace PhotoBank.DbContext.DbContext
                     (p.TakenDate != null && ranges.Count > 0 &&
                         ranges.Any(r => p.TakenDate.Value.Date >= r.From.ToDateTime(TimeOnly.MinValue).Date &&
                                         p.TakenDate.Value.Date <= r.To.ToDateTime(TimeOnly.MinValue).Date)) &&
-                    (!nsfwOnly || p.IsAdultContent)
+                    (canSeeNsfw || !p.IsAdultContent)
                 ));
         }
 
@@ -201,7 +201,7 @@ namespace PhotoBank.DbContext.DbContext
             public IReadOnlySet<int> AllowedStorageIds => new HashSet<int>();
             public IReadOnlySet<int> AllowedPersonGroupIds => new HashSet<int>();
             public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges => new List<(DateOnly From, DateOnly To)>();
-            public bool NsfwOnly => false;
+            public bool CanSeeNsfw => true;
         }
 
     }

--- a/backend/PhotoBank.Services/AccessControl/CurrentUser.cs
+++ b/backend/PhotoBank.Services/AccessControl/CurrentUser.cs
@@ -12,7 +12,7 @@ public sealed class CurrentUser : ICurrentUser
     public IReadOnlySet<int> AllowedStorageIds { get; }
     public IReadOnlySet<int> AllowedPersonGroupIds { get; }
     public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; }
-    public bool NsfwOnly { get; }
+    public bool CanSeeNsfw { get; }
 
     public CurrentUser(IHttpContextAccessor http, IEffectiveAccessProvider provider)
     {
@@ -26,6 +26,6 @@ public sealed class CurrentUser : ICurrentUser
         AllowedStorageIds = eff.StorageIds;
         AllowedPersonGroupIds = eff.PersonGroupIds;
         AllowedDateRanges = eff.DateRanges;
-        NsfwOnly = eff.NsfwOnly;
+        CanSeeNsfw = eff.CanSeeNsfw;
     }
 }

--- a/backend/PhotoBank.Services/AccessControl/EffectiveAccess.cs
+++ b/backend/PhotoBank.Services/AccessControl/EffectiveAccess.cs
@@ -10,7 +10,7 @@ public sealed record EffectiveAccess(
     IReadOnlySet<int> StorageIds,
     IReadOnlySet<int> PersonGroupIds,
     IReadOnlyList<(DateOnly From, DateOnly To)> DateRanges,
-    bool NsfwOnly,
+    bool CanSeeNsfw,
     bool IsAdmin);
 
 public interface IEffectiveAccessProvider

--- a/backend/PhotoBank.Services/AccessControl/EffectiveAccessProvider.cs
+++ b/backend/PhotoBank.Services/AccessControl/EffectiveAccessProvider.cs
@@ -67,16 +67,16 @@ public sealed class EffectiveAccessProvider : IEffectiveAccessProvider
             .Select(x => new { x.FromDate, x.ToDate })
             .ToListAsync(ct);
 
-        var nsfwOnly = await _db.AccessProfiles
+        var canSeeNsfw = await _db.AccessProfiles
             .Where(p => profileIds.Contains(p.Id))
-            .Select(p => p.Flags_NsfwOnly)
+            .Select(p => p.Flags_CanSeeNsfw)
             .AnyAsync(x => x, ct);
 
         var eff = new EffectiveAccess(
             storages.ToHashSet(),
             groups.ToHashSet(),
             ranges.Select(r => (r.FromDate, r.ToDate)).ToList(),
-            nsfwOnly,
+            canSeeNsfw,
             false
         );
 


### PR DESCRIPTION
## Summary
- rename `NsfwOnly` flag to `CanSeeNsfw`
- propagate new flag through access control services and EF models
- update query filters to hide adult content unless explicitly allowed

## Testing
- `dotnet build PhotoBank.Backend.sln` *(fails: The name 'Host' does not exist in the current context)*
- `dotnet build PhotoBank.Api/PhotoBank.Api.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a324f7a57483288c8c90525c786c9a