### PR TITLE
test: exclude dto models migrations from coverage

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
     <Nullable>enable</Nullable>
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory)coverlet.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 </Project>

--- a/backend/coverlet.runsettings
+++ b/backend/coverlet.runsettings
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>opencover</Format>
+          <Exclude>[PhotoBank.ViewModel.Dto]*,[PhotoBank.DbContext]*</Exclude>
+          <ExcludeByFile>**/Models/*.cs</ExcludeByFile>
+          <ExcludeByFile>**/Models/**/*.cs</ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary
- exclude DTOs, EF models and migrations from backend test coverage

## Testing
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --collect:"XPlat Code Coverage"`
- `dotnet test PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj --collect:"XPlat Code Coverage"` *(fails: SQL connection/migration)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fdb2c5708328b2870b5e4b53ffdf