### PR TITLE
Relax photo query filter for dates and people

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -191,13 +191,17 @@ namespace PhotoBank.DbContext.DbContext
                 (
                     (storages.Count > 0 && storages.Contains(p.StorageId)) &&
                     (
-                        !p.Faces.Any() ||
-                        p.Faces.Any(f => f.PersonId != null &&
+                        groups.Count == 0
+                        || !p.Faces.Any()
+                        || p.Faces.Any(f => f.PersonId != null &&
                             f.Person.PersonGroups.Any(pg => groups.Contains(pg.Id)))
                     ) &&
-                    (p.TakenDate != null && ranges.Count > 0 &&
-                        ranges.Any(r => p.TakenDate.Value.Date >= r.From.ToDateTime(TimeOnly.MinValue).Date &&
-                                        p.TakenDate.Value.Date <= r.To.ToDateTime(TimeOnly.MinValue).Date)) &&
+                    (
+                        ranges.Count == 0
+                        || (p.TakenDate != null && ranges.Any(r =>
+                            p.TakenDate.Value.Date >= r.From.ToDateTime(TimeOnly.MinValue).Date &&
+                            p.TakenDate.Value.Date <= r.To.ToDateTime(TimeOnly.MinValue).Date))
+                    ) &&
                     (canSeeNsfw || !p.IsAdultContent)
                 ));
         }


### PR DESCRIPTION
## Summary
- loosen person group filtering: if no groups are allowed, photos with any faces are visible; otherwise require at least one face in an allowed group or no faces
- loosen date filtering: when no date ranges are configured, allow all dates; otherwise restrict to photos in allowed ranges

## Testing
- `dotnet test backend/PhotoBank.sln` *(fails: .NET SDK 8.0 lacks support for targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a3634cb20c8328bac4e6ce6b4d848b