### PR TITLE
refactor: remove ApplicationUser CanSeeNsfw

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -54,7 +54,6 @@ namespace PhotoBank.DbContext.DbContext
 
             modelBuilder.Entity<ApplicationUser>(b =>
             {
-                b.Property(x => x.CanSeeNsfw).HasDefaultValue(false);
                 b.HasIndex(u => u.TelegramUserId)
                     .IsUnique()
                     .HasFilter("[TelegramUserId] IS NOT NULL");

--- a/backend/PhotoBank.DbContext/Models/ApplicationUser.cs
+++ b/backend/PhotoBank.DbContext/Models/ApplicationUser.cs
@@ -11,6 +11,5 @@ namespace PhotoBank.DbContext.Models
     {
         public long? TelegramUserId { get; set; }
         public TimeSpan? TelegramSendTimeUtc { get; set; }
-        public bool CanSeeNsfw { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- remove unused CanSeeNsfw field from ApplicationUser
- stop configuring CanSeeNsfw in PhotoBankDbContext

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: A network-related or instance-specific error occurred while establishing a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_68a38469135c8328afd5ec986faa81b0