### PR TITLE
refactor: use shared access control registration

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -177,7 +177,7 @@ namespace PhotoBank.Api
             });
 
             builder.Services.AddScoped<IEffectiveAccessProvider, EffectiveAccessProvider>();
-            builder.Services.AddScoped<ICurrentUser, CurrentUser>();
+            builder.Services.AddScoped<PhotoBank.AccessControl.ICurrentUser, PhotoBank.AccessControl.CurrentUser>();
 
             var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- register shared access control service in API

## Testing
- `dotnet test backend/PhotoBank.sln` *(fails: workloads maui-tizen wasm-tools missing)*
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: ICurrentUser not found in PhotoBank.DbContext)*

------
https://chatgpt.com/codex/tasks/task_e_68a358e054c08328a0048c19cacf376d