### PR TITLE
test: add coverage for UI components

### DIFF
--- a/frontend/packages/frontend/src/components/EmptyState.test.tsx
+++ b/frontend/packages/frontend/src/components/EmptyState.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import EmptyState from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders icon and text', () => {
+    const { container } = render(<EmptyState text="Nothing here" />);
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+    expect(container.querySelector('svg[aria-hidden="true"]')).toBeInTheDocument();
+  });
+});
+

--- a/frontend/packages/frontend/src/components/ScoreBar.test.tsx
+++ b/frontend/packages/frontend/src/components/ScoreBar.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ScoreBar } from './ScoreBar';
+
+describe('ScoreBar', () => {
+  it('displays label and percentage with correct width', () => {
+    const { container } = render(
+      <ScoreBar label="Accuracy" score={0.5} colorClass="bg-green-500" />
+    );
+
+    expect(screen.getByText('Accuracy')).toBeInTheDocument();
+    expect(screen.getByText('50.0%')).toBeInTheDocument();
+    const bar = container.querySelector('.flex-1 > div');
+    expect(bar).toHaveStyle({ width: '50.0%' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add EmptyState tests
- add ScoreBar tests

## Testing
- `pnpm --filter @photobank/frontend test --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8167aa51083288d5b341dadde8b52