### PR TITLE
fix: remove unnecessary type assertion

### DIFF
--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -20,7 +20,7 @@ export async function sendPhotoSmart(ctx: Context, p: PhotoItemDto) {
   }
   const cached = getFileId(p.id);
   try {
-    const message = (await withTelegramRetry(() =>
+    const message = await withTelegramRetry(() =>
       throttled(() =>
         ctx.api.sendPhoto(
           ctx.chat.id,
@@ -28,7 +28,7 @@ export async function sendPhotoSmart(ctx: Context, p: PhotoItemDto) {
           { caption: buildCaption(p) },
         ),
       ),
-    )) as Message.PhotoMessage;
+    );
     const newId = message.photo?.at(-1)?.file_id || null;
     if (newId && newId !== cached) setFileId(p.id, newId);
     return message;

--- a/frontend/packages/telegram-bot/vitest.config.ts
+++ b/frontend/packages/telegram-bot/vitest.config.ts
@@ -7,6 +7,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      '@photobank/shared': resolve(__dirname, '../shared/src'),
+      '@photobank/shared/': resolve(__dirname, '../shared/src/'),
       '@photobank/shared/api/photobank/msw': resolve(
         __dirname,
         '../shared/src/api/photobank/msw.ts',


### PR DESCRIPTION
## Summary
- remove redundant type assertion when sending photos in telegram bot
- resolve `@photobank/shared` paths in Vitest so tests can run

## Testing
- `pnpm --filter @photobank/telegram-bot lint`
- `pnpm --filter @photobank/telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_68a6bbf38fd8832891b9b806f2612f8d