### PR TITLE
fix: resolve shared msw specifier in tests

### DIFF
--- a/frontend/packages/telegram-bot/test-setup.ts
+++ b/frontend/packages/telegram-bot/test-setup.ts
@@ -2,6 +2,8 @@ import { afterAll, afterEach, beforeAll } from 'vitest';
 import { setupServer } from 'msw/node';
 import { handlers } from '@photobank/shared/api/photobank/msw';
 
+process.env.BOT_TOKEN = process.env.BOT_TOKEN || 'test-token';
+
 export const server = setupServer(...handlers);
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));

--- a/frontend/packages/telegram-bot/test/subscribe.test.ts
+++ b/frontend/packages/telegram-bot/test/subscribe.test.ts
@@ -18,13 +18,25 @@ describe('parseSubscribeTime', () => {
 
 describe('subscribeCommand', () => {
   it('replies with usage on wrong input', async () => {
-    const ctx = { reply: vi.fn(), message: { text: '/subscribe' }, chat: { id: 1 }, t: (k: string) => i18n.t('en', k), i18n: { locale: () => 'en' } } as any;
+    const ctx = {
+      reply: vi.fn(),
+      message: { text: '/subscribe' },
+      chat: { id: 1 },
+      t: (k: string) => i18n.t('en', k),
+      i18n: { getLocale: () => 'en' },
+    } as any;
     await subscribeCommand(ctx);
     expect(ctx.reply).toHaveBeenCalledWith(i18n.t('en', 'subscribe-usage'));
   });
 
   it('stores subscription on valid input', async () => {
-    const ctx = { reply: vi.fn(), message: { text: '/subscribe 07:15' }, chat: { id: 42 }, t: (k: string, p?: any) => i18n.t('en', k, p), i18n: { locale: () => 'en' } } as any;
+    const ctx = {
+      reply: vi.fn(),
+      message: { text: '/subscribe 07:15' },
+      chat: { id: 42 },
+      t: (k: string, p?: any) => i18n.t('en', k, p),
+      i18n: { getLocale: () => 'en' },
+    } as any;
     await subscribeCommand(ctx);
     expect(subscriptions.get(42)?.time).toBe('07:15');
   });

--- a/frontend/packages/telegram-bot/vitest.config.ts
+++ b/frontend/packages/telegram-bot/vitest.config.ts
@@ -1,6 +1,18 @@
 import { defineConfig } from 'vitest/config';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@photobank/shared/api/photobank/msw': resolve(
+        __dirname,
+        '../shared/src/api/photobank/msw.ts',
+      ),
+    },
+  },
   test: {
     setupFiles: ['./test-setup.ts'],
     environment: 'node',


### PR DESCRIPTION
## Summary
- map @photobank/shared/api/photobank/msw to source in vitest
- provide BOT_TOKEN for tests
- fix subscribeCommand tests

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68a6b204051c8328b003ee34211b981c