### PR TITLE
test: fix invalid await in dependency executor test

### DIFF
--- a/backend/PhotoBank.UnitTests/DependencyExecutorTests.cs
+++ b/backend/PhotoBank.UnitTests/DependencyExecutorTests.cs
@@ -132,7 +132,7 @@ namespace PhotoBank.UnitTests
             var executor = new DependencyExecutor();
 
             // Act & Assert
-            await Assert.DoesNotThrowAsync(() => executor.ExecuteAsync(enrichers, null, null));
+            Assert.DoesNotThrowAsync(async () => await executor.ExecuteAsync(enrichers, null, null));
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- remove invalid await in DependencyExecutorTests to restore compilation

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: 2 failed, 78 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d75915a883288b4e8e1879f33ab7