### PR TITLE
fix: correct telegram bot import paths

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -19,6 +19,7 @@
     "bottleneck": "^2.19.5",
     "dotenv": "^17.2.1",
     "fetch-blob": "^4.0.0",
+    "date-fns": "^4.1.0",
     "grammy": "^1.37.0",
     "lru-cache": "^11.1.0",
     "p-retry": "^6.2.1",

--- a/frontend/packages/telegram-bot/src/commands/search.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.ts
@@ -1,10 +1,3 @@
-import type { MyContext } from "../i18n";
-
-import type {
-  FilterDto
-} from '../photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas';
-import { sendPhotosPage } from "./photosPage";
-
 import {
   parse as parseDfns,
   isValid,
@@ -15,6 +8,11 @@ import {
   format as formatDfns,
 } from "date-fns";
 
+import type { MyContext } from "../i18n";
+import type {
+  FilterDto
+} from "../api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas";
+import { sendPhotosPage } from "./photosPage";
 import type { FilterDraft } from "../services/resolvers";
 import { resolveHumanNamesToIds } from "../services/resolvers";
 

--- a/frontend/packages/telegram-bot/src/services/resolvers.ts
+++ b/frontend/packages/telegram-bot/src/services/resolvers.ts
@@ -1,14 +1,15 @@
 import type { Context } from "grammy";
-import type { FilterDto } } from '../photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas';
 
-// ⚠️ проверь путь: файл, который ты прислал, называется dictionary.ts и лежит рядом с i18n.
-// Если другая структура — поправь импорт.
+import type { MyContext } from "../i18n";
+import type {
+  FilterDto,
+} from "../api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas";
 import {
   setDictionariesUser,
   loadDictionaries,
   findBestPersonId,
   findBestTagId,
-} from "../dictionary";
+} from "../dictionaries";
 
 /** Черновик: как в прошлой версии — добавляем имена до резолва */
 export type FilterDraft = FilterDto & {
@@ -41,7 +42,7 @@ export async function resolveHumanNamesToIds(
   setDictionariesUser(userId, locale);
 
   // Подтянуть словари (кэшируется per-user внутри dictionary.ts)
-  await loadDictionaries(ctx as any);
+  await loadDictionaries(ctx as MyContext);
 
   const curTagIds = uniq(draft.tags ?? []);
   const curPersonIds = uniq(draft.persons ?? []);
@@ -60,11 +61,13 @@ export async function resolveHumanNamesToIds(
       .map((n) => findBestPersonId(n))
   ).filter((x): x is number => typeof x === "number");
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   const {
     tagNames: _dropTagNames,
     personNames: _dropPersonNames,
     ...rest
   } = draft;
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   return {
     ...rest,

--- a/frontend/packages/telegram-bot/test/searchCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/searchCommand.test.ts
@@ -1,24 +1,42 @@
 import { describe, it, expect, vi } from 'vitest';
 import * as searchCommands from '../src/commands/search';
 import * as photoService from '../src/services/photo';
+import * as resolvers from '../src/services/resolvers';
 import { i18n } from '../src/i18n';
 
 describe('handleSearch', () => {
   it('replies with usage when caption missing', async () => {
-    const ctx = { reply: vi.fn(), message: { text: '/search' }, t: (k: string) => i18n.t('en', k) } as any;
+    const ctx = {
+      reply: vi.fn(),
+      message: { text: '/search' },
+      from: { id: 1 },
+      t: (k: string) => i18n.t('en', k),
+    } as any;
     await searchCommands.handleSearch(ctx);
     expect(ctx.reply).toHaveBeenCalledWith(i18n.t('en', 'search-usage'));
   });
 
   it('replies with fallback message on API failure', async () => {
-    const ctx = { reply: vi.fn(), message: { text: '/search cats' }, t: (k: string) => i18n.t('en', k) } as any;
+    const ctx = {
+      reply: vi.fn(),
+      message: { text: '/search cats' },
+      from: { id: 1 },
+      t: (k: string) => i18n.t('en', k),
+    } as any;
+    vi.spyOn(resolvers, 'resolveHumanNamesToIds').mockImplementation(async (_ctx, d) => d as any);
     vi.spyOn(photoService, 'searchPhotos').mockRejectedValue(new Error('fail'));
     await searchCommands.handleSearch(ctx);
     expect(ctx.reply).toHaveBeenCalledWith(i18n.t('en', 'sorry-try-later'));
   });
 
   it('strips quotes around caption', async () => {
-    const ctx = { reply: vi.fn(), message: { text: '/search "dog cat"' }, t: (k: string) => i18n.t('en', k) } as any;
+    const ctx = {
+      reply: vi.fn(),
+      message: { text: '/search "dog cat"' },
+      from: { id: 1 },
+      t: (k: string) => i18n.t('en', k),
+    } as any;
+    vi.spyOn(resolvers, 'resolveHumanNamesToIds').mockImplementation(async (_ctx, d) => d as any);
     const searchSpy = vi
       .spyOn(photoService, 'searchPhotos')
       .mockResolvedValue({ data: { count: 0, photos: [] } } as any);


### PR DESCRIPTION
## Summary
- fix broken schema import paths in search command and resolver
- include date-fns runtime dependency
- adjust search tests for user context and resolver mocks

## Testing
- `pnpm lint`
- `API_BASE_URL=https://example.com pnpm test run test/searchCommand.test.ts test/searchPage.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a773cb241c83289afa25e3c4396387