### PR TITLE
refactor: use config for bot service key

### DIFF
--- a/frontend/packages/telegram-bot/src/api/auth.ts
+++ b/frontend/packages/telegram-bot/src/api/auth.ts
@@ -1,8 +1,10 @@
 import { configureApi, customFetcher } from '@photobank/shared/api/photobank';
 
+import { BOT_SERVICE_KEY } from '../config';
+
 configureApi(process.env.API_BASE_URL ?? '');
 
-const serviceKey = process.env.BOT_SERVICE_KEY ?? '';
+const serviceKey = BOT_SERVICE_KEY ?? '';
 
 type ExchangeBody = { telegramUserId: number; username: string | null };
 

--- a/frontend/packages/telegram-bot/test/uploadCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/uploadCommand.test.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import * as dict from '../src/dictionaries';
 import * as photoService from '../src/services/photo';
 
-vi.mock('../src/config', () => ({ BOT_TOKEN: 'token' }));
+vi.mock('../src/config', () => ({ BOT_TOKEN: 'token', BOT_SERVICE_KEY: 'key' }));
 
 import { uploadCommand } from '../src/commands/upload';
 import { i18n } from '../src/i18n';


### PR DESCRIPTION
## Summary
- rely on BOT_SERVICE_KEY from shared config in telegram bot auth API
- update upload command test mock to include BOT_SERVICE_KEY

## Testing
- `BOT_TOKEN=dummy BOT_SERVICE_KEY=test API_BASE_URL=http://localhost pnpm --filter telegram-bot lint`
- `BOT_TOKEN=dummy BOT_SERVICE_KEY=test API_BASE_URL=http://localhost pnpm --filter telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_68a43a4ea0388328b6c2235edbb612d8