### PR TITLE
test: add coverage reporting to frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "lint": "pnpm -r lint",
     "format": "pnpm -r format",
     "test": "pnpm -r --workspace-concurrency=1 test",
+    "test:coverage": "pnpm -r --workspace-concurrency=1 test:coverage",
     "generate:api": "orval --config ../orval.config.ts"
   },
   "keywords": [],

--- a/frontend/packages/frontend/package.json
+++ b/frontend/packages/frontend/package.json
@@ -13,6 +13,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:ci": "vitest --run --reporter=dot --coverage",
+    "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui"
   },
   "eslintConfig": {

--- a/frontend/packages/frontend/vitest.config.ts
+++ b/frontend/packages/frontend/vitest.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './test-setup.ts',
     globals: true,
-    css: true
+    css: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html']
+    }
   }
 });


### PR DESCRIPTION
## Summary
- enable v8 coverage reports in frontend Vitest config
- add `test:coverage` scripts for workspace and frontend package

## Testing
- `cd frontend && pnpm --filter @photobank/frontend lint`
- `cd frontend && pnpm test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a81a927dc48328b4fd0183f49017b9