### PR TITLE
Fix frontend and bot test suites

### DIFF
--- a/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
+++ b/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
@@ -31,13 +31,15 @@ const photo = {
   orientation: 1,
   location: { latitude: 10, longitude: 20 },
 };
-vi.mock('@photobank/shared/api/photobank/photos/photos', () => ({
-  usePhotosGetPhoto: () => ({ data: photo, error: undefined }),
-  getPhotosGetPhotoQueryKey: vi.fn(),
-}));
-vi.mock('@photobank/shared/api/photobank', () => ({
-  useFacesUpdate: () => ({ mutateAsync: vi.fn(), isPending: false }),
-}));
+vi.mock('@photobank/shared/api/photobank', async () => {
+  const actual = await vi.importActual<any>('@photobank/shared/api/photobank');
+  return {
+    ...actual,
+    usePhotosGetPhoto: () => ({ data: photo, error: undefined }),
+    getPhotosGetPhotoQueryKey: vi.fn(),
+    useFacesUpdate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  };
+});
 
 vi.mock('@photobank/shared', async () => {
   const actual = await vi.importActual<any>('@photobank/shared');

--- a/frontend/packages/telegram-bot/vitest.config.ts
+++ b/frontend/packages/telegram-bot/vitest.config.ts
@@ -1,1 +1,3 @@
+process.env.BOT_TOKEN ??= 'test-token';
+process.env.API_BASE_URL ??= 'http://localhost';
 export { default } from '../vitest.base';


### PR DESCRIPTION
## Summary
- fix PhotoDetailsPage tests by partially mocking shared photobank API
- set default env vars for bot tests

## Testing
- `pnpm --filter @photobank/shared test`
- `pnpm --filter @photobank/frontend test`
- `pnpm --filter @photobank/telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_68a46b8c98e083288b612e142da18ffc