### PR TITLE
fix: align API service calls with generated client

### DIFF
--- a/frontend/packages/telegram-bot/src/api/axios-instance.ts
+++ b/frontend/packages/telegram-bot/src/api/axios-instance.ts
@@ -5,15 +5,22 @@ import { ensureUserAccessToken, invalidateUserToken } from '../auth';
 
 const API_BASE_URL = process.env.API_BASE_URL;
 
+let currentCtx: Context | undefined;
+
+export function setRequestContext(ctx: Context) {
+  currentCtx = ctx;
+}
+
 export async function photobankAxios<T>(config: AxiosRequestConfig, ctx?: Context) {
-  if (!ctx) {
+  const context = ctx ?? currentCtx;
+  if (!context) {
     throw new Error('Telegram context is required');
   }
   if (!API_BASE_URL) {
     throw new Error('API_BASE_URL is not set');
   }
   async function doRequest(force = false) {
-    const token = await ensureUserAccessToken(ctx, force);
+    const token = await ensureUserAccessToken(context, force);
     return axios<T>({
       baseURL: API_BASE_URL,
       headers: { Authorization: `Bearer ${token}`, ...(config.headers || {}) },
@@ -26,7 +33,7 @@ export async function photobankAxios<T>(config: AxiosRequestConfig, ctx?: Contex
     const status = (err as AxiosError | undefined)?.response?.status;
     if (status === 401 || status === 403) {
       // токен протух или права изменились — инвалидируем и пробуем ещё раз
-      invalidateUserToken(ctx);
+      invalidateUserToken(context);
       return await doRequest(true);
     }
     throw err;

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -24,8 +24,10 @@ bot.on('inline_query', async (ctx: MyContext) => {
       {
         is_personal: true,
         cache_time: 2,
-        switch_pm_text: ctx.t('deeplink-not-linked'),
-        switch_pm_parameter: 'link',
+        button: {
+          text: ctx.t('deeplink-not-linked'),
+          start_parameter: 'link',
+        },
       } satisfies Parameters<typeof ctx.answerInlineQuery>[1],
     );
     return;

--- a/frontend/packages/telegram-bot/src/services/dictionary.ts
+++ b/frontend/packages/telegram-bot/src/services/dictionary.ts
@@ -4,6 +4,7 @@ import { getPaths } from '../api/photobank/paths/paths';
 import { getPersons } from '../api/photobank/persons/persons';
 import { getStorages } from '../api/photobank/storages/storages';
 import { getTags } from '../api/photobank/tags/tags';
+import { setRequestContext } from '../api/axios-instance';
 import { handleServiceError } from '../errorHandler';
 
 const { pathsGetAll } = getPaths();
@@ -13,7 +14,8 @@ const { tagsGetAll } = getTags();
 
 export async function fetchTags(ctx: Context) {
   try {
-    return await tagsGetAll(ctx);
+    setRequestContext(ctx);
+    return await tagsGetAll();
   } catch (err) {
     handleServiceError(err);
     throw err;
@@ -22,7 +24,8 @@ export async function fetchTags(ctx: Context) {
 
 export async function fetchPersons(ctx: Context) {
   try {
-    return await personsGetAll(ctx);
+    setRequestContext(ctx);
+    return await personsGetAll();
   } catch (err) {
     handleServiceError(err);
     throw err;
@@ -31,7 +34,8 @@ export async function fetchPersons(ctx: Context) {
 
 export async function fetchStorages(ctx: Context) {
   try {
-    return await storagesGetAll(ctx);
+    setRequestContext(ctx);
+    return await storagesGetAll();
   } catch (err) {
     handleServiceError(err);
     throw err;
@@ -40,7 +44,8 @@ export async function fetchStorages(ctx: Context) {
 
 export async function fetchPaths(ctx: Context) {
   try {
-    return await pathsGetAll(ctx);
+    setRequestContext(ctx);
+    return await pathsGetAll();
   } catch (err) {
     handleServiceError(err);
     throw err;

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -2,6 +2,7 @@ import type { Context } from 'grammy';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 
 import { getPhotos } from '../api/photobank/photos/photos';
+import { setRequestContext } from '../api/axios-instance';
 import { handleServiceError } from '../errorHandler';
 
 const { photosSearchPhotos, photosGetPhoto, photosUpload } = getPhotos();
@@ -11,7 +12,8 @@ export async function searchPhotos(
   filter: FilterDto & { top?: number; skip?: number },
 ) {
   try {
-    return await photosSearchPhotos(filter as FilterDto, ctx);
+    setRequestContext(ctx);
+    return await photosSearchPhotos(filter as FilterDto);
   } catch (err) {
     handleServiceError(err);
     throw err;
@@ -20,7 +22,8 @@ export async function searchPhotos(
 
 export async function getPhoto(ctx: Context, id: number) {
   try {
-    return await photosGetPhoto(id, ctx);
+    setRequestContext(ctx);
+    return await photosGetPhoto(id);
   } catch (err) {
     handleServiceError(err);
     throw err;
@@ -36,7 +39,8 @@ export async function uploadPhotos(
   const { files, storageId, path } = options;
   const blobs = files.map(({ data, name }) => new File([data as BlobPart], name));
   try {
-    return await photosUpload({ files: blobs, storageId, path }, ctx);
+    setRequestContext(ctx);
+    return await photosUpload({ files: blobs, storageId, path });
   } catch (err) {
     handleServiceError(err);
     throw err;

--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -28,7 +28,7 @@ export async function sendPhotoSmart(ctx: Context, p: PhotoItemDto) {
           { caption: buildCaption(p) },
         ),
       ),
-    ));
+    )) as Message.PhotoMessage;
     const newId = message.photo?.at(-1)?.file_id || null;
     if (newId && newId !== cached) setFileId(p.id, newId);
     return message;
@@ -85,9 +85,9 @@ export async function sendAlbumSmart(ctx: Context, photos: PhotoItemDto[]) {
 
     try {
       // mediaGroup cannot be edited, so just send and continue
-      const msgs = await withTelegramRetry(() =>
+      const msgs = (await withTelegramRetry(() =>
         throttled(() => ctx.api.sendMediaGroup(ctx.chat.id, medias)),
-      );
+      )) as Message.PhotoMessage[];
       // Save file_id for all items where it appears
       msgs.forEach((m, i) => {
         const p = group[i];


### PR DESCRIPTION
## Summary
- use API request context helper with generated client
- handle inline auth button with new Telegram API format
- typecast photo send helpers to access file IDs safely

## Testing
- `pnpm build`
- `pnpm test` *(fails: Cannot find package '@photobank/shared/ai/openai')*

------
https://chatgpt.com/codex/tasks/task_e_68a6b65f8440832891b3503f1e081ec4