### PR TITLE
feat: add msw helpers for photobank API

### DIFF
--- a/frontend/packages/shared/src/api/photobank/msw.helpers.ts
+++ b/frontend/packages/shared/src/api/photobank/msw.helpers.ts
@@ -1,0 +1,9 @@
+import { delay, HttpResponse } from 'msw';
+
+export const withDelay = (ms = 300) => delay(ms);
+
+export const respond = <T>(data: T, init?: number | ResponseInit) =>
+  HttpResponse.json(data as any, init);
+
+export const respondError = (status = 500, message = 'Server error', extra?: Record<string, unknown>) =>
+  HttpResponse.json({ title: message, status, ...extra }, { status });


### PR DESCRIPTION
## Summary
- add reusable MSW helper utilities for Photobank API tests

## Testing
- `pnpm lint` *(fails: @photobank/shared/src/types/requestinit.d.ts unexpected any)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a9736ca88328991b1ecb1704ad82