### PR TITLE
ci: add shared package build and test workflow

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -1,0 +1,34 @@
+name: Shared CI
+
+on:
+  push:
+    paths:
+      - 'frontend/packages/shared/**'
+      - '.github/workflows/shared.yml'
+  pull_request:
+    paths:
+      - 'frontend/packages/shared/**'
+      - '.github/workflows/shared.yml'
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10
+      - name: Install dependencies
+        run: pnpm -w install
+        working-directory: frontend
+      - name: Build shared package
+        run: pnpm --filter @photobank/shared build
+        working-directory: frontend
+      - name: Test shared package
+        run: pnpm --filter @photobank/shared test
+        working-directory: frontend


### PR DESCRIPTION
## Summary
- add GitHub Action to build and test shared package

## Testing
- `pnpm -w install`
- `pnpm --filter @photobank/shared build` *(fails: Parameter 'props' implicitly has an 'any' type)*
- `pnpm --filter @photobank/shared test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d7f3f7a48328bfaeb3389ae5f841