### PR TITLE
Enforce profile-based access control for photo visibility

### DIFF
--- a/backend/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
+++ b/backend/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
@@ -1,3 +1,4 @@
+extern alias ServicesLib;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -10,6 +11,7 @@ using PhotoBank.ViewModel.Dto;
 using System.Diagnostics;
 using System;
 using System.Threading.Tasks;
+using AccessCurrentUser = ServicesLib.PhotoBank.AccessControl.ICurrentUser;
 
 namespace PhotoBank.IntegrationTests;
 
@@ -58,6 +60,7 @@ public class GetAllPhotosIntegrationTests
         {
             cfg.AddProfile<MappingProfile>();
         });
+        services.AddSingleton<AccessCurrentUser>(new TestCurrentUser());
         _provider = services.BuildServiceProvider();
     }
 
@@ -65,6 +68,15 @@ public class GetAllPhotosIntegrationTests
     public void TearDown()
     {
         _provider.Dispose();
+    }
+
+    private sealed class TestCurrentUser : AccessCurrentUser
+    {
+        public bool IsAdmin { get; init; } = true;
+        public IReadOnlySet<int> AllowedStorageIds { get; init; } = new HashSet<int>();
+        public IReadOnlySet<int> AllowedPersonGroupIds { get; init; } = new HashSet<int>();
+        public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; init; } = new List<(DateOnly, DateOnly)>();
+        public bool CanSeeNsfw { get; init; } = true;
     }
 
     [Test]

--- a/backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj
+++ b/backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj
@@ -22,6 +22,6 @@
   <ItemGroup>
     <ProjectReference Include="..\PhotoBank.DbContext\PhotoBank.DbContext.csproj" />
     <ProjectReference Include="..\PhotoBank.Repositories\PhotoBank.Repositories.csproj" />
-    <ProjectReference Include="..\PhotoBank.Services\PhotoBank.Services.csproj" />
+    <ProjectReference Include="..\PhotoBank.Services\PhotoBank.Services.csproj" Aliases="global,ServicesLib" />
   </ItemGroup>
 </Project>

--- a/backend/PhotoBank.Services/Api/PhotoService.cs
+++ b/backend/PhotoBank.Services/Api/PhotoService.cs
@@ -12,6 +12,7 @@ using PhotoBank.DbContext.Models;
 using PhotoBank.Repositories;
 using PhotoBank.ViewModel.Dto;
 using PhotoBank.Services;
+using PhotoBank.AccessControl;
 using System.IO;
 
 namespace PhotoBank.Services.Api;
@@ -40,6 +41,7 @@ public class PhotoService : IPhotoService
     private readonly IMemoryCache _cache;
     private readonly Lazy<Task<IReadOnlyList<TagDto>>> _tags;
     private readonly Lazy<Task<IReadOnlyList<PathDto>>> _paths;
+    private readonly ICurrentUser _currentUser;
 
     private static readonly MemoryCacheEntryOptions CacheOptions = new()
     {
@@ -55,7 +57,8 @@ public class PhotoService : IPhotoService
         IRepository<Storage> storageRepository,
         IRepository<Tag> tagRepository,
         IMapper mapper,
-        IMemoryCache cache)
+        IMemoryCache cache,
+        ICurrentUser currentUser)
     {
         _db = db;
         _photoRepository = photoRepository;
@@ -64,6 +67,7 @@ public class PhotoService : IPhotoService
         _storageRepository = storageRepository;
         _mapper = mapper;
         _cache = cache;
+        _currentUser = currentUser;
         _tags = new Lazy<Task<IReadOnlyList<TagDto>>>(() =>
             GetCachedAsync("tags", async () => (IReadOnlyList<TagDto>)await tagRepository.GetAll()
                 .AsNoTracking()
@@ -144,9 +148,54 @@ public class PhotoService : IPhotoService
         return query;
     }
 
+    private IQueryable<Photo> ApplyAccessControl(IQueryable<Photo> query)
+    {
+        if (_currentUser.IsAdmin) return query;
+
+        if (_currentUser.AllowedStorageIds.Count > 0)
+        {
+            var storages = _currentUser.AllowedStorageIds.ToList();
+            query = query.Where(p => storages.Contains(p.StorageId));
+        }
+        else
+        {
+            // no access to any storage
+            return query.Where(p => false);
+        }
+
+        if (_currentUser.AllowedDateRanges.Count > 0)
+        {
+            var ranges = _currentUser.AllowedDateRanges
+                .Select(r => new { From = r.From.ToDateTime(TimeOnly.MinValue), To = r.To.ToDateTime(TimeOnly.MaxValue) })
+                .ToList();
+            query = query.Where(p => p.TakenDate.HasValue && ranges.Any(r => p.TakenDate.Value >= r.From && p.TakenDate.Value <= r.To));
+        }
+
+        if (_currentUser.AllowedPersonGroupIds.Count > 0)
+        {
+            var allowedGroups = _currentUser.AllowedPersonGroupIds.ToList();
+            var faces = from f in _db.Faces
+                        where f.PersonId != null
+                        from pg in f.Person.PersonGroups
+                        select new { f.PhotoId, GroupId = pg.Id };
+
+            query = query.Where(p =>
+                !faces.Any(f => f.PhotoId == p.Id) ||
+                faces.Any(f => f.PhotoId == p.Id && allowedGroups.Contains(f.GroupId)));
+        }
+
+        if (!_currentUser.CanSeeNsfw)
+        {
+            query = query.Where(p => !p.IsAdultContent && !p.IsRacyContent);
+        }
+
+        return query;
+    }
+
     public async Task<PageResponse<PhotoItemDto>> GetAllPhotosAsync(FilterDto filter)
     {
         var query = ApplyFilter(_photoRepository.GetAll().AsNoTracking().AsSplitQuery(), filter);
+        query = ApplyAccessControl(query);
 
         // Execute the count query first
         var count = await query.CountAsync();
@@ -174,13 +223,32 @@ public class PhotoService : IPhotoService
     public async Task<PhotoDto> GetPhotoAsync(int id)
     {
         var photo = await CompiledQueries.PhotoById(_db, id);
+        if (photo == null) return null;
+
+        var query = ApplyAccessControl(_db.Photos.Where(p => p.Id == id));
+        var hasAccess = await query.AnyAsync();
+        if (!hasAccess) return null;
+
         return _mapper.Map<Photo, PhotoDto>(photo);
     }
 
     public async Task<IEnumerable<PersonDto>> GetAllPersonsAsync()
     {
-        return await _personRepository.GetAll()
-            .AsNoTracking()
+        var query = _personRepository.GetAll().AsNoTracking();
+        if (!_currentUser.IsAdmin)
+        {
+            if (_currentUser.AllowedPersonGroupIds.Count > 0)
+            {
+                var groups = _currentUser.AllowedPersonGroupIds.ToList();
+                query = query.Where(p => p.PersonGroups.Any(pg => groups.Contains(pg.Id)));
+            }
+            else
+            {
+                return Enumerable.Empty<PersonDto>();
+            }
+        }
+
+        return await query
             .OrderBy(p => p.Name)
             .ThenBy(p => p.Id)
             .ProjectTo<PersonDto>(_mapper.ConfigurationProvider)
@@ -191,8 +259,21 @@ public class PhotoService : IPhotoService
 
     public async Task<IEnumerable<StorageDto>> GetAllStoragesAsync()
     {
-        return await _storageRepository.GetAll()
-            .AsNoTracking()
+        var query = _storageRepository.GetAll().AsNoTracking();
+        if (!_currentUser.IsAdmin)
+        {
+            if (_currentUser.AllowedStorageIds.Count > 0)
+            {
+                var storages = _currentUser.AllowedStorageIds.ToList();
+                query = query.Where(s => storages.Contains(s.Id));
+            }
+            else
+            {
+                return Enumerable.Empty<StorageDto>();
+            }
+        }
+
+        return await query
             .OrderBy(p => p.Name)
             .ThenBy(p => p.Id)
             .ProjectTo<StorageDto>(_mapper.ConfigurationProvider)

--- a/backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj
+++ b/backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <ProjectReference Include="..\PhotoBank.DbContext\PhotoBank.DbContext.csproj" />
     <ProjectReference Include="..\PhotoBank.Repositories\PhotoBank.Repositories.csproj" />
-    <ProjectReference Include="..\PhotoBank.Services\PhotoBank.Services.csproj" />
+    <ProjectReference Include="..\PhotoBank.Services\PhotoBank.Services.csproj" Aliases="global,ServicesLib" />
   </ItemGroup>
 
 </Project>

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿extern alias ServicesLib;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
+using AccessCurrentUser = ServicesLib.PhotoBank.AccessControl.ICurrentUser;
 
 namespace PhotoBank.UnitTests.Services
 {
@@ -37,12 +39,13 @@ namespace PhotoBank.UnitTests.Services
             _mapper = provider.GetRequiredService<IMapper>();
         }
 
-        private PhotoService CreateService(string dbName)
+        private PhotoService CreateService(string dbName, AccessCurrentUser? user = null)
         {
             var services = new ServiceCollection();
             services.AddDbContext<PhotoBankDbContext>(o => o.UseInMemoryDatabase(dbName));
             var provider = services.BuildServiceProvider();
             var context = provider.GetRequiredService<PhotoBankDbContext>();
+            user ??= new TestCurrentUser { IsAdmin = true };
             return new PhotoService(
                 context,
                 new Repository<Photo>(provider),
@@ -50,7 +53,16 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Face>(provider),
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
-                _mapper, new MemoryCache(new MemoryCacheOptions()));
+                _mapper, new MemoryCache(new MemoryCacheOptions()), user);
+        }
+
+        private sealed class TestCurrentUser : AccessCurrentUser
+        {
+            public bool IsAdmin { get; init; }
+            public IReadOnlySet<int> AllowedStorageIds { get; init; } = new HashSet<int>();
+            public IReadOnlySet<int> AllowedPersonGroupIds { get; init; } = new HashSet<int>();
+            public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; init; } = new List<(DateOnly, DateOnly)>();
+            public bool CanSeeNsfw { get; init; } = true;
         }
 
         [Test]
@@ -306,6 +318,61 @@ namespace PhotoBank.UnitTests.Services
             // Assert
             result.TotalCount.Should().Be(1);
             result.Items.Should().ContainSingle(p => p.Name == "both");
+        }
+
+        [Test]
+        public async Task GetAllPhotosAsync_RespectsAccessControl()
+        {
+            var dbName = Guid.NewGuid().ToString();
+            var services = new ServiceCollection();
+            services.AddDbContext<PhotoBankDbContext>(o => o.UseInMemoryDatabase(dbName));
+            var provider = services.BuildServiceProvider();
+            var context = provider.GetRequiredService<PhotoBankDbContext>();
+
+            var storage1 = new Storage { Name = "s1" };
+            var storage2 = new Storage { Name = "s2" };
+            context.Storages.AddRange(storage1, storage2);
+
+            var group1 = new PersonGroup { Name = "g1" };
+            var group2 = new PersonGroup { Name = "g2" };
+            context.PersonGroups.AddRange(group1, group2);
+
+            var person1 = new Person { Name = "p1", PersonGroups = new List<PersonGroup> { group1 } };
+            var person2 = new Person { Name = "p2", PersonGroups = new List<PersonGroup> { group2 } };
+            context.Persons.AddRange(person1, person2);
+            await context.SaveChangesAsync();
+
+            var allowedPhoto = new Photo { Storage = storage1, StorageId = storage1.Id, Name = "allowed", TakenDate = new DateTime(2020, 1, 1) };
+            allowedPhoto.Faces = new List<Face> { new Face { Photo = allowedPhoto, Person = person1, PersonId = person1.Id } };
+
+            var foreignPhoto = new Photo { Storage = storage1, StorageId = storage1.Id, Name = "foreign", TakenDate = new DateTime(2020, 1, 1) };
+            foreignPhoto.Faces = new List<Face> { new Face { Photo = foreignPhoto, Person = person2, PersonId = person2.Id } };
+
+            var noFacePhoto = new Photo { Storage = storage1, StorageId = storage1.Id, Name = "noface", TakenDate = new DateTime(2020, 1, 1) };
+
+            var nsfwPhoto = new Photo { Storage = storage1, StorageId = storage1.Id, Name = "nsfw", TakenDate = new DateTime(2020, 1, 1), IsAdultContent = true };
+
+            var otherStoragePhoto = new Photo { Storage = storage2, StorageId = storage2.Id, Name = "other", TakenDate = new DateTime(2020, 1, 1) };
+
+            context.Photos.AddRange(allowedPhoto, foreignPhoto, noFacePhoto, nsfwPhoto, otherStoragePhoto);
+            await context.SaveChangesAsync();
+
+            var currentUser = new TestCurrentUser
+            {
+                IsAdmin = false,
+                AllowedStorageIds = new HashSet<int> { storage1.Id },
+                AllowedPersonGroupIds = new HashSet<int> { group1.Id },
+                AllowedDateRanges = new List<(DateOnly, DateOnly)> { (DateOnly.FromDateTime(new DateTime(2019, 1, 1)), DateOnly.FromDateTime(new DateTime(2021, 1, 1))) },
+                CanSeeNsfw = false
+            };
+
+            var service = CreateService(dbName, currentUser);
+            var filter = new FilterDto();
+
+            var result = await service.GetAllPhotosAsync(filter);
+
+            result.TotalCount.Should().Be(2);
+            result.Items.Select(p => p.Name).Should().BeEquivalentTo(new[] { "allowed", "noface" });
         }
     }
 }

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -1,6 +1,8 @@
+extern alias ServicesLib;
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -13,6 +15,7 @@ using PhotoBank.DbContext.Models;
 using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
+using AccessCurrentUser = ServicesLib.PhotoBank.AccessControl.ICurrentUser;
 
 namespace PhotoBank.UnitTests.Services
 {
@@ -52,7 +55,8 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 _mapper,
-                new MemoryCache(new MemoryCacheOptions()));
+                new MemoryCache(new MemoryCacheOptions()),
+                new TestCurrentUser { IsAdmin = true });
 
             var bytes = new byte[] { 1, 2, 3, 4 };
             await using var ms = new MemoryStream(bytes);
@@ -87,7 +91,8 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 _mapper,
-                new MemoryCache(new MemoryCacheOptions()));
+                new MemoryCache(new MemoryCacheOptions()),
+                new TestCurrentUser { IsAdmin = true });
 
             var bytes = new byte[] { 1, 2, 3, 4 };
             await using var ms1 = new MemoryStream(bytes);
@@ -126,7 +131,8 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 _mapper,
-                new MemoryCache(new MemoryCacheOptions()));
+                new MemoryCache(new MemoryCacheOptions()),
+                new TestCurrentUser { IsAdmin = true });
 
             var bytes1 = new byte[] { 1, 2, 3, 4 };
             await using var ms1 = new MemoryStream(bytes1);
@@ -146,5 +152,14 @@ namespace PhotoBank.UnitTests.Services
 
             Directory.Delete(tempFolder, true);
         }
+    }
+
+    internal sealed class TestCurrentUser : AccessCurrentUser
+    {
+        public bool IsAdmin { get; init; }
+        public IReadOnlySet<int> AllowedStorageIds { get; init; } = new HashSet<int>();
+        public IReadOnlySet<int> AllowedPersonGroupIds { get; init; } = new HashSet<int>();
+        public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; init; } = new List<(DateOnly, DateOnly)>();
+        public bool CanSeeNsfw { get; init; } = true;
     }
 }


### PR DESCRIPTION
## Summary
- inject current user context into `PhotoService`
- filter photos, persons and storages by user profile, groups, date ranges and NSFW flag
- add tests for profile-based filtering

## Testing
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails to report final summary; warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_68a40d736974832899cbb7a093f80e59