### PR TITLE
chore: export test server and mute asset requests

### DIFF
--- a/frontend/packages/frontend/test-setup.ts
+++ b/frontend/packages/frontend/test-setup.ts
@@ -42,7 +42,17 @@ Object.defineProperty(globalThis, 'HTMLCanvasElement', {
   },
 });
 
-const server = setupServer(...(handlers as any));
-beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+export const server = setupServer(...(handlers as any));
+beforeAll(() =>
+  server.listen({
+    onUnhandledRequest(request, print) {
+      if (request.url.pathname.startsWith('/assets')) {
+        return;
+      }
+
+      print.warning();
+    },
+  }),
+);
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());


### PR DESCRIPTION
## Summary
- export MSW server from frontend test setup
- avoid warnings for unhandled asset requests in tests

## Testing
- `pnpm --filter frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b3d3ca3083289a2c063dba75d069