### PR TITLE
Add query filters for storage and person entities

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -186,6 +186,14 @@ namespace PhotoBank.DbContext.DbContext
             var ranges = _user.AllowedDateRanges?.ToList() ?? new List<(DateOnly From, DateOnly To)>();
             var canSeeNsfw = _user.CanSeeNsfw;
 
+            // Storage — only allowed, admin sees all
+            modelBuilder.Entity<Storage>().HasQueryFilter(s =>
+                isAdmin || storages.Contains(s.Id));
+
+            // Person — only from allowed groups, admin sees all
+            modelBuilder.Entity<Person>().HasQueryFilter(p =>
+                isAdmin || p.PersonGroups.Any(pg => groups.Contains(pg.Id)));
+
             modelBuilder.Entity<Photo>().HasQueryFilter(p =>
                 isAdmin ||
                 (


### PR DESCRIPTION
## Summary
- limit `Storage` queries to allowed IDs while allowing admin override
- restrict `Person` queries to user-permitted groups with admin bypass

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a38151f8b883288e97c10cdc7ffa5f