### PR TITLE
fix: remove unnecessary non-null assertions

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
@@ -49,7 +49,7 @@ function UserEditor({ user, onSave }: UserEditorProps) {
         { }
         <form
           onSubmit={(e) => {
-            void form.handleSubmit((d) => onSave(user.id!, d))(e);
+            void form.handleSubmit((d) => onSave(user.id, d))(e);
           }}
           className="space-y-4"
         >

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
@@ -42,7 +42,7 @@ const PhotoListItemMobile = ({
           <div className="font-medium truncate">{photo.name}</div>
           {photo.captions && photo.captions.length > 0 && (
             <div className="text-xs text-muted-foreground truncate">
-              {firstNWords(photo.captions[0]!, 5)}
+              {firstNWords(photo.captions[0], 5)}
             </div>
           )}
           <Badge variant="outline" className="font-mono text-xs mt-1">


### PR DESCRIPTION
## Summary
- remove redundant non-null assertion in photo list item mobile
- drop unnecessary id assertion in users page

## Testing
- `pnpm --filter @photobank/frontend lint`
- `pnpm --filter @photobank/frontend test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68a627b19c8883288c58aaa0a5356b30