### PR TITLE
test: add photos access policy test

### DIFF
--- a/frontend/packages/frontend/src/features/photos/PhotosPage.tsx
+++ b/frontend/packages/frontend/src/features/photos/PhotosPage.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import type { PhotoItemDto } from '@photobank/shared/api/photobank';
+
+interface AccessProfile {
+  storages?: string[];
+}
+
+export const PhotosPage = () => {
+  const [photos, setPhotos] = useState<PhotoItemDto[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      const profileRes = await fetch('/api/access/profile');
+      const profile: AccessProfile = await profileRes.json();
+      const allowedStorages = profile.storages ?? [];
+
+      const photosRes = await fetch('/api/photos');
+      const data = await photosRes.json();
+      const filtered = (data.items ?? []).filter((p: PhotoItemDto) =>
+        allowedStorages.length === 0 || allowedStorages.includes(p.storageId ?? '')
+      );
+      if (active) {
+        setPhotos(filtered);
+      }
+    };
+    load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <div>
+      {photos.map((p) => (
+        <div key={p.id}>{p.id}</div>
+      ))}
+    </div>
+  );
+};
+
+export default PhotosPage;

--- a/frontend/packages/frontend/src/features/photos/__tests__/photos.access.spec.tsx
+++ b/frontend/packages/frontend/src/features/photos/__tests__/photos.access.spec.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { server } from '@/test-setup';
+import { scenarioUserLimitedAccess } from '@photobank/shared/api/photobank/msw.scenarios';
+import { PhotosPage } from '../PhotosPage';
+
+describe('Photos access policy', () => {
+  beforeEach(() => {
+    server.resetHandlers(...scenarioUserLimitedAccess());
+  });
+
+  it('shows only allowed photos for user', async () => {
+    render(<PhotosPage />);
+    expect(await screen.findByText(/p_1/i)).toBeInTheDocument();
+    expect(screen.queryByText(/p_3/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/packages/frontend/src/test-setup.ts
+++ b/frontend/packages/frontend/src/test-setup.ts
@@ -1,0 +1,1 @@
+export { server } from '../test-setup';

--- a/frontend/packages/frontend/test-setup.ts
+++ b/frontend/packages/frontend/test-setup.ts
@@ -42,7 +42,7 @@ Object.defineProperty(globalThis, 'HTMLCanvasElement', {
   },
 });
 
-const server = setupServer(...(handlers as any));
+export const server = setupServer(...(handlers as any));
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());


### PR DESCRIPTION
## Summary
- implement PhotosPage with access profile filtering
- export test server for msw scenarios
- add access policy unit test

## Testing
- `pnpm --filter @photobank/frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b422b2448328bb085a4010340439