### PR TITLE
feat: add language detector service and tests

### DIFF
--- a/backend/PhotoBank.Services/LanguageDetector.cs
+++ b/backend/PhotoBank.Services/LanguageDetector.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace PhotoBank.Services
+{
+    public static class LanguageDetector
+    {
+        /// <summary>
+        /// Detects whether the provided text contains predominantly Russian or English letters.
+        /// Returns "ru" for Russian, "en" for English, or "unknown" if neither language letters are found.
+        /// </summary>
+        /// <param name="text">Input text to analyze.</param>
+        /// <returns>"ru", "en" or "unknown".</returns>
+        public static string DetectRuEn(string? text)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return "unknown";
+            int cyr = 0, lat = 0;
+            foreach (char c in text)
+            {
+                if ((c >= 'А' && c <= 'я') || c is 'ё' or 'Ё') cyr++;
+                else if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) lat++;
+            }
+            if (cyr == 0 && lat == 0) return "unknown";
+            return cyr >= lat ? "ru" : "en";
+        }
+    }
+}

--- a/backend/PhotoBank.UnitTests/LanguageDetectorTests.cs
+++ b/backend/PhotoBank.UnitTests/LanguageDetectorTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using NUnit.Framework;
+using PhotoBank.Services;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class LanguageDetectorTests
+{
+    [TestCase(null, "unknown")]
+    [TestCase("", "unknown")]
+    [TestCase("!@#", "unknown")]
+    [TestCase("hello world", "en")]
+    [TestCase("привет мир", "ru")]
+    [TestCase("привет world", "ru")]
+    [TestCase("hello мир", "en")]
+    public void DetectRuEn_ReturnsExpectedLanguage(string? text, string expected)
+    {
+        var result = LanguageDetector.DetectRuEn(text);
+
+        result.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary
- add LanguageDetector service for simple Russian/English detection
- cover LanguageDetector with unit tests

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68a82b94c68483288fd25599f4872ce8