### PR TITLE
fix: refine RequestInit typing

### DIFF
--- a/frontend/packages/shared/src/api/photobank/msw.helpers.ts
+++ b/frontend/packages/shared/src/api/photobank/msw.helpers.ts
@@ -1,9 +1,17 @@
-import { delay, HttpResponse } from 'msw';
+import {
+  delay,
+  HttpResponse,
+  type HttpResponseInit,
+  type JsonBodyType,
+} from 'msw';
 
 export const withDelay = (ms = 300) => delay(ms);
 
-export const respond = <T>(data: T, init?: number | ResponseInit) =>
-  HttpResponse.json(data as any, init);
+export const respond = <T>(data: T, init?: number | HttpResponseInit) => {
+  const responseInit: HttpResponseInit | undefined =
+    typeof init === 'number' ? { status: init } : init;
+  return HttpResponse.json(data as JsonBodyType, responseInit);
+};
 
 export const respondError = (status = 500, message = 'Server error', extra?: Record<string, unknown>) =>
   HttpResponse.json({ title: message, status, ...extra }, { status });

--- a/frontend/packages/shared/src/types/requestinit.d.ts
+++ b/frontend/packages/shared/src/types/requestinit.d.ts
@@ -1,4 +1,16 @@
 interface RequestInit {
   signal?: AbortSignal | null | undefined;
-  [key: string]: any;
+  /**
+   * Allows consumers to extend the RequestInit object with
+   * additional, typed properties without using `any`.
+   */
+  [key: string]: unknown;
+}
+
+interface AbortSignal {
+  /**
+   * Enables passing an `AbortSignal` where a `RequestInit` is expected
+   * without violating the index signature requirements above.
+   */
+  [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary
- avoid `any` in RequestInit and make AbortSignal compatible
- fix MSW helpers types for `HttpResponse.json`

## Testing
- `pnpm -C frontend/packages/shared run lint`
- `pnpm -C frontend/packages/shared run test`
- `pnpm -C frontend/packages/shared run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6201ccbfc8328b545aef9c680159d