### PR TITLE
Apply ACL checks to photo queries

### DIFF
--- a/backend/PhotoBank.Services/AccessControl/DummyCurrentUser.cs
+++ b/backend/PhotoBank.Services/AccessControl/DummyCurrentUser.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace PhotoBank.AccessControl;
+
+public sealed class DummyCurrentUser : ICurrentUser
+{
+    public string UserId => string.Empty;
+    public bool IsAdmin => true;
+    public IReadOnlySet<int> AllowedStorageIds { get; } = new HashSet<int>();
+    public IReadOnlySet<int> AllowedPersonGroupIds { get; } = new HashSet<int>();
+    public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; } = new List<(DateOnly From, DateOnly To)>();
+    public bool CanSeeNsfw => true;
+}

--- a/backend/PhotoBank.Services/RegisterServicesForApi.cs
+++ b/backend/PhotoBank.Services/RegisterServicesForApi.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using PhotoBank.Repositories;
 using PhotoBank.Services.Api;
+using PhotoBank.AccessControl;
 
 namespace PhotoBank.Services
 {
@@ -11,6 +13,7 @@ namespace PhotoBank.Services
             services.AddMemoryCache();
             services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
             services.AddScoped<IPhotoService, PhotoService>();
+            services.TryAddScoped<ICurrentUser, DummyCurrentUser>();
             services.AddSingleton<ITokenService, TokenService>();
             services.AddSingleton<IImageService, ImageService>();
         }

--- a/backend/PhotoBank.Services/RegisterServicesForConsole.cs
+++ b/backend/PhotoBank.Services/RegisterServicesForConsole.cs
@@ -11,6 +11,7 @@ using PhotoBank.Services.Api;
 using PhotoBank.Services.Enrichers;
 using PhotoBank.Services.Enrichers.Services;
 using PhotoBank.Services.Recognition;
+using PhotoBank.AccessControl;
 using ApiKeyServiceClientCredentials = Microsoft.Azure.CognitiveServices.Vision.ComputerVision.ApiKeyServiceClientCredentials;
 
 namespace PhotoBank.Services
@@ -54,6 +55,7 @@ namespace PhotoBank.Services
 
             services.AddTransient<IPhotoProcessor, PhotoProcessor>();
             services.AddTransient<IPhotoService, PhotoService>();
+            services.AddSingleton<ICurrentUser, DummyCurrentUser>();
             services.AddTransient<IImageService, ImageService>();
             services.AddTransient<ISyncService, SyncService>();
 

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -15,6 +15,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
+using PhotoBank.AccessControl;
 
 namespace PhotoBank.UnitTests.Services
 {
@@ -50,7 +51,9 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Face>(provider),
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
-                _mapper, new MemoryCache(new MemoryCacheOptions()));
+                _mapper,
+                new MemoryCache(new MemoryCacheOptions()),
+                new DummyCurrentUser());
         }
 
         [Test]

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -13,6 +13,7 @@ using PhotoBank.DbContext.Models;
 using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
+using PhotoBank.AccessControl;
 
 namespace PhotoBank.UnitTests.Services
 {
@@ -52,7 +53,8 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 _mapper,
-                new MemoryCache(new MemoryCacheOptions()));
+                new MemoryCache(new MemoryCacheOptions()),
+                new DummyCurrentUser());
 
             var bytes = new byte[] { 1, 2, 3, 4 };
             await using var ms = new MemoryStream(bytes);
@@ -87,7 +89,8 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 _mapper,
-                new MemoryCache(new MemoryCacheOptions()));
+                new MemoryCache(new MemoryCacheOptions()),
+                new DummyCurrentUser());
 
             var bytes = new byte[] { 1, 2, 3, 4 };
             await using var ms1 = new MemoryStream(bytes);
@@ -126,7 +129,8 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 _mapper,
-                new MemoryCache(new MemoryCacheOptions()));
+                new MemoryCache(new MemoryCacheOptions()),
+                new DummyCurrentUser());
 
             var bytes1 = new byte[] { 1, 2, 3, 4 };
             await using var ms1 = new MemoryStream(bytes1);


### PR DESCRIPTION
## Summary
- enforce ACL restrictions in photo queries with admin bypass and deterministic sorting
- register and provide dummy current user for non-HTTP environments
- update tests for new PhotoService dependency

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: PhotoService constructor missing currentUser prior to test fixes)*
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(hangs after start; no results)*

------
https://chatgpt.com/codex/tasks/task_e_68a560e3bdfc8328bf02a17a24dd247c