### PR TITLE
fix: update telegram bot lockfile

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
       bottleneck:
         specifier: ^2.19.5
         version: 2.19.5
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1


### PR DESCRIPTION
## Summary
- sync `packages/telegram-bot` dependencies by regenerating lockfile

## Testing
- `pnpm -w test` *(fails: ELIFECYCLE Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a778175e7c832894741a3f3d388100