### PR TITLE
test: add photos access policy test

### DIFF
--- a/frontend/packages/frontend/src/features/photos/PhotosPage.tsx
+++ b/frontend/packages/frontend/src/features/photos/PhotosPage.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+interface PhotoItem {
+  id: string;
+}
+
+export function PhotosPage() {
+  const [photos, setPhotos] = useState<PhotoItem[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const profileRes = await fetch('/api/access/profile');
+      const profile = await profileRes.json();
+      const storageId = profile.storages?.[0];
+      const photosRes = await fetch(`/api/photos?storageId=${storageId}`);
+      const data = await photosRes.json();
+      setPhotos(data.items ?? []);
+    };
+    void load();
+  }, []);
+
+  return (
+    <div>
+      {photos.map((p) => (
+        <div key={p.id}>{p.id}</div>
+      ))}
+    </div>
+  );
+}
+
+export default PhotosPage;

--- a/frontend/packages/frontend/src/features/photos/__tests__/photos.access.spec.ts
+++ b/frontend/packages/frontend/src/features/photos/__tests__/photos.access.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { server } from '../../../../test-setup';
+import { scenarioUserLimitedAccess } from '@photobank/shared/api/photobank/msw.scenarios';
+import { PhotosPage } from '../PhotosPage';
+
+describe('Photos access policy', () => {
+  beforeEach(() => {
+    server.resetHandlers(...scenarioUserLimitedAccess());
+  });
+
+  it('shows only allowed photos for user', async () => {
+    render(React.createElement(PhotosPage));
+    expect(await screen.findByText(/p_1/i)).toBeInTheDocument();
+    expect(screen.queryByText(/p_3/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add PhotosPage wrapper for access-filtered photo requests
- test limited user access to photos

## Testing
- `pnpm test src/features/photos/__tests__/photos.access.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4c487c32883289bbc77148cd84c44