### PR TITLE
feat: add admin user management endpoints

### DIFF
--- a/backend/PhotoBank.ViewModel.Dto/CreateUserDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/CreateUserDto.cs
@@ -1,0 +1,9 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class CreateUserDto
+{
+    public required string Email { get; init; }
+    public required string Password { get; init; }
+    public string? PhoneNumber { get; init; }
+    public IEnumerable<string>? Roles { get; init; }
+}

--- a/backend/PhotoBank.ViewModel.Dto/ResetPasswordDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/ResetPasswordDto.cs
@@ -1,0 +1,6 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class ResetPasswordDto
+{
+    public required string NewPassword { get; init; }
+}

--- a/backend/PhotoBank.ViewModel.Dto/SetRolesDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/SetRolesDto.cs
@@ -1,0 +1,6 @@
+namespace PhotoBank.ViewModel.Dto;
+
+public class SetRolesDto
+{
+    public IEnumerable<string> Roles { get; init; } = Array.Empty<string>();
+}


### PR DESCRIPTION
## Summary
- add create, delete, reset password and role management endpoints for admin users
- introduce DTOs for create, reset password and role assignments

## Testing
- `dotnet test backend/PhotoBank.Backend.sln` (fails: 13 tests failed)
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a483292d0483289473caa1051f3576