### PR TITLE
test: add MSSQL integration tests project

### DIFF
--- a/backend/PhotoBank.Backend.sln
+++ b/backend/PhotoBank.Backend.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoBank.ViewModel.Dto", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoBank.BlobMigrator", "PhotoBank.BlobMigrator\PhotoBank.BlobMigrator.csproj", "{1265499D-2C5A-41FE-A82D-5E1F7EC22678}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobank.MsSqlIntegrationTests", "Photobank.MsSqlIntegrationTests\Photobank.MsSqlIntegrationTests.csproj", "{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -153,6 +155,18 @@ Global
 		{1265499D-2C5A-41FE-A82D-5E1F7EC22678}.Release|x64.Build.0 = Release|Any CPU
 		{1265499D-2C5A-41FE-A82D-5E1F7EC22678}.Release|x86.ActiveCfg = Release|Any CPU
 		{1265499D-2C5A-41FE-A82D-5E1F7EC22678}.Release|x86.Build.0 = Release|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Debug|x64.Build.0 = Debug|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Debug|x86.Build.0 = Debug|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Release|x64.ActiveCfg = Release|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Release|x64.Build.0 = Release|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Release|x86.ActiveCfg = Release|Any CPU
+		{88AB1F7D-EE8E-4011-A4C0-CA8E4D679CB0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/backend/PhotoBank.sln
+++ b/backend/PhotoBank.sln
@@ -27,6 +27,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoBank.InsightFaceApiCli
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoBank.BlobMigrator", "PhotoBank.BlobMigrator\PhotoBank.BlobMigrator.csproj", "{794473DE-6A3C-45C2-A33A-D2E9767CFB61}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobank.MsSqlIntegrationTests", "Photobank.MsSqlIntegrationTests\Photobank.MsSqlIntegrationTests.csproj", "{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -185,6 +187,18 @@ Global
 		{794473DE-6A3C-45C2-A33A-D2E9767CFB61}.Release|x64.Build.0 = Release|Any CPU
 		{794473DE-6A3C-45C2-A33A-D2E9767CFB61}.Release|x86.ActiveCfg = Release|Any CPU
 		{794473DE-6A3C-45C2-A33A-D2E9767CFB61}.Release|x86.Build.0 = Release|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Debug|x64.Build.0 = Debug|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Debug|x86.Build.0 = Debug|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Release|x64.ActiveCfg = Release|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Release|x64.Build.0 = Release|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Release|x86.ActiveCfg = Release|Any CPU
+		{F94A3F31-8D15-47CF-9CEA-6550D72D85AA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/backend/Photobank.MsSqlIntegrationTests/MsSqlContainerTests.cs
+++ b/backend/Photobank.MsSqlIntegrationTests/MsSqlContainerTests.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using PhotoBank.DbContext.DbContext;
+using Testcontainers.MsSql;
+using Xunit;
+
+public class MsSqlContainerTests : IAsyncLifetime
+{
+    private readonly MsSqlContainer _msSqlContainer =
+        new MsSqlBuilder().WithPassword("yourStrong(!)Password").Build();
+
+    public async Task InitializeAsync() => await _msSqlContainer.StartAsync();
+
+    public async Task DisposeAsync() => await _msSqlContainer.DisposeAsync();
+
+    [Fact]
+    public async Task Should_connect_and_apply_migrations()
+    {
+        var options = new DbContextOptionsBuilder<PhotoBankDbContext>()
+            .UseSqlServer(_msSqlContainer.GetConnectionString())
+            .Options;
+
+        await using var context = new PhotoBankDbContext(options);
+        await context.Database.MigrateAsync();
+
+        await using var connection = new SqlConnection(_msSqlContainer.GetConnectionString());
+        await connection.OpenAsync();
+
+        using var command = new SqlCommand("SELECT 1", connection);
+        var result = (int)await command.ExecuteScalarAsync();
+
+        result.Should().Be(1);
+    }
+}

--- a/backend/Photobank.MsSqlIntegrationTests/Photobank.MsSqlIntegrationTests.csproj
+++ b/backend/Photobank.MsSqlIntegrationTests/Photobank.MsSqlIntegrationTests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.6.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.6.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PhotoBank.DbContext\PhotoBank.DbContext.csproj" />
+    <ProjectReference Include="..\PhotoBank.Services\PhotoBank.Services.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add xUnit-based MsSql integration test project
- sample test starts SQL Server container and applies EF migrations

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test Photobank.MsSqlIntegrationTests/Photobank.MsSqlIntegrationTests.csproj -v n` *(fails: Docker is either not running or misconfigured)*


------
https://chatgpt.com/codex/tasks/task_e_68a58c94cd0483289ce4a8cec71b42aa