### PR TITLE
chore: add msw setup for telegram bot tests

### DIFF
--- a/frontend/packages/telegram-bot/test-setup.ts
+++ b/frontend/packages/telegram-bot/test-setup.ts
@@ -1,8 +1,8 @@
+import { afterAll, afterEach, beforeAll } from 'vitest';
 import { setupServer } from 'msw/node';
-import { beforeAll, afterAll, afterEach } from 'vitest';
 import { handlers } from '@photobank/shared/api/photobank/msw';
 
-const server = setupServer(...handlers);
+export const server = setupServer(...handlers);
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
 afterEach(() => server.resetHandlers());

--- a/frontend/packages/telegram-bot/vitest.config.ts
+++ b/frontend/packages/telegram-bot/vitest.config.ts
@@ -1,14 +1,9 @@
-import { defineConfig, mergeConfig } from 'vitest/config';
-import baseConfig from '../vitest.base';
+import { defineConfig } from 'vitest/config';
 
-process.env.BOT_TOKEN ??= 'test-token';
-process.env.API_BASE_URL ??= 'http://localhost';
-
-export default mergeConfig(
-  baseConfig,
-  defineConfig({
-    test: {
-      setupFiles: './test-setup.ts',
-    },
-  }),
-);
+export default defineConfig({
+  test: {
+    setupFiles: ['./test-setup.ts'],
+    environment: 'node',
+    restoreMocks: true,
+  },
+});


### PR DESCRIPTION
## Summary
- export test server for msw and configure vitest

## Testing
- `pnpm --filter @photobank/telegram-bot test` *(fails: Missing "./api/photobank/msw" specifier in "@photobank/shared" package)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b3eb832083288700cb094c3bf677