### PR TITLE
feat: add nsfw claim hook

### DIFF
--- a/frontend/packages/frontend/src/components/FilterFormFields.tsx
+++ b/frontend/packages/frontend/src/components/FilterFormFields.tsx
@@ -4,6 +4,7 @@ import { ChevronDownIcon } from 'lucide-react';
 import * as React from 'react';
 import { format } from 'date-fns';
 import { useIsAdmin } from '@photobank/shared';
+import { useCanSeeNsfw } from '@photobank/shared/hooks/useCanSeeNsfw';
 import { useTranslation } from 'react-i18next';
 
 import { useAppSelector } from '@/app/hook';
@@ -25,6 +26,7 @@ export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
     const [openFrom, setOpenFrom] = React.useState(false)
     const [openTo, setOpenTo] = React.useState(false)
     const isAdmin = useIsAdmin()
+    const canSeeNsfw = useCanSeeNsfw()
     const { t } = useTranslation();
 
     const tags = useAppSelector((state) => state.metadata.tags)
@@ -255,7 +257,7 @@ export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
                     )}
                 />
 
-                {isAdmin && (
+                {(canSeeNsfw || isAdmin) && (
                     <FormField
                         control={control}
                         name="isAdultContent"
@@ -275,7 +277,7 @@ export const FilterFormFields = ({control}: FilterFormFieldsProps) => {
                     />
                 )}
 
-                {isAdmin && (
+                {(canSeeNsfw || isAdmin) && (
                     <FormField
                         control={control}
                         name="isRacyContent"

--- a/frontend/packages/frontend/test/FilterFormFields.test.tsx
+++ b/frontend/packages/frontend/test/FilterFormFields.test.tsx
@@ -23,6 +23,7 @@ const renderWithRoles = async (roles: any[]) => {
   }));
   vi.doMock('@photobank/shared/api/photobank', () => ({
     authGetUserRoles: getUserRoles,
+    useAuthGetUserClaims: () => ({ data: { data: [] }, isLoading: false, isError: false })
   }));
 
   const { FilterFormFields } = await import('../src/components/FilterFormFields');

--- a/frontend/packages/shared/src/hooks/useCanSeeNsfw.ts
+++ b/frontend/packages/shared/src/hooks/useCanSeeNsfw.ts
@@ -1,0 +1,13 @@
+import { useAuthGetUserClaims } from '../api/photobank';
+export function useCanSeeNsfw(): boolean | null {
+  const { data, isLoading, isError } = useAuthGetUserClaims();
+  if (isLoading) return null;
+  if (isError) return false;
+  const claims = data?.data ?? [];
+  // поддержим несколько вариантов названий клейма
+  return claims.some(c => {
+    const t = (c.type ?? '').toLowerCase();
+    const v = (c.value ?? '').toLowerCase();
+    return (t.includes('nsfw') || t.includes('canseensfw')) && (v === 'true' || v === '1');
+  });
+}

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -38,5 +38,6 @@ export const firstNWords = (sentence: string, count: number): string => {
 };
 
 export { useIsAdmin } from './hooks/useIsAdmin';
+export { useCanSeeNsfw } from './hooks/useCanSeeNsfw';
 export { getPlaceByGeoPoint } from './utils/geocode';
 export { uploadPhotosAdapter } from './adapters/photos-upload.adapter';


### PR DESCRIPTION
## Summary
- expose hook to detect NSFW claim
- show adult and racy filters for users with NSFW claim

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a47ff90b2c832889d26f5cfc854581