### PR TITLE
chore: remove Blazor project from backend solution

### DIFF
--- a/backend/PhotoBank.Backend.sln
+++ b/backend/PhotoBank.Backend.sln
@@ -15,8 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.UnitTests", "Phot
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.IntegrationTests", "PhotoBank.IntegrationTests\PhotoBank.IntegrationTests.csproj", "{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PhotoBank.ServerBlazorApp", "Photobank.ServerBlazorApp\PhotoBank.ServerBlazorApp.csproj", "{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoBank.Api", "PhotoBank.Api\PhotoBank.Api.csproj", "{3267B5DA-F866-471C-B496-2510EAED53E4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PhotoBank.ViewModel.Dto", "PhotoBank.ViewModel.Dto\PhotoBank.ViewModel.Dto.csproj", "{84FA7787-892C-45A8-8988-B21CBA3FE2AC}"
@@ -105,18 +103,6 @@ Global
 		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|x64.Build.0 = Release|x64
 		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|x86.ActiveCfg = Release|Any CPU
 		{CF28F8CA-E0F4-4DB1-95B2-DEEC8703EC1C}.Release|x86.Build.0 = Release|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|x64.Build.0 = Debug|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Debug|x86.Build.0 = Debug|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|x64.ActiveCfg = Release|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|x64.Build.0 = Release|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|x86.ActiveCfg = Release|Any CPU
-		{A21D0451-C13F-42FD-B0B2-2A5EEB4DFE5B}.Release|x86.Build.0 = Release|Any CPU
 		{3267B5DA-F866-471C-B496-2510EAED53E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3267B5DA-F866-471C-B496-2510EAED53E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3267B5DA-F866-471C-B496-2510EAED53E4}.Debug|x64.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
## Summary
- remove ServerBlazorApp project from backend solution

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln` (fails: Cannot await 'void')
- `dotnet test PhotoBank.Backend.sln` (fails: SQL Server connection; Cannot await 'void')

------
https://chatgpt.com/codex/tasks/task_e_68a6d356771883288e52d0b7edb20cc0