### PR TITLE
fix(frontend): remove unnecessary type assertions

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
@@ -49,7 +49,7 @@ function UserEditor({ user, onSave }: UserEditorProps) {
         { }
         <form
           onSubmit={(e) => {
-            void form.handleSubmit((d) => onSave(user.id!, d))(e);
+            void form.handleSubmit((d) => onSave(user.id, d))(e);
           }}
           className="space-y-4"
         >

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -135,7 +135,7 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
         }
         const controller = new AbortController();
         (async () => {
-            const name = await getPlaceByGeoPoint(photoData.location!);
+            const name = await getPlaceByGeoPoint(photoData.location);
             if (!controller.signal.aborted) setPlaceName(name);
         })();
         return () => {

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
@@ -42,7 +42,7 @@ const PhotoListItemMobile = ({
           <div className="font-medium truncate">{photo.name}</div>
           {photo.captions && photo.captions.length > 0 && (
             <div className="text-xs text-muted-foreground truncate">
-              {firstNWords(photo.captions[0]!, 5)}
+              {firstNWords(photo.captions[0], 5)}
             </div>
           )}
           <Badge variant="outline" className="font-mono text-xs mt-1">


### PR DESCRIPTION
## Summary
- remove redundant non-null assertions in frontend pages for cleaner lint

## Testing
- `pnpm --filter @photobank/shared lint`
- `pnpm --filter @photobank/frontend lint`
- `pnpm --filter @photobank/telegram-bot lint`
- `pnpm --filter @photobank/shared test`
- `pnpm --filter @photobank/frontend test`
- `pnpm --filter @photobank/telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_68a46df2a7fc8328803fd5b909e1e672