### PR TITLE
feat(telegram-bot): add token invalidation

### DIFF
--- a/frontend/packages/telegram-bot/src/auth.ts
+++ b/frontend/packages/telegram-bot/src/auth.ts
@@ -5,14 +5,19 @@ import { exchangeTelegramUserToken } from './api/auth';
 type CacheEntry = { token: string; exp: number }; // seconds since epoch
 const tokenCache = new Map<number, CacheEntry>();
 
-export async function ensureUserAccessToken(ctx: Context): Promise<string> {
+export async function ensureUserAccessToken(ctx: Context, force = false): Promise<string> {
   const tgId = ctx.from?.id;
   if (!tgId) throw new Error('No Telegram user');
   const now = Math.floor(Date.now() / 1000);
-  const cached = tokenCache.get(tgId);
+  const cached = force ? undefined : tokenCache.get(tgId);
   if (cached && cached.exp - now > 60) return cached.token;
 
   const { accessToken, expiresIn } = await exchangeTelegramUserToken(tgId, ctx.from?.username);
   tokenCache.set(tgId, { token: accessToken, exp: now + Math.max(60, Math.min(expiresIn, 3600)) });
   return accessToken;
+}
+
+export function invalidateUserToken(ctx: Context | { from?: { id?: number } }) {
+  const tgId = ctx.from?.id;
+  if (tgId) tokenCache.delete(tgId);
 }

--- a/frontend/packages/telegram-bot/test/auth.test.ts
+++ b/frontend/packages/telegram-bot/test/auth.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ensureUserAccessToken, invalidateUserToken } from '../src/auth';
+import * as apiAuth from '../src/api/auth';
+
+describe('ensureUserAccessToken', () => {
+  it('respects cache, force flag and invalidation', async () => {
+    const ctx = { from: { id: 1, username: 'user' } } as any;
+    const spy = vi
+      .spyOn(apiAuth, 'exchangeTelegramUserToken')
+      .mockResolvedValueOnce({ accessToken: 't1', expiresIn: 3600 })
+      .mockResolvedValueOnce({ accessToken: 't2', expiresIn: 3600 })
+      .mockResolvedValueOnce({ accessToken: 't3', expiresIn: 3600 });
+
+    const token1 = await ensureUserAccessToken(ctx);
+    const token2 = await ensureUserAccessToken(ctx);
+    const token3 = await ensureUserAccessToken(ctx, true);
+    const token4 = await ensureUserAccessToken(ctx);
+    invalidateUserToken(ctx);
+    const token5 = await ensureUserAccessToken(ctx);
+
+    expect(token1).toBe('t1');
+    expect(token2).toBe('t1');
+    expect(token3).toBe('t2');
+    expect(token4).toBe('t2');
+    expect(token5).toBe('t3');
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- allow force-refreshing cached auth tokens
- expose helper to invalidate cached user tokens
- cover token cache behaviour with tests

## Testing
- `BOT_TOKEN=1 pnpm --filter telegram-bot test`
- `BOT_TOKEN=1 pnpm --filter telegram-bot lint`


------
https://chatgpt.com/codex/tasks/task_e_68a43c97ec908328b959ff37667baf5a