### PR TITLE
feat(telegram-bot): add MSW test setup

### DIFF
--- a/frontend/packages/shared/src/api/photobank/msw.ts
+++ b/frontend/packages/shared/src/api/photobank/msw.ts
@@ -17,3 +17,5 @@ export const getPhotobankMock = () => [
   ...getTagsMock(),
   ...getUsersMock(),
 ];
+
+export const handlers = getPhotobankMock();

--- a/frontend/packages/telegram-bot/test-setup.ts
+++ b/frontend/packages/telegram-bot/test-setup.ts
@@ -1,0 +1,9 @@
+import { setupServer } from 'msw/node';
+import { beforeAll, afterAll, afterEach } from 'vitest';
+import { handlers } from '@photobank/shared/api/photobank/msw';
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/frontend/packages/telegram-bot/vitest.config.ts
+++ b/frontend/packages/telegram-bot/vitest.config.ts
@@ -1,3 +1,14 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../vitest.base';
+
 process.env.BOT_TOKEN ??= 'test-token';
 process.env.API_BASE_URL ??= 'http://localhost';
-export { default } from '../vitest.base';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      setupFiles: './test-setup.ts',
+    },
+  }),
+);


### PR DESCRIPTION
## Summary
- export reusable photobank handlers from shared API
- run msw server in telegram-bot tests using shared handlers
- load test setup via vitest config

## Testing
- `pnpm -F @photobank/telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a42f6d3c83289000bcfae164d8fd