### PR TITLE
Add user access entities and NSFW flag

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -6,6 +6,7 @@ using PhotoBank.AccessControl;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace PhotoBank.DbContext.DbContext
 {
@@ -32,6 +33,9 @@ namespace PhotoBank.DbContext.DbContext
         public DbSet<File> Files { get; set; }
         public DbSet<PropertyName> PropertyNames { get; set; }
         public DbSet<Enricher> Enrichers { get; set; }
+        public DbSet<UserStorageAllow> UserStorageAllows => Set<UserStorageAllow>();
+        public DbSet<UserPersonGroupAllow> UserPersonGroupAllows => Set<UserPersonGroupAllow>();
+        public DbSet<UserDateRangeAllow> UserDateRangeAllows => Set<UserDateRangeAllow>();
 
         public PhotoBankDbContext(DbContextOptions<PhotoBankDbContext> options, ICurrentUser user) : base(options)
         {
@@ -50,6 +54,7 @@ namespace PhotoBank.DbContext.DbContext
 
             modelBuilder.Entity<ApplicationUser>(b =>
             {
+                b.Property(x => x.CanSeeNsfw).HasDefaultValue(false);
                 b.HasIndex(u => u.TelegramUserId)
                     .IsUnique()
                     .HasFilter("[TelegramUserId] IS NOT NULL");
@@ -165,6 +170,14 @@ namespace PhotoBank.DbContext.DbContext
             modelBuilder.Entity<Enricher>()
                 .HasIndex(u => u.Name)
                 .IsUnique();
+            modelBuilder.Entity<UserStorageAllow>().HasKey(x => new { x.UserId, x.StorageId });
+            modelBuilder.Entity<UserPersonGroupAllow>().HasKey(x => new { x.UserId, x.PersonGroupId });
+            modelBuilder.Entity<UserDateRangeAllow>().HasKey(x => new { x.UserId, x.FromDate, x.ToDate });
+            var dConv = new ValueConverter<DateOnly, DateTime>(
+                d => d.ToDateTime(TimeOnly.MinValue),
+                dt => DateOnly.FromDateTime(dt));
+            modelBuilder.Entity<UserDateRangeAllow>().Property(x => x.FromDate).HasConversion(dConv).HasColumnType("date");
+            modelBuilder.Entity<UserDateRangeAllow>().Property(x => x.ToDate).HasConversion(dConv).HasColumnType("date");
 
             // --- Global filter for Photo ---
             var isAdmin = _user.IsAdmin;
@@ -204,5 +217,24 @@ namespace PhotoBank.DbContext.DbContext
             public bool CanSeeNsfw => true;
         }
 
+    }
+
+    public class UserStorageAllow
+    {
+        public string UserId { get; set; } = default!;
+        public int StorageId { get; set; }
+    }
+
+    public class UserPersonGroupAllow
+    {
+        public string UserId { get; set; } = default!;
+        public int PersonGroupId { get; set; }
+    }
+
+    public class UserDateRangeAllow
+    {
+        public string UserId { get; set; } = default!;
+        public DateOnly FromDate { get; set; }
+        public DateOnly ToDate { get; set; }
     }
 }

--- a/backend/PhotoBank.DbContext/Models/ApplicationUser.cs
+++ b/backend/PhotoBank.DbContext/Models/ApplicationUser.cs
@@ -11,5 +11,6 @@ namespace PhotoBank.DbContext.Models
     {
         public long? TelegramUserId { get; set; }
         public TimeSpan? TelegramSendTimeUtc { get; set; }
+        public bool CanSeeNsfw { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- add user-scoped allow entities for storages, person groups and date ranges
- expose NSFW visibility flag on application users

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: The type or namespace name 'ICurrentUser' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68a35f59c0b48328a7335bf0b397a012