### PR TITLE
feat(frontend): add flag to enable msw mock backend

### DIFF
--- a/frontend/packages/frontend/.env.development
+++ b/frontend/packages/frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_USE_MOCKS=1

--- a/frontend/packages/frontend/src/main.tsx
+++ b/frontend/packages/frontend/src/main.tsx
@@ -15,9 +15,12 @@ import './index.css';
 async function start() {
   configureApi(API_BASE_URL);
 
-  if (import.meta.env.DEV) {
+  // ВАЖНО: импортируй только по флагу, чтобы не тянуть msw в прод-бандл
+  if (import.meta.env.DEV && import.meta.env.VITE_USE_MOCKS === '1') {
     const { worker } = await import('./mocks/browser');
-    await worker.start({ onUnhandledRequest: 'bypass' });
+    await worker.start({
+      onUnhandledRequest: 'bypass', // реальные вызовы не ломаем
+    });
   }
 
   const root = document.getElementById('root')!;


### PR DESCRIPTION
## Summary
- start msw worker only in dev when VITE_USE_MOCKS=1
- add .env.development enabling mocks by default

## Testing
- `pnpm lint` *(fails: Unexpected any in packages/shared)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a3b8428483288b715a80dec09eba