### PR TITLE
fix: remove unnecessary non-null assertion

### DIFF
--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -90,7 +90,7 @@ export async function sendAlbumSmart(ctx: Context, photos: PhotoItemDto[]) {
       );
       // Save file_id for all items where it appears
       msgs.forEach((m, i) => {
-        const p = group[i]!;
+        const p = group[i];
         const id = m.photo?.at(-1)?.file_id;
         if (id) setFileId(p.id, id);
       });


### PR DESCRIPTION
## Summary
- clean up sendAlbumSmart cache handling

## Testing
- `pnpm --filter telegram-bot lint`
- `pnpm --filter telegram-bot test` *(fails: Missing "./api/photobank/msw" specifier in "@photobank/shared" package)*

------
https://chatgpt.com/codex/tasks/task_e_68a6314b6a908328b993370802db8d65