### PR TITLE
fix: correct build flag in backend CI

### DIFF
--- a/.github/workflows/manual-backend-ci.yml
+++ b/.github/workflows/manual-backend-ci.yml
@@ -19,4 +19,4 @@ jobs:
         run: dotnet restore backend/PhotoBank.Backend.sln
 
       - name: Build (Release, no warn-as-error)
-        run: dotnet build backend/PhotoBank.Backend.sln -c Release -warnaserror- --no-restore
+        run: dotnet build backend/PhotoBank.Backend.sln -c Release -p:TreatWarningsAsErrors=false --no-restore


### PR DESCRIPTION
## Summary
- fix manual backend workflow to properly disable warnings-as-errors

## Testing
- `dotnet restore backend/PhotoBank.Backend.sln`
- `dotnet build backend/PhotoBank.Backend.sln -c Release -p:TreatWarningsAsErrors=false --no-restore` *(fails: CS4008, CS0019, CS0246, CS1662)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cf4051e88328a5a67386663b9e98