### PR TITLE
fix: generate cobertura coverage

### DIFF
--- a/backend/coverlet.runsettings
+++ b/backend/coverlet.runsettings
@@ -4,7 +4,7 @@
     <DataCollectors>
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
-          <Format>opencover</Format>
+          <Format>cobertura</Format>
           <Exclude>[PhotoBank.ViewModel.Dto]*,[PhotoBank.DbContext]*</Exclude>
           <ExcludeByFile>**/Models/*.cs</ExcludeByFile>
           <ExcludeByFile>**/Models/**/*.cs</ExcludeByFile>


### PR DESCRIPTION
## Summary
- change code coverage format to cobetura

## Testing
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --collect:"XPlat Code Coverage" -s coverlet.runsettings` *(fails: Build failed with 154 warning(s))*

------
https://chatgpt.com/codex/tasks/task_e_68a70746eaf88328ad93b2c69360d6e5