### PR TITLE
Add env sample and update Telegram service key

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,12 @@
+# Telegram
+BOT_TOKEN=xxxxxxxxx:yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+
+# Photobank API
+API_BASE_URL=https://your-api.example.com
+BOT_SERVICE_KEY=your-super-secret-service-key
+
+# Azure OpenAI (если используете)
+VITE_AZURE_OPENAI_ENDPOINT=
+VITE_AZURE_OPENAI_KEY=
+VITE_AZURE_OPENAI_DEPLOYMENT=
+VITE_AZURE_OPENAI_API_VERSION=

--- a/backend/PhotoBank.Api/appsettings.Development.json
+++ b/backend/PhotoBank.Api/appsettings.Development.json
@@ -12,7 +12,7 @@
   },
   "Auth": {
     "Telegram": {
-      "ServiceKey": "your-long-random-secret"
+      "ServiceKey": "your-super-secret-service-key"
     }
   }
 }

--- a/backend/PhotoBank.Api/appsettings.Production.json
+++ b/backend/PhotoBank.Api/appsettings.Production.json
@@ -7,7 +7,7 @@
   },
   "Auth": {
     "Telegram": {
-      "ServiceKey": "your-long-random-secret"
+      "ServiceKey": "your-super-secret-service-key"
     }
   }
 }

--- a/backend/PhotoBank.Api/appsettings.json
+++ b/backend/PhotoBank.Api/appsettings.json
@@ -64,7 +64,7 @@
   },
   "Auth": {
     "Telegram": {
-      "ServiceKey": "your-long-random-secret"
+      "ServiceKey": "your-super-secret-service-key"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `.env.sample` with API, Telegram, and optional Azure OpenAI settings
- align backend `Auth:Telegram:ServiceKey` with sample `BOT_SERVICE_KEY`

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: PhotoBank.IntegrationTests - Failed: 13, Passed: 0)*
- `pnpm -r test` *(fails: BOT_TOKEN is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4465d80d4832888cf54906edd7aa9