### PR TITLE
Retry photobank API call after invalid token

### DIFF
--- a/frontend/packages/telegram-bot/src/api/axios-instance.ts
+++ b/frontend/packages/telegram-bot/src/api/axios-instance.ts
@@ -1,15 +1,28 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosRequestConfig, AxiosError } from 'axios';
 import type { Context } from 'grammy';
 
-import { ensureUserAccessToken } from '../auth';
+import { ensureUserAccessToken, invalidateUserToken } from '../auth';
 
 const API_BASE_URL = process.env.API_BASE_URL;
 
 export async function photobankAxios<T>(config: AxiosRequestConfig, ctx: Context) {
-  const token = await ensureUserAccessToken(ctx);
-  return axios<T>({
-    baseURL: API_BASE_URL,
-    headers: { Authorization: `Bearer ${token}`, ...(config.headers || {}) },
-    ...config,
-  });
+  async function doRequest(force = false) {
+    const token = await ensureUserAccessToken(ctx, force);
+    return axios<T>({
+      baseURL: API_BASE_URL,
+      headers: { Authorization: `Bearer ${token}`, ...(config.headers || {}) },
+      ...config,
+    });
+  }
+  try {
+    return await doRequest(false);
+  } catch (err) {
+    const status = (err as AxiosError | undefined)?.response?.status;
+    if (status === 401 || status === 403) {
+      // токен протух или права изменились — инвалидируем и пробуем ещё раз
+      invalidateUserToken(ctx);
+      return await doRequest(true);
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## Summary
- retry API requests after invalid tokens
- invalidate stale tokens and retry with fresh token

## Testing
- `pnpm --filter @photobank/telegram-bot lint`
- `BOT_TOKEN=1 API_BASE_URL=http://example.com pnpm --filter @photobank/telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_68a43ef2d80c8328ac82c9a5b65d532c