### PR TITLE
Add debug endpoint for effective access

### DIFF
--- a/backend/PhotoBank.Api/Controllers/AuthController.cs
+++ b/backend/PhotoBank.Api/Controllers/AuthController.cs
@@ -3,11 +3,14 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Http;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Services.Api;
+using PhotoBank.AccessControl;
 using PhotoBank.ViewModel.Dto;
 using System.Linq;
 using System.Collections.Generic;
+using System.Security.Claims;
 
 namespace PhotoBank.Api.Controllers;
 
@@ -166,6 +169,15 @@ public class AuthController(
         }
 
         return Ok(roles);
+    }
+
+    [HttpGet("debug/effective-access")]
+    [Authorize(Roles = "Admin")]
+    public async Task<ActionResult> GetEffective([FromServices] IEffectiveAccessProvider eff, [FromServices] IHttpContextAccessor http)
+    {
+        var userId = http.HttpContext!.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        var data = await eff.GetAsync(userId, http.HttpContext!.User);
+        return Ok(data);
     }
 }
 


### PR DESCRIPTION
## Summary
- expose admin-only debug endpoint returning effective access information

## Testing
- `dotnet test PhotoBank.sln` *(fails: workloads maui-tizen wasm-tools missing)*
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: ImageMagick missing delegate for format `XC`)*

------
https://chatgpt.com/codex/tasks/task_e_68a384829a1c8328b37693f377e70d6b