### PR TITLE
Add in-memory TestDbFactory helper

### DIFF
--- a/backend/PhotoBank.UnitTests/TestDbFactory.cs
+++ b/backend/PhotoBank.UnitTests/TestDbFactory.cs
@@ -1,0 +1,21 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using PhotoBank.DbContext.DbContext;
+
+namespace PhotoBank.UnitTests;
+
+public static class TestDbFactory
+{
+    public static PhotoBankDbContext CreateInMemory()
+    {
+        var options = new DbContextOptionsBuilder<PhotoBankDbContext>()
+            .UseInMemoryDatabase($"pb-tests-{Guid.NewGuid()}")
+            .EnableSensitiveDataLogging()
+            .EnableDetailedErrors()
+            .Options;
+
+        var ctx = new PhotoBankDbContext(options);
+        ctx.Database.EnsureCreated();
+        return ctx;
+    }
+}


### PR DESCRIPTION
## Summary
- add TestDbFactory utility to create in-memory PhotoBankDbContext for unit tests

## Testing
- `dotnet format backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --verify-no-changes --verbosity diagnostic`
- `MSBUILDTERMINALLOGGER=false dotnet restore backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj`
- `MSBUILDTERMINALLOGGER=false dotnet build backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj`
- `MSBUILDTERMINALLOGGER=false dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: The source 'IQueryable' doesn't implement 'IAsyncEnumerable')*


------
https://chatgpt.com/codex/tasks/task_e_68a7228f404883289a2eca91b2cd1dd6