### PR TITLE
chore: regenerate API clients

### DIFF
--- a/frontend/packages/shared/src/api/photobank/admin-access-profiles/admin-access-profiles.msw.ts
+++ b/frontend/packages/shared/src/api/photobank/admin-access-profiles/admin-access-profiles.msw.ts
@@ -103,6 +103,16 @@ export const getAdminAccessProfilesAssignRoleMockHandler = (overrideResponse?: n
       })
   })
 }
+
+export const getAdminAccessProfilesUnassignRoleMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.delete>[1]>[0]) => Promise<null> | null)) => {
+  return http.delete('/api/admin/access-profiles/:id/assign-role/:roleId', async (info) => {await delay(1000);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+    return new HttpResponse(null,
+      { status: 200,
+        
+      })
+  })
+}
 export const getAdminAccessProfilesMock = () => [
   getAdminAccessProfilesListMockHandler(),
   getAdminAccessProfilesCreateMockHandler(),
@@ -111,5 +121,6 @@ export const getAdminAccessProfilesMock = () => [
   getAdminAccessProfilesDeleteMockHandler(),
   getAdminAccessProfilesAssignUserMockHandler(),
   getAdminAccessProfilesUnassignUserMockHandler(),
-  getAdminAccessProfilesAssignRoleMockHandler()
+  getAdminAccessProfilesAssignRoleMockHandler(),
+  getAdminAccessProfilesUnassignRoleMockHandler()
 ]

--- a/frontend/packages/shared/src/api/photobank/admin-access-profiles/admin-access-profiles.ts
+++ b/frontend/packages/shared/src/api/photobank/admin-access-profiles/admin-access-profiles.ts
@@ -642,4 +642,81 @@ const {mutation: mutationOptions} = options ?
 
       return useMutation(mutationOptions );
     }
+    export type adminAccessProfilesUnassignRoleResponse200 = {
+  data: null
+  status: 200
+}
+    
+export type adminAccessProfilesUnassignRoleResponseComposite = adminAccessProfilesUnassignRoleResponse200;
+    
+export type adminAccessProfilesUnassignRoleResponse = adminAccessProfilesUnassignRoleResponseComposite & {
+  headers: Headers;
+}
+
+export const getAdminAccessProfilesUnassignRoleUrl = (id: number,
+    roleId: string,) => {
+
+
+  
+
+  return `/admin/access-profiles/${id}/assign-role/${roleId}`
+}
+
+export const adminAccessProfilesUnassignRole = async (id: number,
+    roleId: string, options?: RequestInit): Promise<adminAccessProfilesUnassignRoleResponse> => {
+  
+  return customFetcher<adminAccessProfilesUnassignRoleResponse>(getAdminAccessProfilesUnassignRoleUrl(id,roleId),
+  {      
+    ...options,
+    method: 'DELETE'
+    
+    
+  }
+);}
+
+
+
+
+export const getAdminAccessProfilesUnassignRoleMutationOptions = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof adminAccessProfilesUnassignRole>>, TError,{id: number;roleId: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof adminAccessProfilesUnassignRole>>, TError,{id: number;roleId: string}, TContext> => {
+
+const mutationKey = ['adminAccessProfilesUnassignRole'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof adminAccessProfilesUnassignRole>>, {id: number;roleId: string}> = (props) => {
+          const {id,roleId} = props ?? {};
+
+          return  adminAccessProfilesUnassignRole(id,roleId,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type AdminAccessProfilesUnassignRoleMutationResult = NonNullable<Awaited<ReturnType<typeof adminAccessProfilesUnassignRole>>>
+    
+    export type AdminAccessProfilesUnassignRoleMutationError = unknown
+
+    export const useAdminAccessProfilesUnassignRole = <TError = unknown,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof adminAccessProfilesUnassignRole>>, TError,{id: number;roleId: string}, TContext>, }
+ ): UseMutationResult<
+        Awaited<ReturnType<typeof adminAccessProfilesUnassignRole>>,
+        TError,
+        {id: number;roleId: string},
+        TContext
+      > => {
+
+      const mutationOptions = getAdminAccessProfilesUnassignRoleMutationOptions(options);
+
+      return useMutation(mutationOptions );
+    }
     

--- a/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
+++ b/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
@@ -51,6 +51,17 @@ export interface ClaimDto {
   value: string | null;
 }
 
+export interface CreateUserDto {
+  /** @nullable */
+  email: string | null;
+  /** @nullable */
+  password: string | null;
+  /** @nullable */
+  phoneNumber?: string | null;
+  /** @nullable */
+  roles?: string[] | null;
+}
+
 export interface FaceBoxDto {
   top: number;
   left: number;
@@ -211,11 +222,21 @@ export interface RegisterRequestDto {
   password: string | null;
 }
 
+export interface ResetPasswordDto {
+  /** @nullable */
+  newPassword: string | null;
+}
+
 export interface RoleDto {
   /** @nullable */
   name: string | null;
   /** @nullable */
   claims?: ClaimDto[] | null;
+}
+
+export interface SetRolesDto {
+  /** @nullable */
+  roles?: string[] | null;
 }
 
 export interface StorageDto {

--- a/frontend/packages/shared/src/api/photobank/users/users.msw.ts
+++ b/frontend/packages/shared/src/api/photobank/users/users.msw.ts
@@ -17,6 +17,8 @@ import {
 
 export const getUsersGetAllResponseMock = (): UserWithClaimsDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined])})))
 
+export const getUsersCreateResponseMock = (overrideResponse: Partial< UserWithClaimsDto > = {}): UserWithClaimsDto => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined]), ...overrideResponse})
+
 
 export const getUsersGetAllMockHandler = (overrideResponse?: UserWithClaimsDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<UserWithClaimsDto[]> | UserWithClaimsDto[])) => {
   return http.get('/api/admin/users', async (info) => {await delay(1000);
@@ -25,6 +27,18 @@ export const getUsersGetAllMockHandler = (overrideResponse?: UserWithClaimsDto[]
     ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
     : getUsersGetAllResponseMock(),
       { status: 200,
+        headers: { 'Content-Type': 'text/plain' }
+      })
+  })
+}
+
+export const getUsersCreateMockHandler = (overrideResponse?: UserWithClaimsDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<UserWithClaimsDto> | UserWithClaimsDto)) => {
+  return http.post('/api/admin/users', async (info) => {await delay(1000);
+  
+    return new HttpResponse(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getUsersCreateResponseMock(),
+      { status: 201,
         headers: { 'Content-Type': 'text/plain' }
       })
   })
@@ -40,6 +54,26 @@ export const getUsersUpdateMockHandler = (overrideResponse?: null | ((info: Para
   })
 }
 
+export const getUsersDeleteMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.delete>[1]>[0]) => Promise<null> | null)) => {
+  return http.delete('/api/admin/users/:id', async (info) => {await delay(1000);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+    return new HttpResponse(null,
+      { status: 204,
+        
+      })
+  })
+}
+
+export const getUsersResetPasswordMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<null> | null)) => {
+  return http.post('/api/admin/users/:id/reset-password', async (info) => {await delay(1000);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+    return new HttpResponse(null,
+      { status: 204,
+        
+      })
+  })
+}
+
 export const getUsersSetClaimsMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Promise<null> | null)) => {
   return http.put('/api/admin/users/:id/claims', async (info) => {await delay(1000);
   if (typeof overrideResponse === 'function') {await overrideResponse(info); }
@@ -49,8 +83,22 @@ export const getUsersSetClaimsMockHandler = (overrideResponse?: null | ((info: P
       })
   })
 }
+
+export const getUsersSetRolesMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Promise<null> | null)) => {
+  return http.put('/api/admin/users/:id/roles', async (info) => {await delay(1000);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+    return new HttpResponse(null,
+      { status: 204,
+        
+      })
+  })
+}
 export const getUsersMock = () => [
   getUsersGetAllMockHandler(),
+  getUsersCreateMockHandler(),
   getUsersUpdateMockHandler(),
-  getUsersSetClaimsMockHandler()
+  getUsersDeleteMockHandler(),
+  getUsersResetPasswordMockHandler(),
+  getUsersSetClaimsMockHandler(),
+  getUsersSetRolesMockHandler()
 ]

--- a/frontend/packages/shared/src/api/photobank/users/users.ts
+++ b/frontend/packages/shared/src/api/photobank/users/users.ts
@@ -20,7 +20,10 @@ import type {
 
 import type {
   ClaimDto,
+  CreateUserDto,
   ProblemDetails,
+  ResetPasswordDto,
+  SetRolesDto,
   UpdateUserDto,
   UserWithClaimsDto
 } from '../photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas';
@@ -110,7 +113,88 @@ export function useUsersGetAll<TData = Awaited<ReturnType<typeof usersGetAll>>, 
 
 
 
-export type usersUpdateResponse200 = {
+export type usersCreateResponse201 = {
+  data: UserWithClaimsDto
+  status: 201
+}
+
+export type usersCreateResponse400 = {
+  data: ProblemDetails
+  status: 400
+}
+    
+export type usersCreateResponseComposite = usersCreateResponse201 | usersCreateResponse400;
+    
+export type usersCreateResponse = usersCreateResponseComposite & {
+  headers: Headers;
+}
+
+export const getUsersCreateUrl = () => {
+
+
+  
+
+  return `/admin/users`
+}
+
+export const usersCreate = async (createUserDto: CreateUserDto, options?: RequestInit): Promise<usersCreateResponse> => {
+  
+  return customFetcher<usersCreateResponse>(getUsersCreateUrl(),
+  {      
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      createUserDto,)
+  }
+);}
+
+
+
+
+export const getUsersCreateMutationOptions = <TError = ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersCreate>>, TError,{data: CreateUserDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof usersCreate>>, TError,{data: CreateUserDto}, TContext> => {
+
+const mutationKey = ['usersCreate'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof usersCreate>>, {data: CreateUserDto}> = (props) => {
+          const {data} = props ?? {};
+
+          return  usersCreate(data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type UsersCreateMutationResult = NonNullable<Awaited<ReturnType<typeof usersCreate>>>
+    export type UsersCreateMutationBody = CreateUserDto
+    export type UsersCreateMutationError = ProblemDetails
+
+    export const useUsersCreate = <TError = ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersCreate>>, TError,{data: CreateUserDto}, TContext>, }
+ ): UseMutationResult<
+        Awaited<ReturnType<typeof usersCreate>>,
+        TError,
+        {data: CreateUserDto},
+        TContext
+      > => {
+
+      const mutationOptions = getUsersCreateMutationOptions(options);
+
+      return useMutation(mutationOptions );
+    }
+    export type usersUpdateResponse200 = {
   data: null
   status: 200
 }
@@ -194,6 +278,168 @@ const {mutation: mutationOptions} = options ?
       > => {
 
       const mutationOptions = getUsersUpdateMutationOptions(options);
+
+      return useMutation(mutationOptions );
+    }
+    export type usersDeleteResponse204 = {
+  data: null
+  status: 204
+}
+
+export type usersDeleteResponse404 = {
+  data: ProblemDetails
+  status: 404
+}
+    
+export type usersDeleteResponseComposite = usersDeleteResponse204 | usersDeleteResponse404;
+    
+export type usersDeleteResponse = usersDeleteResponseComposite & {
+  headers: Headers;
+}
+
+export const getUsersDeleteUrl = (id: string,) => {
+
+
+  
+
+  return `/admin/users/${id}`
+}
+
+export const usersDelete = async (id: string, options?: RequestInit): Promise<usersDeleteResponse> => {
+  
+  return customFetcher<usersDeleteResponse>(getUsersDeleteUrl(id),
+  {      
+    ...options,
+    method: 'DELETE'
+    
+    
+  }
+);}
+
+
+
+
+export const getUsersDeleteMutationOptions = <TError = ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersDelete>>, TError,{id: string}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof usersDelete>>, TError,{id: string}, TContext> => {
+
+const mutationKey = ['usersDelete'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof usersDelete>>, {id: string}> = (props) => {
+          const {id} = props ?? {};
+
+          return  usersDelete(id,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type UsersDeleteMutationResult = NonNullable<Awaited<ReturnType<typeof usersDelete>>>
+    
+    export type UsersDeleteMutationError = ProblemDetails
+
+    export const useUsersDelete = <TError = ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersDelete>>, TError,{id: string}, TContext>, }
+ ): UseMutationResult<
+        Awaited<ReturnType<typeof usersDelete>>,
+        TError,
+        {id: string},
+        TContext
+      > => {
+
+      const mutationOptions = getUsersDeleteMutationOptions(options);
+
+      return useMutation(mutationOptions );
+    }
+    export type usersResetPasswordResponse204 = {
+  data: null
+  status: 204
+}
+
+export type usersResetPasswordResponse404 = {
+  data: ProblemDetails
+  status: 404
+}
+    
+export type usersResetPasswordResponseComposite = usersResetPasswordResponse204 | usersResetPasswordResponse404;
+    
+export type usersResetPasswordResponse = usersResetPasswordResponseComposite & {
+  headers: Headers;
+}
+
+export const getUsersResetPasswordUrl = (id: string,) => {
+
+
+  
+
+  return `/admin/users/${id}/reset-password`
+}
+
+export const usersResetPassword = async (id: string,
+    resetPasswordDto: ResetPasswordDto, options?: RequestInit): Promise<usersResetPasswordResponse> => {
+  
+  return customFetcher<usersResetPasswordResponse>(getUsersResetPasswordUrl(id),
+  {      
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      resetPasswordDto,)
+  }
+);}
+
+
+
+
+export const getUsersResetPasswordMutationOptions = <TError = ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersResetPassword>>, TError,{id: string;data: ResetPasswordDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof usersResetPassword>>, TError,{id: string;data: ResetPasswordDto}, TContext> => {
+
+const mutationKey = ['usersResetPassword'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof usersResetPassword>>, {id: string;data: ResetPasswordDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  usersResetPassword(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type UsersResetPasswordMutationResult = NonNullable<Awaited<ReturnType<typeof usersResetPassword>>>
+    export type UsersResetPasswordMutationBody = ResetPasswordDto
+    export type UsersResetPasswordMutationError = ProblemDetails
+
+    export const useUsersResetPassword = <TError = ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersResetPassword>>, TError,{id: string;data: ResetPasswordDto}, TContext>, }
+ ): UseMutationResult<
+        Awaited<ReturnType<typeof usersResetPassword>>,
+        TError,
+        {id: string;data: ResetPasswordDto},
+        TContext
+      > => {
+
+      const mutationOptions = getUsersResetPasswordMutationOptions(options);
 
       return useMutation(mutationOptions );
     }
@@ -281,6 +527,88 @@ const {mutation: mutationOptions} = options ?
       > => {
 
       const mutationOptions = getUsersSetClaimsMutationOptions(options);
+
+      return useMutation(mutationOptions );
+    }
+    export type usersSetRolesResponse204 = {
+  data: null
+  status: 204
+}
+
+export type usersSetRolesResponse404 = {
+  data: ProblemDetails
+  status: 404
+}
+    
+export type usersSetRolesResponseComposite = usersSetRolesResponse204 | usersSetRolesResponse404;
+    
+export type usersSetRolesResponse = usersSetRolesResponseComposite & {
+  headers: Headers;
+}
+
+export const getUsersSetRolesUrl = (id: string,) => {
+
+
+  
+
+  return `/admin/users/${id}/roles`
+}
+
+export const usersSetRoles = async (id: string,
+    setRolesDto: SetRolesDto, options?: RequestInit): Promise<usersSetRolesResponse> => {
+  
+  return customFetcher<usersSetRolesResponse>(getUsersSetRolesUrl(id),
+  {      
+    ...options,
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      setRolesDto,)
+  }
+);}
+
+
+
+
+export const getUsersSetRolesMutationOptions = <TError = ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersSetRoles>>, TError,{id: string;data: SetRolesDto}, TContext>, }
+): UseMutationOptions<Awaited<ReturnType<typeof usersSetRoles>>, TError,{id: string;data: SetRolesDto}, TContext> => {
+
+const mutationKey = ['usersSetRoles'];
+const {mutation: mutationOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof usersSetRoles>>, {id: string;data: SetRolesDto}> = (props) => {
+          const {id,data} = props ?? {};
+
+          return  usersSetRoles(id,data,)
+        }
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type UsersSetRolesMutationResult = NonNullable<Awaited<ReturnType<typeof usersSetRoles>>>
+    export type UsersSetRolesMutationBody = SetRolesDto
+    export type UsersSetRolesMutationError = ProblemDetails
+
+    export const useUsersSetRoles = <TError = ProblemDetails,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersSetRoles>>, TError,{id: string;data: SetRolesDto}, TContext>, }
+ ): UseMutationResult<
+        Awaited<ReturnType<typeof usersSetRoles>>,
+        TError,
+        {id: string;data: SetRolesDto},
+        TContext
+      > => {
+
+      const mutationOptions = getUsersSetRolesMutationOptions(options);
 
       return useMutation(mutationOptions );
     }

--- a/frontend/packages/telegram-bot/src/api/photobank/admin-access-profiles/admin-access-profiles.msw.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/admin-access-profiles/admin-access-profiles.msw.ts
@@ -103,6 +103,16 @@ export const getAdminAccessProfilesAssignRoleMockHandler = (overrideResponse?: n
       })
   })
 }
+
+export const getAdminAccessProfilesUnassignRoleMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.delete>[1]>[0]) => Promise<null> | null)) => {
+  return http.delete('/api/admin/access-profiles/:id/assign-role/:roleId', async (info) => {await delay(1000);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+    return new HttpResponse(null,
+      { status: 200,
+        
+      })
+  })
+}
 export const getAdminAccessProfilesMock = () => [
   getAdminAccessProfilesListMockHandler(),
   getAdminAccessProfilesCreateMockHandler(),
@@ -111,4 +121,5 @@ export const getAdminAccessProfilesMock = () => [
   getAdminAccessProfilesDeleteMockHandler(),
   getAdminAccessProfilesAssignUserMockHandler(),
   getAdminAccessProfilesUnassignUserMockHandler(),
-  getAdminAccessProfilesAssignRoleMockHandler()]
+  getAdminAccessProfilesAssignRoleMockHandler(),
+  getAdminAccessProfilesUnassignRoleMockHandler()]

--- a/frontend/packages/telegram-bot/src/api/photobank/admin-access-profiles/admin-access-profiles.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/admin-access-profiles/admin-access-profiles.ts
@@ -11,83 +11,90 @@ import type {
 import { photobankAxios } from '../../axios-instance';
 
 
-type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
-
 
   export const getAdminAccessProfiles = () => {
 const adminAccessProfilesList = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<AccessProfile[]>(
       {url: `/admin/access-profiles`, method: 'GET'
     },
-      options);
+      );
     }
   const adminAccessProfilesCreate = (
     accessProfile: AccessProfile,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/admin/access-profiles`, method: 'POST',
       headers: {'Content-Type': 'application/json', },
       data: accessProfile
     },
-      options);
+      );
     }
   const adminAccessProfilesGet = (
     id: number,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<AccessProfile>(
       {url: `/admin/access-profiles/${id}`, method: 'GET'
     },
-      options);
+      );
     }
   const adminAccessProfilesUpdate = (
     id: number,
     accessProfile: AccessProfile,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/admin/access-profiles/${id}`, method: 'PUT',
       headers: {'Content-Type': 'application/json', },
       data: accessProfile
     },
-      options);
+      );
     }
   const adminAccessProfilesDelete = (
     id: number,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/admin/access-profiles/${id}`, method: 'DELETE'
     },
-      options);
+      );
     }
   const adminAccessProfilesAssignUser = (
     id: number,
     userId: string,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/admin/access-profiles/${id}/assign-user/${userId}`, method: 'POST'
     },
-      options);
+      );
     }
   const adminAccessProfilesUnassignUser = (
     id: number,
     userId: string,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/admin/access-profiles/${id}/assign-user/${userId}`, method: 'DELETE'
     },
-      options);
+      );
     }
   const adminAccessProfilesAssignRole = (
     id: number,
     roleId: string,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/admin/access-profiles/${id}/assign-role/${roleId}`, method: 'POST'
     },
-      options);
+      );
     }
-  return {adminAccessProfilesList,adminAccessProfilesCreate,adminAccessProfilesGet,adminAccessProfilesUpdate,adminAccessProfilesDelete,adminAccessProfilesAssignUser,adminAccessProfilesUnassignUser,adminAccessProfilesAssignRole}};
+  const adminAccessProfilesUnassignRole = (
+    id: number,
+    roleId: string,
+ ) => {
+      return photobankAxios<null>(
+      {url: `/admin/access-profiles/${id}/assign-role/${roleId}`, method: 'DELETE'
+    },
+      );
+    }
+  return {adminAccessProfilesList,adminAccessProfilesCreate,adminAccessProfilesGet,adminAccessProfilesUpdate,adminAccessProfilesDelete,adminAccessProfilesAssignUser,adminAccessProfilesUnassignUser,adminAccessProfilesAssignRole,adminAccessProfilesUnassignRole}};
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -101,3 +108,4 @@ export type AdminAccessProfilesDeleteResult = NonNullable<Awaited<ReturnType<Ret
 export type AdminAccessProfilesAssignUserResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAdminAccessProfiles>['adminAccessProfilesAssignUser']>>>
 export type AdminAccessProfilesUnassignUserResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAdminAccessProfiles>['adminAccessProfilesUnassignUser']>>>
 export type AdminAccessProfilesAssignRoleResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAdminAccessProfiles>['adminAccessProfilesAssignRole']>>>
+export type AdminAccessProfilesUnassignRoleResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAdminAccessProfiles>['adminAccessProfilesUnassignRole']>>>

--- a/frontend/packages/telegram-bot/src/api/photobank/auth/auth.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/auth/auth.ts
@@ -19,81 +19,79 @@ import type {
 import { photobankAxios } from '../../axios-instance';
 
 
-type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
-
 
   export const getAuth = () => {
 const authLogin = (
     loginRequestDto: LoginRequestDto,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<LoginResponseDto>(
       {url: `/auth/login`, method: 'POST',
       headers: {'Content-Type': 'application/json', },
       data: loginRequestDto
     },
-      options);
+      );
     }
   const authRegister = (
     registerRequestDto: RegisterRequestDto,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/auth/register`, method: 'POST',
       headers: {'Content-Type': 'application/json', },
       data: registerRequestDto
     },
-      options);
+      );
     }
   const authGetUser = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<UserDto>(
       {url: `/auth/user`, method: 'GET'
     },
-      options);
+      );
     }
   const authUpdateUser = (
     updateUserDto: UpdateUserDto,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/auth/user`, method: 'PUT',
       headers: {'Content-Type': 'application/json', },
       data: updateUserDto
     },
-      options);
+      );
     }
   const authTelegramExchange = (
     telegramExchangeRequest: TelegramExchangeRequest,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<TelegramExchangeResponse>(
       {url: `/auth/telegram/exchange`, method: 'POST',
       headers: {'Content-Type': 'application/json', },
       data: telegramExchangeRequest
     },
-      options);
+      );
     }
   const authGetUserClaims = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<ClaimDto[]>(
       {url: `/auth/claims`, method: 'GET'
     },
-      options);
+      );
     }
   const authGetUserRoles = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<RoleDto[]>(
       {url: `/auth/roles`, method: 'GET'
     },
-      options);
+      );
     }
   const authGetEffective = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/auth/debug/effective-access`, method: 'GET'
     },
-      options);
+      );
     }
   return {authLogin,authRegister,authGetUser,authUpdateUser,authTelegramExchange,authGetUserClaims,authGetUserRoles,authGetEffective}};
 

--- a/frontend/packages/telegram-bot/src/api/photobank/faces/faces.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/faces/faces.ts
@@ -11,19 +11,17 @@ import type {
 import { photobankAxios } from '../../axios-instance';
 
 
-type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
-
 
   export const getFaces = () => {
 const facesUpdate = (
     updateFaceDto: UpdateFaceDto,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/faces`, method: 'PUT',
       headers: {'Content-Type': 'application/json', },
       data: updateFaceDto
     },
-      options);
+      );
     }
   return {facesUpdate}};
 

--- a/frontend/packages/telegram-bot/src/api/photobank/paths/paths.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/paths/paths.ts
@@ -11,17 +11,15 @@ import type {
 import { photobankAxios } from '../../axios-instance';
 
 
-type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
-
 
   export const getPaths = () => {
 const pathsGetAll = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<PathDto[]>(
       {url: `/paths`, method: 'GET'
     },
-      options);
+      );
     }
   return {pathsGetAll}};
 

--- a/frontend/packages/telegram-bot/src/api/photobank/persons/persons.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/persons/persons.ts
@@ -11,17 +11,15 @@ import type {
 import { photobankAxios } from '../../axios-instance';
 
 
-type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
-
 
   export const getPersons = () => {
 const personsGetAll = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<PersonDto[]>(
       {url: `/persons`, method: 'GET'
     },
-      options);
+      );
     }
   return {personsGetAll}};
 

--- a/frontend/packages/telegram-bot/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
@@ -51,6 +51,17 @@ export interface ClaimDto {
   value: string | null;
 }
 
+export interface CreateUserDto {
+  /** @nullable */
+  email: string | null;
+  /** @nullable */
+  password: string | null;
+  /** @nullable */
+  phoneNumber?: string | null;
+  /** @nullable */
+  roles?: string[] | null;
+}
+
 export interface FaceBoxDto {
   top: number;
   left: number;
@@ -211,11 +222,21 @@ export interface RegisterRequestDto {
   password: string | null;
 }
 
+export interface ResetPasswordDto {
+  /** @nullable */
+  newPassword: string | null;
+}
+
 export interface RoleDto {
   /** @nullable */
   name: string | null;
   /** @nullable */
   claims?: ClaimDto[] | null;
+}
+
+export interface SetRolesDto {
+  /** @nullable */
+  roles?: string[] | null;
 }
 
 export interface StorageDto {

--- a/frontend/packages/telegram-bot/src/api/photobank/photos/photos.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/photos/photos.ts
@@ -16,31 +16,29 @@ import type {
 import { photobankAxios } from '../../axios-instance';
 
 
-type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
-
 
   export const getPhotos = () => {
 const photosSearchPhotos = (
     filterDto: FilterDto,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<PhotoItemDtoPageResponse>(
       {url: `/photos/search`, method: 'POST',
       headers: {'Content-Type': 'application/json', },
       data: filterDto
     },
-      options);
+      );
     }
   const photosGetPhoto = (
     id: number,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<PhotoDto>(
       {url: `/photos/${id}`, method: 'GET'
     },
-      options);
+      );
     }
   const photosUpload = (
     photosUploadBody: PhotosUploadBody,
- options?: SecondParameter<typeof photobankAxios>,) => {const formData = new FormData();
+ ) => {const formData = new FormData();
 if(photosUploadBody.files !== undefined) {
  photosUploadBody.files.forEach(value => formData.append(`files`, value));
  }
@@ -56,16 +54,16 @@ if(photosUploadBody.path !== undefined) {
       headers: {'Content-Type': 'multipart/form-data', },
        data: formData
     },
-      options);
+      );
     }
   const photosGetDuplicates = (
     params?: PhotosGetDuplicatesParams,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<PhotoItemDto[]>(
       {url: `/photos/duplicates`, method: 'GET',
         params
     },
-      options);
+      );
     }
   return {photosSearchPhotos,photosGetPhoto,photosUpload,photosGetDuplicates}};
 

--- a/frontend/packages/telegram-bot/src/api/photobank/storages/storages.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/storages/storages.ts
@@ -11,17 +11,15 @@ import type {
 import { photobankAxios } from '../../axios-instance';
 
 
-type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
-
 
   export const getStorages = () => {
 const storagesGetAll = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<StorageDto[]>(
       {url: `/storages`, method: 'GET'
     },
-      options);
+      );
     }
   return {storagesGetAll}};
 

--- a/frontend/packages/telegram-bot/src/api/photobank/tags/tags.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/tags/tags.ts
@@ -11,17 +11,15 @@ import type {
 import { photobankAxios } from '../../axios-instance';
 
 
-type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
-
 
   export const getTags = () => {
 const tagsGetAll = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<TagDto[]>(
       {url: `/tags`, method: 'GET'
     },
-      options);
+      );
     }
   return {tagsGetAll}};
 

--- a/frontend/packages/telegram-bot/src/api/photobank/users/users.msw.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/users/users.msw.ts
@@ -17,6 +17,8 @@ import {
 
 export const getUsersGetAllResponseMock = (): UserWithClaimsDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined])})))
 
+export const getUsersCreateResponseMock = (overrideResponse: Partial< UserWithClaimsDto > = {}): UserWithClaimsDto => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined]), ...overrideResponse})
+
 
 export const getUsersGetAllMockHandler = (overrideResponse?: UserWithClaimsDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<UserWithClaimsDto[]> | UserWithClaimsDto[])) => {
   return http.get('/api/admin/users', async (info) => {await delay(1000);
@@ -25,6 +27,18 @@ export const getUsersGetAllMockHandler = (overrideResponse?: UserWithClaimsDto[]
     ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
     : getUsersGetAllResponseMock(),
       { status: 200,
+        headers: { 'Content-Type': 'text/plain' }
+      })
+  })
+}
+
+export const getUsersCreateMockHandler = (overrideResponse?: UserWithClaimsDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<UserWithClaimsDto> | UserWithClaimsDto)) => {
+  return http.post('/api/admin/users', async (info) => {await delay(1000);
+  
+    return new HttpResponse(overrideResponse !== undefined
+    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
+    : getUsersCreateResponseMock(),
+      { status: 201,
         headers: { 'Content-Type': 'text/plain' }
       })
   })
@@ -40,6 +54,26 @@ export const getUsersUpdateMockHandler = (overrideResponse?: null | ((info: Para
   })
 }
 
+export const getUsersDeleteMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.delete>[1]>[0]) => Promise<null> | null)) => {
+  return http.delete('/api/admin/users/:id', async (info) => {await delay(1000);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+    return new HttpResponse(null,
+      { status: 204,
+        
+      })
+  })
+}
+
+export const getUsersResetPasswordMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<null> | null)) => {
+  return http.post('/api/admin/users/:id/reset-password', async (info) => {await delay(1000);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+    return new HttpResponse(null,
+      { status: 204,
+        
+      })
+  })
+}
+
 export const getUsersSetClaimsMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Promise<null> | null)) => {
   return http.put('/api/admin/users/:id/claims', async (info) => {await delay(1000);
   if (typeof overrideResponse === 'function') {await overrideResponse(info); }
@@ -49,7 +83,21 @@ export const getUsersSetClaimsMockHandler = (overrideResponse?: null | ((info: P
       })
   })
 }
+
+export const getUsersSetRolesMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Promise<null> | null)) => {
+  return http.put('/api/admin/users/:id/roles', async (info) => {await delay(1000);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+    return new HttpResponse(null,
+      { status: 204,
+        
+      })
+  })
+}
 export const getUsersMock = () => [
   getUsersGetAllMockHandler(),
+  getUsersCreateMockHandler(),
   getUsersUpdateMockHandler(),
-  getUsersSetClaimsMockHandler()]
+  getUsersDeleteMockHandler(),
+  getUsersResetPasswordMockHandler(),
+  getUsersSetClaimsMockHandler(),
+  getUsersSetRolesMockHandler()]

--- a/frontend/packages/telegram-bot/src/api/photobank/users/users.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/users/users.ts
@@ -6,6 +6,9 @@
  */
 import type {
   ClaimDto,
+  CreateUserDto,
+  ResetPasswordDto,
+  SetRolesDto,
   UpdateUserDto,
   UserWithClaimsDto
 } from '../photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas';
@@ -13,46 +16,88 @@ import type {
 import { photobankAxios } from '../../axios-instance';
 
 
-type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
-
 
   export const getUsers = () => {
 const usersGetAll = (
     
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<UserWithClaimsDto[]>(
       {url: `/admin/users`, method: 'GET'
     },
-      options);
+      );
+    }
+  const usersCreate = (
+    createUserDto: CreateUserDto,
+ ) => {
+      return photobankAxios<UserWithClaimsDto>(
+      {url: `/admin/users`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: createUserDto
+    },
+      );
     }
   const usersUpdate = (
     id: string,
     updateUserDto: UpdateUserDto,
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/admin/users/${id}`, method: 'PUT',
       headers: {'Content-Type': 'application/json', },
       data: updateUserDto
     },
-      options);
+      );
+    }
+  const usersDelete = (
+    id: string,
+ ) => {
+      return photobankAxios<null>(
+      {url: `/admin/users/${id}`, method: 'DELETE'
+    },
+      );
+    }
+  const usersResetPassword = (
+    id: string,
+    resetPasswordDto: ResetPasswordDto,
+ ) => {
+      return photobankAxios<null>(
+      {url: `/admin/users/${id}/reset-password`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: resetPasswordDto
+    },
+      );
     }
   const usersSetClaims = (
     id: string,
     claimDto: ClaimDto[],
- options?: SecondParameter<typeof photobankAxios>,) => {
+ ) => {
       return photobankAxios<null>(
       {url: `/admin/users/${id}/claims`, method: 'PUT',
       headers: {'Content-Type': 'application/json', },
       data: claimDto
     },
-      options);
+      );
     }
-  return {usersGetAll,usersUpdate,usersSetClaims}};
+  const usersSetRoles = (
+    id: string,
+    setRolesDto: SetRolesDto,
+ ) => {
+      return photobankAxios<null>(
+      {url: `/admin/users/${id}/roles`, method: 'PUT',
+      headers: {'Content-Type': 'application/json', },
+      data: setRolesDto
+    },
+      );
+    }
+  return {usersGetAll,usersCreate,usersUpdate,usersDelete,usersResetPassword,usersSetClaims,usersSetRoles}};
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
     type Awaited<O> = O extends AwaitedInput<infer T> ? T : never;
 
 export type UsersGetAllResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersGetAll']>>>
+export type UsersCreateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersCreate']>>>
 export type UsersUpdateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersUpdate']>>>
+export type UsersDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersDelete']>>>
+export type UsersResetPasswordResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersResetPassword']>>>
 export type UsersSetClaimsResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersSetClaims']>>>
+export type UsersSetRolesResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersSetRoles']>>>


### PR DESCRIPTION
## Summary
- regenerate API clients with Orval using latest OpenAPI spec

## Testing
- `pnpm lint` *(fails: Unexpected any in requestinit.d.ts)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a490c4b1f08328bd673bcdb3194813