### PR TITLE
Add Swagger server base path filter

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -21,6 +21,7 @@ using HealthChecks.UI.Client;
 using FluentValidation;
 using FluentValidation.AspNetCore;
 using System.Text.Json.Serialization;
+using PhotoBank.Api.Swagger;
 using PhotoBank.Api.Validators;
 
 namespace PhotoBank.Api
@@ -164,6 +165,7 @@ namespace PhotoBank.Api
 
                     return null;
                 });
+                c.DocumentFilter<ServersDocumentFilter>();
             });
 
             builder.Services.AddFaceRecognition(builder.Configuration);

--- a/backend/PhotoBank.Api/Swagger/ServersDocumentFilter.cs
+++ b/backend/PhotoBank.Api/Swagger/ServersDocumentFilter.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace PhotoBank.Api.Swagger;
+
+public class ServersDocumentFilter : IDocumentFilter
+{
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        swaggerDoc.Servers = new List<OpenApiServer>
+        {
+            new OpenApiServer { Url = "/api" }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add `ServersDocumentFilter` to force Swagger's server URL to `/api`
- register the new document filter in Swagger configuration

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: Failed: 13, Passed: 0, Skipped: 0, Total: 13 in PhotoBank.IntegrationTests.dll)*

------
https://chatgpt.com/codex/tasks/task_e_68a4299d496c8328b793384c508eb261