### PR TITLE
fix: include additional fields in filter

### DIFF
--- a/backend/PhotoBank.UnitTests/FilterDtoTests.cs
+++ b/backend/PhotoBank.UnitTests/FilterDtoTests.cs
@@ -71,6 +71,38 @@ namespace PhotoBank.Tests.ViewModel.Dto
         }
 
         [Test]
+        public void IsNotEmpty_ShouldReturnTrue_WhenPathsIsNotEmpty()
+        {
+            // Arrange
+            var filterDto = new FilterDto
+            {
+                Paths = new List<int> { 1 }
+            };
+
+            // Act
+            var result = filterDto.IsNotEmpty();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void IsNotEmpty_ShouldReturnTrue_WhenRelativePathIsNotEmpty()
+        {
+            // Arrange
+            var filterDto = new FilterDto
+            {
+                RelativePath = "path"
+            };
+
+            // Act
+            var result = filterDto.IsNotEmpty();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
         public void IsNotEmpty_ShouldReturnTrue_WhenIsBWIsTrue()
         {
             // Arrange

--- a/backend/PhotoBank.ViewModel.Dto/FilterDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/FilterDto.cs
@@ -23,7 +23,18 @@ namespace PhotoBank.ViewModel.Dto
 
         public bool IsNotEmpty()
         {
-            return (Storages != null && Storages.Any()) || (Persons!= null && Persons.Any()) || (Tags!= null && Tags.Any()) || IsBW.HasValue || IsAdultContent.HasValue || IsRacyContent.HasValue || ThisDay != null || TakenDateFrom.HasValue || TakenDateTo.HasValue || !string.IsNullOrEmpty(Caption);
+            return (Storages != null && Storages.Any())
+                   || (Persons != null && Persons.Any())
+                   || (Tags != null && Tags.Any())
+                   || (Paths != null && Paths.Any())
+                   || !string.IsNullOrEmpty(RelativePath)
+                   || IsBW.HasValue
+                   || IsAdultContent.HasValue
+                   || IsRacyContent.HasValue
+                   || ThisDay != null
+                   || TakenDateFrom.HasValue
+                   || TakenDateTo.HasValue
+                   || !string.IsNullOrEmpty(Caption);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure `FilterDto.IsNotEmpty` considers `Paths` and `RelativePath`
- add coverage for `Paths` and `RelativePath` in unit tests

## Testing
- `dotnet test PhotoBank.Backend.sln -c Release` *(fails: .NET SDK 8.0 does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a5658d552c83289e2458419d26e27d