### PR TITLE
Remove API prefix from controller routes

### DIFF
--- a/backend/PhotoBank.Api/Controllers/Admin/AdminAccessProfilesController.cs
+++ b/backend/PhotoBank.Api/Controllers/Admin/AdminAccessProfilesController.cs
@@ -6,7 +6,7 @@ using PhotoBank.AccessControl;
 namespace PhotoBank.Api.Controllers.Admin;
 
 [ApiController]
-[Route("api/admin/access-profiles")]
+[Route("admin/access-profiles")]
 [Authorize(Roles = "Admin")]
 public class AdminAccessProfilesController : ControllerBase
 {

--- a/backend/PhotoBank.Api/Controllers/Admin/UsersController.cs
+++ b/backend/PhotoBank.Api/Controllers/Admin/UsersController.cs
@@ -8,7 +8,7 @@ using PhotoBank.ViewModel.Dto;
 
 namespace PhotoBank.Api.Controllers.Admin;
 
-[Route("api/admin/[controller]")]
+[Route("admin/[controller]")]
 [ApiController]
 [Authorize(Roles = "Admin")]
 public class UsersController(UserManager<ApplicationUser> userManager) : ControllerBase

--- a/backend/PhotoBank.Api/Controllers/AuthController.cs
+++ b/backend/PhotoBank.Api/Controllers/AuthController.cs
@@ -14,7 +14,7 @@ using System.Security.Claims;
 
 namespace PhotoBank.Api.Controllers;
 
-[Route("api/[controller]")]
+[Route("[controller]")]
 [ApiController]
 public class AuthController(
     UserManager<ApplicationUser> userManager,

--- a/backend/PhotoBank.Api/Controllers/FacesController.cs
+++ b/backend/PhotoBank.Api/Controllers/FacesController.cs
@@ -5,7 +5,7 @@ using PhotoBank.ViewModel.Dto;
 
 namespace PhotoBank.Api.Controllers;
 
-[Route("api/[controller]")]
+[Route("[controller]")]
 [ApiController]
 [Authorize]
 public class FacesController(IPhotoService photoService) : ControllerBase

--- a/backend/PhotoBank.Api/Controllers/PathsController.cs
+++ b/backend/PhotoBank.Api/Controllers/PathsController.cs
@@ -5,7 +5,7 @@ using PhotoBank.ViewModel.Dto;
 
 namespace PhotoBank.Api.Controllers;
 
-[Route("api/[controller]")]
+[Route("[controller]")]
 [ApiController]
 [Authorize]
 public class PathsController(IPhotoService photoService) : ControllerBase

--- a/backend/PhotoBank.Api/Controllers/PersonsController.cs
+++ b/backend/PhotoBank.Api/Controllers/PersonsController.cs
@@ -5,7 +5,7 @@ using PhotoBank.ViewModel.Dto;
 
 namespace PhotoBank.Api.Controllers;
 
-[Route("api/[controller]")]
+[Route("[controller]")]
 [ApiController]
 [Authorize]
 public class PersonsController(IPhotoService photoService) : ControllerBase

--- a/backend/PhotoBank.Api/Controllers/PhotosController.cs
+++ b/backend/PhotoBank.Api/Controllers/PhotosController.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace PhotoBank.Api.Controllers
 {
-    [Route("api/[controller]")]
+    [Route("[controller]")]
     [Authorize]
     [ApiController]
     public class PhotosController(ILogger<PhotosController> logger, IPhotoService photoService)

--- a/backend/PhotoBank.Api/Controllers/StoragesController.cs
+++ b/backend/PhotoBank.Api/Controllers/StoragesController.cs
@@ -5,7 +5,7 @@ using PhotoBank.ViewModel.Dto;
 
 namespace PhotoBank.Api.Controllers;
 
-[Route("api/[controller]")]
+[Route("[controller]")]
 [ApiController]
 [Authorize]
 public class StoragesController(IPhotoService photoService) : ControllerBase

--- a/backend/PhotoBank.Api/Controllers/TagsController.cs
+++ b/backend/PhotoBank.Api/Controllers/TagsController.cs
@@ -5,7 +5,7 @@ using PhotoBank.ViewModel.Dto;
 
 namespace PhotoBank.Api.Controllers;
 
-[Route("api/[controller]")]
+[Route("[controller]")]
 [ApiController]
 [Authorize]
 public class TagsController(IPhotoService photoService) : ControllerBase


### PR DESCRIPTION
## Summary
- remove `api/` prefix from controller routes

## Testing
- `dotnet test PhotoBank.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e40b0d0832895d96898a74ed912