### PR TITLE
fix: enable nullable reference types in backend

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -241,7 +241,7 @@ namespace PhotoBank.Api
                 opts.EnrichDiagnosticContext = (diag, http) =>
                 {
                     diag.Set("UserAgent", http.Request.Headers.UserAgent.ToString());
-                    diag.Set("RemoteIp", http.Connection.RemoteIpAddress?.ToString());
+                    diag.Set("RemoteIp", http.Connection.RemoteIpAddress?.ToString() ?? string.Empty);
                     diag.Set("RequestId", http.TraceIdentifier);
                 };
             });

--- a/backend/PhotoBank.Services/FaceService.cs
+++ b/backend/PhotoBank.Services/FaceService.cs
@@ -258,9 +258,6 @@ namespace PhotoBank.Services
 
             _persons = await _personRepository.GetAll().AsNoTracking().ToListAsync();
 
-            int currentMinute = DateTime.Now.Minute;
-            int callCounter = 0;
-
             foreach (var face in faces)
             {
                 try
@@ -270,7 +267,6 @@ namespace PhotoBank.Services
 
                     try
                     {
-                        //await SleepAsync();
                         detectedFaces = await DetectFacesAsync(face.Image);
                     }
                     catch (Exception e)
@@ -281,7 +277,6 @@ namespace PhotoBank.Services
                         continue;
                     }
 
-                    //await SleepAsync();
                     var identifyResults = await IdentifyAsync(detectedFaces.Select(f => f.FaceId).ToList());
 
                     if (!identifyResults.Any())
@@ -324,28 +319,6 @@ namespace PhotoBank.Services
                 }
             }
 
-            async Task SleepAsync()
-            {
-                const int callsPerMinute = 6000;
-                if (currentMinute == DateTime.Now.Minute && ++callCounter >= callsPerMinute)
-                {
-                    var millisecondsDelay = 60000 - DateTime.Now.Millisecond;
-                    var color = Console.ForegroundColor;
-                    Console.ForegroundColor = ConsoleColor.Red;
-                    Console.WriteLine($"Sleep for {millisecondsDelay}");
-                    await Task.Delay(millisecondsDelay);
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine($"Resume");
-                    Console.ForegroundColor = color;
-                }
-
-                if (currentMinute < DateTime.Now.Minute)
-                {
-                    callCounter = 0;
-                }
-
-                currentMinute = DateTime.Now.Minute;
-            }
         }
 
         public async Task<IList<IdentifyResult>> IdentifyAsync(IList<Guid?> faceIds)

--- a/backend/PhotoBank.Services/InternalMagickFormatInfo.cs
+++ b/backend/PhotoBank.Services/InternalMagickFormatInfo.cs
@@ -1,6 +1,8 @@
-﻿using System;
+using System;
 using System.Drawing.Imaging;
 using ImageMagick;
+
+#pragma warning disable CA1416 // Validate platform compatibility
 
 namespace PhotoBank.Services
 {
@@ -25,3 +27,5 @@ namespace PhotoBank.Services
         }
     }
 }
+
+#pragma warning restore CA1416

--- a/backend/PhotoBank.UnitTests/DependencyExecutorTests.cs
+++ b/backend/PhotoBank.UnitTests/DependencyExecutorTests.cs
@@ -132,7 +132,7 @@ namespace PhotoBank.UnitTests
             var executor = new DependencyExecutor();
 
             // Act & Assert
-            Assert.DoesNotThrowAsync(async () => await executor.ExecuteAsync(enrichers, null, null));
+            await Assert.DoesNotThrowAsync(() => executor.ExecuteAsync(enrichers, null, null));
         }
 
         [Test]

--- a/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoDetail.razor
+++ b/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoDetail.razor
@@ -7,7 +7,7 @@
 
 @if (Photo != null)
 {
-    <Title value="@Photo.Name"></Title>
+    <PageTitle>@Photo.Name</PageTitle>
 }
 
 <style type="text/css">
@@ -46,14 +46,14 @@
 else
 {
     <div class="wrapper">
-        <img src="data:image;base64,@Convert.ToBase64String(Photo.PreviewImage)" alt="@string.Join(" ", Photo.Captions)"/>
-        @for (var i = 0; i < Photo.Faces.Count; i++)
+        <img src="data:image;base64,@Convert.ToBase64String(Photo.PreviewImage ?? Array.Empty<byte>())" alt="@string.Join(" ", Photo.Captions ?? Array.Empty<string>())"/>
+        @for (var i = 0; i < (Photo.Faces?.Count ?? 0); i++)
         {
             var i2 = i;
-            var face = Photo.Faces[i];
+            var face = Photo.Faces![i];
             var faceBox = face.FaceBox;
             <div class="box" style="top: @($"{faceBox.Top}px"); left: @($"{faceBox.Left}px"); width: @($"{faceBox.Width}px"); height: @($"{faceBox.Height}px")"
-                 @ref="MemberRef[i2]" @onmouseover="@(args => ShowTooltipWithHtml(i2, face.FriendlyFaceAttributes))">
+                 @ref="MemberRef![i2]" @onmouseover="@(args => ShowTooltipWithHtml(i2, face.FriendlyFaceAttributes))">
                 <span>@((i + 1).ToString())</span><span>.</span>
             </div>
         }
@@ -64,7 +64,7 @@ else
                 <div>Name:</div>
                 <b>@Photo.Name</b>
                 <div style="margin-top:20px">Caption:</div>
-                @foreach (var caption in Photo.Captions)
+                @foreach (var caption in Photo.Captions ?? Array.Empty<string>())
                 {
                     <b>@caption</b>
                     <br />
@@ -72,16 +72,16 @@ else
                 <div style="margin-top:20px"></div>
                 <span>Adult Score: <strong>@Math.Round(Photo.AdultScore, 3)</strong>;</span>&nbsp;<span>Racy Score: <strong>@Math.Round(Photo.RacyScore, 3)</strong></span>
                 <div style="margin-top:20px">Tags:</div>
-                @foreach (var tag in Photo.Tags)
+                @foreach (var tag in Photo.Tags ?? Array.Empty<string>())
                 {
                     <span style="display:inline-block;color:#fff;margin:4px;padding:0 4px;border-radius:4px;background-color: #5319e7">@tag</span>
                 }
             </div>
             <div class="col-md-6">
                 <div>Faces:</div>
-                @for (var i = 0; i < Photo.Faces.Count; i++)
+                @for (var i = 0; i < (Photo.Faces?.Count ?? 0); i++)
                 {
-                    var face = Photo.Faces[i];
+                    var face = Photo.Faces![i];
                     <div>
                         <span>@((i + 1).ToString())&nbsp;@(face.Age.ToString())&nbsp;@(face.Gender.HasValue ? (face.Gender.Value && face.FaceAttributes != null ? "M" : "F") : string.Empty)</span>
                         <AuthorizeView Roles="User">
@@ -89,7 +89,7 @@ else
                         </AuthorizeView>
 
                         <AuthorizeView Roles="Administrator">
-                            <RadzenDropDown Data=@Persons @bind-Value=@face.PersonId TextProperty="Name" ValueProperty="Id" Change=@(args => OnChangePersonAsync(face.Id, args))/>
+                            <RadzenDropDown Data=@(Persons ?? Array.Empty<PersonDto>()) @bind-Value=@face.PersonId TextProperty="Name" ValueProperty="Id" Change=@(args => OnChangePersonAsync(face.Id, args))/>
                         </AuthorizeView>
                     </div>
                 }

--- a/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoDetailBase.cs
+++ b/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoDetailBase.cs
@@ -9,16 +9,16 @@ namespace PhotoBank.ServerBlazorApp.Components.Pages
     {
         private readonly TooltipOptions _options = new() { Position = TooltipPosition.Bottom, Duration = 5000 };
         [Inject]
-        public IPhotoService PhotoDataService { get; set; }
-        [Inject] 
-        public TooltipService TooltipService { get; set; }
+        public IPhotoService PhotoDataService { get; set; } = default!;
+        [Inject]
+        public TooltipService TooltipService { get; set; } = default!;
         [Parameter]
-        public string PhotoId { get; set; }
-        protected PhotoDto Photo { get; set; }
-        protected IEnumerable<PersonDto> Persons { get; set; }
-        protected ElementReference[] MemberRef { get; set; }
+        public string PhotoId { get; set; } = default!;
+        protected PhotoDto? Photo { get; set; }
+        protected IEnumerable<PersonDto>? Persons { get; set; }
+        protected ElementReference[]? MemberRef { get; set; }
 
-        protected void ShowTooltipWithHtml(int i, string content) => TooltipService.Open(MemberRef[i], ds =>
+        protected void ShowTooltipWithHtml(int i, string content) => TooltipService.Open(MemberRef![i], ds =>
         {
             return builder =>
             {
@@ -38,7 +38,7 @@ namespace PhotoBank.ServerBlazorApp.Components.Pages
 
         protected string? GetPersonNameById(int? id)
         {
-            return !id.HasValue ? string.Empty : Persons.FirstOrDefault(p => p.Id == id)?.Name;
+            return !id.HasValue ? string.Empty : Persons?.FirstOrDefault(p => p.Id == id)?.Name;
         }
 
         protected async Task OnChangePersonAsync(int faceId, object personId)

--- a/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoOverview.razor
+++ b/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoOverview.razor
@@ -17,8 +17,8 @@
                     </RadzenDropDown>
                     @if (Filter.Storages != null)
                     {
-                        <RadzenDropDown @bind-Value="Filter.RelativePath" AllowClear="true" Data="@(Paths.Where(o => Filter.Storages.Contains(o.StorageId) && !string.IsNullOrEmpty(o.Path)))" Style="width: 100%;" TextProperty="Path" ValueProperty="Path" Name="Paths">
-                        </RadzenDropDown>
+                    <RadzenDropDown @bind-Value="Filter.RelativePath" AllowClear="true" Data="@(Paths?.Where(o => Filter.Storages.Contains(o.StorageId) && !string.IsNullOrEmpty(o.Path)) ?? Enumerable.Empty<PathDto>())" Style="width: 100%;" TextProperty="Path" ValueProperty="Path" Name="Paths">
+                    </RadzenDropDown>
                     }
                 </RadzenStack>
                 
@@ -78,7 +78,7 @@
             </RadzenDataGridColumn>
             <RadzenDataGridColumn TItem="PhotoItemDto" Property="Thumbnail" Title="Thumbnail" Sortable="false" Filterable="false">
                 <Template Context="data">
-                    <img src="data:image;base64,@Convert.ToBase64String(data?.Thumbnail)" />
+                    <img src="data:image;base64,@Convert.ToBase64String(data?.Thumbnail ?? Array.Empty<byte>())" />
                 </Template>
             </RadzenDataGridColumn>
             <RadzenDataGridColumn TItem="PhotoItemDto" Property="Name" Title="Name" />

--- a/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoOverviewBase.cs
+++ b/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoOverviewBase.cs
@@ -9,7 +9,7 @@ namespace PhotoBank.ServerBlazorApp.Components.Pages
     public class PhotoOverviewBase: ComponentBase
     {
         [Inject]
-        public IPhotoService PhotoService { get; set; }
+        public IPhotoService PhotoService { get; set; } = default!;
         
         public IEnumerable<PhotoItemDto>? Photos { get; set; }
         public IEnumerable<StorageDto>? Storages { get; set; }
@@ -22,7 +22,7 @@ namespace PhotoBank.ServerBlazorApp.Components.Pages
         public bool AllowRacyFilter { get; set; }
         public bool IsLoading { get; set; }
 
-        protected RadzenDataGrid<PhotoItemDto> grid;
+        protected RadzenDataGrid<PhotoItemDto>? grid;
 
         public PhotoOverviewBase()
         {

--- a/backend/Photobank.ServerBlazorApp/Components/Pages/UploadBase.cs
+++ b/backend/Photobank.ServerBlazorApp/Components/Pages/UploadBase.cs
@@ -6,7 +6,7 @@ namespace PhotoBank.ServerBlazorApp.Components.Pages
     public class UploadBase: ComponentBase
     {
         [Inject]
-        public NavigationManager NavigationManager { get; set; }
+        public NavigationManager NavigationManager { get; set; } = default!;
 
         public int Progress { get; set; }
 


### PR DESCRIPTION
## Summary
- enable nullable annotations across backend
- silence platform compatibility warnings for image formats
- fix null-safety issues in API, tests, and Blazor components

## Testing
- `dotnet build PhotoBank.Backend.sln -c Release --no-restore /warnaserror` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c82e7dac8328bb82abd4127063ab