### PR TITLE
fix: handle nullable ids and captions in frontend

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
@@ -30,7 +30,7 @@ const schema = z.object({
 type FormData = z.infer<typeof schema>;
 
 interface UserEditorProps {
-  user: UserWithClaimsDto;
+  user: UserWithClaimsDto & { id: string };
   onSave: (id: string, data: FormData) => Promise<void>;
 }
 
@@ -101,7 +101,9 @@ function UserEditor({ user, onSave }: UserEditorProps) {
 
 export default function UsersPage() {
   const { data: usersResp } = useUsersGetAll();
-  const users = usersResp?.data ?? [];
+  const users = (usersResp?.data ?? []).filter(
+    (u): u is UserWithClaimsDto & { id: string } => Boolean(u.id),
+  );
   const { mutateAsync: updateUser } = useUsersUpdate();
   const { mutateAsync: setClaims } = useUsersSetClaims();
   const { t } = useTranslation();

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
@@ -40,11 +40,11 @@ const PhotoListItemMobile = ({
         />
         <div className="flex-1 min-w-0">
           <div className="font-medium truncate">{photo.name}</div>
-          {photo.captions && photo.captions.length > 0 && (
-            <div className="text-xs text-muted-foreground truncate">
-              {firstNWords(photo.captions[0], 5)}
-            </div>
-          )}
+            {photo.captions && photo.captions.length > 0 && (
+              <div className="text-xs text-muted-foreground truncate">
+                {firstNWords(photo.captions[0] ?? '', 5)}
+              </div>
+            )}
           <Badge variant="outline" className="font-mono text-xs mt-1">
             {photo.id}
           </Badge>


### PR DESCRIPTION
## Summary
- ensure users with missing ids are excluded and onSave expects non-null id
- guard photo caption preview with fallback string

## Testing
- `pnpm build` *(fails: Cannot find type definition file for 'node', local package.json exists, but node_modules missing, did you mean to install?)*
- `pnpm test` *(fails: vitest not found, local package.json exists, but node_modules missing, did you mean to install?)*

------
https://chatgpt.com/codex/tasks/task_e_68a62b3cf0808328b09f4b4a4462038d