### PR TITLE
test: add face recognition service tests

### DIFF
--- a/backend/PhotoBank.UnitTests/FaceRecognition/FaceProviderFactoryTests.cs
+++ b/backend/PhotoBank.UnitTests/FaceRecognition/FaceProviderFactoryTests.cs
@@ -1,0 +1,71 @@
+using Amazon.Rekognition;
+using Amazon.Runtime;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.Services.FaceRecognition;
+using PhotoBank.Services.FaceRecognition.Abstractions;
+using PhotoBank.Services.FaceRecognition.Aws;
+using PhotoBank.Services.FaceRecognition.Azure;
+using PhotoBank.Services.FaceRecognition.Local;
+
+namespace PhotoBank.UnitTests.FaceRecognition;
+
+[TestFixture]
+public class FaceProviderFactoryTests
+{
+    private ServiceProvider _sp = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<LocalInsightFaceProvider>(_ =>
+            new LocalInsightFaceProvider(
+                client: Mock.Of<ILocalInsightFaceClient>(),
+                embeddings: Mock.Of<IFaceEmbeddingRepository>(),
+                opts: Options.Create(new LocalInsightFaceOptions()),
+                log: Mock.Of<ILogger<LocalInsightFaceProvider>>()));
+
+        services.AddSingleton<AzureFaceProvider>(_ =>
+            new AzureFaceProvider(
+                client: Mock.Of<Microsoft.Azure.CognitiveServices.Vision.Face.IFaceClient>(),
+                opts: Options.Create(new AzureFaceOptions()),
+                log: Mock.Of<ILogger<AzureFaceProvider>>()));
+
+        services.AddSingleton<AwsFaceProvider>(_ =>
+            new AwsFaceProvider(
+                client: new AmazonRekognitionClient(new AnonymousAWSCredentials(), Amazon.RegionEndpoint.USEast1),
+                opts: Options.Create(new RekognitionOptions()),
+                log: Mock.Of<ILogger<AwsFaceProvider>>()));
+
+        _sp = services.BuildServiceProvider();
+    }
+
+    [TearDown]
+    public void TearDown() => _sp.Dispose();
+
+    [Test]
+    public void Get_WithExplicitKind_ReturnsCorrectProvider()
+    {
+        var opts = Options.Create(new FaceProviderOptions { Default = FaceProviderKind.Local });
+        var factory = new FaceProviderFactory(_sp, opts);
+
+        factory.Get(FaceProviderKind.Local).Should().BeOfType<LocalInsightFaceProvider>();
+        factory.Get(FaceProviderKind.Azure).Should().BeOfType<AzureFaceProvider>();
+        factory.Get(FaceProviderKind.Aws).Should().BeOfType<AwsFaceProvider>();
+    }
+
+    [Test]
+    public void Get_WithoutKind_UsesDefaultFromOptions()
+    {
+        var opts = Options.Create(new FaceProviderOptions { Default = FaceProviderKind.Aws });
+        var factory = new FaceProviderFactory(_sp, opts);
+
+        factory.Get().Should().BeOfType<AwsFaceProvider>();
+    }
+}

--- a/backend/PhotoBank.UnitTests/FaceRecognition/LocalInsightFaceProviderTests.cs
+++ b/backend/PhotoBank.UnitTests/FaceRecognition/LocalInsightFaceProviderTests.cs
@@ -1,0 +1,86 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.Services.FaceRecognition;
+using PhotoBank.Services.FaceRecognition.Abstractions;
+using PhotoBank.Services.FaceRecognition.Local;
+
+namespace PhotoBank.UnitTests.FaceRecognition;
+
+[TestFixture]
+public class LocalInsightFaceProviderTests
+{
+    private Mock<ILocalInsightFaceClient> _client = null!;
+    private Mock<IFaceEmbeddingRepository> _repo = null!;
+    private LocalInsightFaceProvider _provider = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _client = new Mock<ILocalInsightFaceClient>();
+        _repo = new Mock<IFaceEmbeddingRepository>();
+        var opts = Options.Create(new LocalInsightFaceOptions { FaceMatchThreshold = 0.5f, TopK = 2, MaxParallelism = 2 });
+        var logger = Mock.Of<ILogger<LocalInsightFaceProvider>>();
+        _provider = new LocalInsightFaceProvider(_client.Object, _repo.Object, opts, logger);
+    }
+
+    [Test]
+    public async Task UpsertPersonsAsync_ReturnsLocalIds()
+    {
+        var persons = new[]
+        {
+            new PersonSyncItem(1, "A", null),
+            new PersonSyncItem(2, "B", null)
+        };
+
+        var res = await _provider.UpsertPersonsAsync(persons, CancellationToken.None);
+        res.Should().Contain(new KeyValuePair<int,string>(1,"local:1"));
+        res.Should().Contain(new KeyValuePair<int,string>(2,"local:2"));
+    }
+
+    [Test]
+    public async Task LinkFacesToPersonAsync_EmbedsAndStoresVectors()
+    {
+        _client.SetupSequence(c => c.EmbedAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LocalEmbedResponse(new float[] { 2, 0 }, "m"))
+            .ReturnsAsync(new LocalEmbedResponse(new float[] { 0, 3 }, "m"));
+
+        var faces = new List<FaceToLink>
+        {
+            new(10, () => new MemoryStream(new byte[]{1}), null),
+            new(11, () => new MemoryStream(new byte[]{2}), null)
+        };
+
+        await _provider.LinkFacesToPersonAsync(5, faces, CancellationToken.None);
+
+        _client.Verify(c => c.EmbedAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _repo.Verify(r => r.UpsertAsync(5, 10, It.Is<float[]>(v => System.Math.Abs(v[0]-1f) < 1e-6 && System.Math.Abs(v[1]) < 1e-6), "m", It.IsAny<CancellationToken>()));
+        _repo.Verify(r => r.UpsertAsync(5, 11, It.Is<float[]>(v => System.Math.Abs(v[1]-1f) < 1e-6 && System.Math.Abs(v[0]) < 1e-6), "m", It.IsAny<CancellationToken>()));
+    }
+
+    [Test]
+    public async Task SearchUsersByImageAsync_ReturnsOrderedMatchesAboveThreshold()
+    {
+        _client.Setup(c => c.EmbedAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LocalEmbedResponse(new float[] { 1, 1 }, null));
+        _repo.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<(int, int, float[])>
+        {
+            (1, 1, new float[]{1,0}),
+            (2, 2, new float[]{0.70710677f,0.70710677f}),
+            (3, 3, new float[]{-1,0})
+        });
+
+        var res = await _provider.SearchUsersByImageAsync(new MemoryStream(new byte[]{1}), CancellationToken.None);
+
+        res.Should().HaveCount(2);
+        res[0].ProviderPersonId.Should().Be("local:2");
+        res[1].ProviderPersonId.Should().Be("local:1");
+    }
+}

--- a/backend/PhotoBank.UnitTests/FaceRecognition/UnifiedFaceServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/FaceRecognition/UnifiedFaceServiceTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+using PhotoBank.Services.FaceRecognition;
+using PhotoBank.Services.FaceRecognition.Abstractions;
+
+namespace PhotoBank.UnitTests.FaceRecognition;
+
+[TestFixture]
+public class UnifiedFaceServiceTests
+{
+    private Mock<IFaceProvider> _provider = null!;
+    private Mock<IRepository<Person>> _persons = null!;
+    private Mock<IRepository<Face>> _faces = null!;
+    private Mock<IRepository<PersonGroupFace>> _links = null!;
+    private UnifiedFaceService _service = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _provider = new Mock<IFaceProvider>();
+        _provider.SetupGet(p => p.Kind).Returns(FaceProviderKind.Local);
+
+        _persons = new Mock<IRepository<Person>>();
+        _faces = new Mock<IRepository<Face>>();
+        _links = new Mock<IRepository<PersonGroupFace>>();
+        var logger = Mock.Of<ILogger<UnifiedFaceService>>();
+
+        _service = new UnifiedFaceService(_provider.Object, _persons.Object, _faces.Object, _links.Object, logger);
+    }
+
+    [Test]
+    public async Task SyncPersonsAsync_UpsertsAndUpdatesRepository()
+    {
+        var people = new List<Person>
+        {
+            new() { Id = 1, Name = "Alice", Provider = null },
+            new() { Id = 2, Name = "Bob", Provider = "Local" },
+            new() { Id = 3, Name = "Charlie", Provider = "Azure" }
+        }.AsQueryable();
+        _persons.Setup(r => r.GetAll()).Returns(people);
+        _persons.Setup(r => r.UpdateAsync(It.IsAny<Person>(), It.IsAny<System.Linq.Expressions.Expression<System.Func<Person, object>>[]>())).ReturnsAsync(1);
+
+        _provider.Setup(p => p.UpsertPersonsAsync(It.IsAny<IReadOnlyCollection<PersonSyncItem>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, string> { { 1, "ext1" }, { 2, "ext2" } });
+
+        await _service.SyncPersonsAsync();
+
+        _provider.Verify(p => p.UpsertPersonsAsync(It.Is<IReadOnlyCollection<PersonSyncItem>>(c => c.Count == 2 && c.Any(x => x.PersonId == 1) && c.Any(x => x.PersonId == 2)), It.IsAny<CancellationToken>()), Times.Once);
+        _persons.Verify(r => r.UpdateAsync(It.Is<Person>(p => p.Id == 1 && p.ExternalId == "ext1" && p.Provider == "Local"), It.IsAny<System.Linq.Expressions.Expression<System.Func<Person, object>>[]>()), Times.Once);
+        _persons.Verify(r => r.UpdateAsync(It.Is<Person>(p => p.Id == 2 && p.ExternalId == "ext2" && p.Provider == "Local"), It.IsAny<System.Linq.Expressions.Expression<System.Func<Person, object>>[]>()), Times.Once);
+        _persons.Verify(r => r.UpdateAsync(It.Is<Person>(p => p.Id == 3), It.IsAny<System.Linq.Expressions.Expression<System.Func<Person, object>>[]>()), Times.Never);
+    }
+
+    [Test]
+    public async Task SyncFacesToPersonsAsync_LinksMissingFaces()
+    {
+        var linkData = new List<PersonGroupFace>
+        {
+            new() { PersonId = 1, FaceId = 101, ExternalId = null },
+            new() { PersonId = 1, FaceId = 102, ExternalId = "have" },
+            new() { PersonId = 2, FaceId = 201, ExternalId = null }
+        }.AsQueryable();
+        _links.Setup(r => r.GetAll()).Returns(linkData);
+        _links.Setup(r => r.UpdateAsync(It.IsAny<PersonGroupFace>(), It.IsAny<System.Linq.Expressions.Expression<System.Func<PersonGroupFace, object>>[]>())).ReturnsAsync(1);
+
+        var faceData = new List<Face>
+        {
+            new() { Id = 101, Image = new byte[] { 1 } },
+            new() { Id = 201, Image = new byte[] { 2 } }
+        }.AsQueryable();
+        _faces.Setup(r => r.GetAll()).Returns(faceData);
+
+        _provider.Setup(p => p.LinkFacesToPersonAsync(1, It.IsAny<IReadOnlyCollection<FaceToLink>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, string> { { 101, "extA" } });
+        _provider.Setup(p => p.LinkFacesToPersonAsync(2, It.IsAny<IReadOnlyCollection<FaceToLink>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, string> { { 201, "extB" } });
+
+        await _service.SyncFacesToPersonsAsync();
+
+        _provider.Verify(p => p.LinkFacesToPersonAsync(1, It.Is<IReadOnlyCollection<FaceToLink>>(l => l.Single().FaceId == 101), It.IsAny<CancellationToken>()), Times.Once);
+        _provider.Verify(p => p.LinkFacesToPersonAsync(2, It.Is<IReadOnlyCollection<FaceToLink>>(l => l.Single().FaceId == 201), It.IsAny<CancellationToken>()), Times.Once);
+        _links.Verify(r => r.UpdateAsync(It.Is<PersonGroupFace>(x => x.PersonId == 1 && x.FaceId == 101 && x.ExternalId == "extA" && x.Provider == "Local"), It.IsAny<System.Linq.Expressions.Expression<System.Func<PersonGroupFace, object>>[]>()), Times.Once);
+        _links.Verify(r => r.UpdateAsync(It.Is<PersonGroupFace>(x => x.PersonId == 2 && x.FaceId == 201 && x.ExternalId == "extB" && x.Provider == "Local"), It.IsAny<System.Linq.Expressions.Expression<System.Func<PersonGroupFace, object>>[]>()), Times.Once);
+    }
+
+    [Test]
+    public async Task DetectFacesAsync_ForwardsToProvider()
+    {
+        var bytes = new byte[] { 1, 2, 3 };
+        var expected = new List<DetectedFaceDto> { new("id", 0.9f, 20, "M") };
+        _provider.Setup(p => p.DetectAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+
+        var res = await _service.DetectFacesAsync(bytes);
+
+        res.Should().BeEquivalentTo(expected);
+        _provider.Verify(p => p.DetectAsync(It.Is<Stream>(s => s is MemoryStream), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- add DI factory tests for FaceRecognition providers
- cover UnifiedFaceService logic for syncing and detection
- test LocalInsightFaceProvider embedding and search logic

## Testing
- `dotnet restore PhotoBank.UnitTests/PhotoBank.UnitTests.csproj`
- `dotnet build PhotoBank.UnitTests/PhotoBank.UnitTests.csproj`
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build` *(fails: no test results output)*

------
https://chatgpt.com/codex/tasks/task_e_68a71172e0a083289e7f4069e22579a7