### PR TITLE
Add user access control entities and NSFW user flag

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Logging;
 using System.Reflection;
+using System;
 
 namespace PhotoBank.DbContext.DbContext
 {
@@ -26,6 +27,9 @@ namespace PhotoBank.DbContext.DbContext
         public DbSet<File> Files { get; set; }
         public DbSet<PropertyName> PropertyNames { get; set; }
         public DbSet<Enricher> Enrichers { get; set; }
+        public DbSet<UserStorageAllow> UserStorageAllows => Set<UserStorageAllow>();
+        public DbSet<UserPersonGroupAllow> UserPersonGroupAllows => Set<UserPersonGroupAllow>();
+        public DbSet<UserDateRangeAllow> UserDateRangeAllows => Set<UserDateRangeAllow>();
 
         public PhotoBankDbContext(DbContextOptions<PhotoBankDbContext> options) : base(options)
         {
@@ -42,6 +46,7 @@ namespace PhotoBank.DbContext.DbContext
                     .IsUnique()
                     .HasFilter("[TelegramUserId] IS NOT NULL");
             });
+            modelBuilder.Entity<ApplicationUser>().Property(x => x.CanSeeNsfw).HasDefaultValue(false);
 
             modelBuilder.Entity<Photo>()
                 .HasIndex(p => p.Id)
@@ -153,6 +158,10 @@ namespace PhotoBank.DbContext.DbContext
             modelBuilder.Entity<Enricher>()
                 .HasIndex(u => u.Name)
                 .IsUnique();
+
+            modelBuilder.Entity<UserStorageAllow>().HasKey(x => new { x.UserId, x.StorageId });
+            modelBuilder.Entity<UserPersonGroupAllow>().HasKey(x => new { x.UserId, x.PersonGroupId });
+            modelBuilder.Entity<UserDateRangeAllow>().HasKey(x => new { x.UserId, x.FromDate, x.ToDate });
         }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -160,5 +169,24 @@ namespace PhotoBank.DbContext.DbContext
             optionsBuilder.UseLoggerFactory(PhotoBankLoggerFactory);
         }
 
+    }
+
+    public class UserStorageAllow
+    {
+        public string UserId { get; set; } = default!;
+        public int StorageId { get; set; }
+    }
+
+    public class UserPersonGroupAllow
+    {
+        public string UserId { get; set; } = default!;
+        public int PersonGroupId { get; set; }
+    }
+
+    public class UserDateRangeAllow
+    {
+        public string UserId { get; set; } = default!;
+        public DateOnly FromDate { get; set; }
+        public DateOnly ToDate { get; set; }
     }
 }

--- a/backend/PhotoBank.DbContext/Models/ApplicationUser.cs
+++ b/backend/PhotoBank.DbContext/Models/ApplicationUser.cs
@@ -11,5 +11,6 @@ namespace PhotoBank.DbContext.Models
     {
         public long? TelegramUserId { get; set; }
         public TimeSpan? TelegramSendTimeUtc { get; set; }
+        public bool CanSeeNsfw { get; set; }  // по умолчанию false
     }
 }


### PR DESCRIPTION
## Summary
- add access allow entities for storages, person groups, and date ranges
- expose NSFW visibility flag on `ApplicationUser`

## Testing
- `dotnet test PhotoBank.Backend.sln` (failed: ImageMagick.MagickMissingDelegateErrorException)


------
https://chatgpt.com/codex/tasks/task_e_68a35cf940708328a34c2d7e3dc434e5