### PR TITLE
feat: add translator service

### DIFF
--- a/backend/PhotoBank.Api/appsettings.Development.json
+++ b/backend/PhotoBank.Api/appsettings.Development.json
@@ -10,6 +10,10 @@
     "Issuer": "PhotoBank.Api",
     "Audience": "PhotoBank.Api"
   },
+  "Translator": {
+    "Endpoint": "https://api.cognitive.microsofttranslator.com",
+    "Region": "westeurope"
+  },
   "Auth": {
     "Telegram": {
       "ServiceKey": "your-super-secret-service-key"

--- a/backend/PhotoBank.Api/appsettings.json
+++ b/backend/PhotoBank.Api/appsettings.json
@@ -62,6 +62,10 @@
     "IdentifyChunkSize": 10,
     "TrainTimeoutSeconds": 300
   },
+  "Translator": {
+    "Endpoint": "https://api.cognitive.microsofttranslator.com",
+    "Region": "westeurope"
+  },
   "Auth": {
     "Telegram": {
       "ServiceKey": "your-super-secret-service-key"

--- a/backend/PhotoBank.Console/PhotoBank.Console.csproj
+++ b/backend/PhotoBank.Console/PhotoBank.Console.csproj
@@ -15,18 +15,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="9.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
   </ItemGroup>

--- a/backend/PhotoBank.Console/appsettings.json
+++ b/backend/PhotoBank.Console/appsettings.json
@@ -10,6 +10,10 @@
     "Key": "",
     "Endpoint": ""
   },
+  "Translator": {
+    "Endpoint": "https://api.cognitive.microsofttranslator.com",
+    "Region": "westeurope"
+  },
   "CheckDuplicates": true,
   "Logging": {
     "LogLevel": {

--- a/backend/PhotoBank.Services/PhotoBank.Services.csproj
+++ b/backend/PhotoBank.Services/PhotoBank.Services.csproj
@@ -12,13 +12,15 @@
     <PackageReference Include="MetadataExtractor" Version="2.8.1" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="7.0.1" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.Face" Version="2.6.0-preview.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.7" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/PhotoBank.Services/RegisterServicesForApi.cs
+++ b/backend/PhotoBank.Services/RegisterServicesForApi.cs
@@ -1,8 +1,11 @@
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using PhotoBank.Repositories;
 using PhotoBank.Services.Api;
 using PhotoBank.AccessControl;
+using PhotoBank.Services.Translator;
+using Polly;
 
 namespace PhotoBank.Services
 {
@@ -16,6 +19,9 @@ namespace PhotoBank.Services
             services.TryAddScoped<ICurrentUser, DummyCurrentUser>();
             services.AddSingleton<ITokenService, TokenService>();
             services.AddSingleton<IImageService, ImageService>();
+            services.AddOptions<TranslatorOptions>().BindConfiguration("Translator");
+            services.AddHttpClient<ITranslatorService, TranslatorService>()
+                .AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, attempt => TimeSpan.FromMilliseconds(100 * attempt)));
         }
     }
 }

--- a/backend/PhotoBank.Services/RegisterServicesForConsole.cs
+++ b/backend/PhotoBank.Services/RegisterServicesForConsole.cs
@@ -11,8 +11,10 @@ using PhotoBank.Services.Api;
 using PhotoBank.Services.Enrichers;
 using PhotoBank.Services.Enrichers.Services;
 using PhotoBank.Services.Recognition;
+using PhotoBank.Services.Translator;
 using PhotoBank.AccessControl;
 using ApiKeyServiceClientCredentials = Microsoft.Azure.CognitiveServices.Vision.ComputerVision.ApiKeyServiceClientCredentials;
+using Polly;
 
 namespace PhotoBank.Services
 {
@@ -58,6 +60,9 @@ namespace PhotoBank.Services
             services.AddSingleton<ICurrentUser, DummyCurrentUser>();
             services.AddTransient<IImageService, ImageService>();
             services.AddTransient<ISyncService, SyncService>();
+            services.AddOptions<TranslatorOptions>().Bind(configuration.GetSection("Translator"));
+            services.AddHttpClient<ITranslatorService, TranslatorService>()
+                .AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, attempt => TimeSpan.FromMilliseconds(100 * attempt)));
 
             services.AddTransient<IEnricher, MetadataEnricher>();
             services.AddTransient<IEnricher, ThumbnailEnricher>();

--- a/backend/PhotoBank.Services/Translator/ITranslatorService.cs
+++ b/backend/PhotoBank.Services/Translator/ITranslatorService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PhotoBank.Services.Translator;
+
+public interface ITranslatorService
+{
+    Task<TranslateResponse> TranslateAsync(TranslateRequest req, CancellationToken ct = default);
+}
+

--- a/backend/PhotoBank.Services/Translator/TranslateRequest.cs
+++ b/backend/PhotoBank.Services/Translator/TranslateRequest.cs
@@ -1,0 +1,11 @@
+namespace PhotoBank.Services.Translator;
+
+public sealed record TranslateRequest(
+    string[] Texts,
+    string To,
+    string? From = null,
+    string TextType = "plain",
+    string? ProfanityAction = null,
+    string? Category = null
+);
+

--- a/backend/PhotoBank.Services/Translator/TranslateResponse.cs
+++ b/backend/PhotoBank.Services/Translator/TranslateResponse.cs
@@ -1,0 +1,4 @@
+namespace PhotoBank.Services.Translator;
+
+public sealed record TranslateResponse(string[] Translations);
+

--- a/backend/PhotoBank.Services/Translator/TranslatorOptions.cs
+++ b/backend/PhotoBank.Services/Translator/TranslatorOptions.cs
@@ -1,0 +1,9 @@
+namespace PhotoBank.Services.Translator;
+
+public sealed class TranslatorOptions
+{
+    public string Endpoint { get; init; } = "https://api.cognitive.microsofttranslator.com";
+    public string Region { get; init; } = "westeurope";
+    public string Key { get; init; } = ""; // comes from environment
+}
+

--- a/backend/PhotoBank.Services/Translator/TranslatorService.cs
+++ b/backend/PhotoBank.Services/Translator/TranslatorService.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace PhotoBank.Services.Translator;
+
+public sealed class TranslatorService(HttpClient http, IOptions<TranslatorOptions> opts) : ITranslatorService
+{
+    private readonly HttpClient _http = http;
+    private readonly TranslatorOptions _opts = opts.Value;
+
+    public async Task<TranslateResponse> TranslateAsync(TranslateRequest req, CancellationToken ct = default)
+    {
+        if (req.Texts is null || req.Texts.Length == 0)
+            return new TranslateResponse(Array.Empty<string>());
+
+        var query = new List<string> { "api-version=3.0", $"to={Uri.EscapeDataString(req.To)}" };
+        if (!string.IsNullOrWhiteSpace(req.From)) query.Add($"from={Uri.EscapeDataString(req.From)}");
+        if (!string.IsNullOrWhiteSpace(req.TextType)) query.Add($"textType={req.TextType}");
+        if (!string.IsNullOrWhiteSpace(req.ProfanityAction)) query.Add($"profanityAction={req.ProfanityAction}");
+        if (!string.IsNullOrWhiteSpace(req.Category)) query.Add($"category={Uri.EscapeDataString(req.Category)}");
+
+        var url = $"{_opts.Endpoint.TrimEnd('/')}/translate?{string.Join("&", query)}";
+
+        using var message = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(req.Texts.Select(t => new { Text = t }))
+        };
+
+        message.Headers.Add("Ocp-Apim-Subscription-Key", _opts.Key);
+        message.Headers.Add("Ocp-Apim-Subscription-Region", _opts.Region);
+
+        using var resp = await _http.SendAsync(message, ct);
+        var payload = await resp.Content.ReadAsStringAsync(ct);
+
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException($"Translator error {(int)resp.StatusCode}: {payload}");
+
+        using var doc = JsonDocument.Parse(payload);
+        var root = doc.RootElement;
+
+        var result = new List<string>(req.Texts.Length);
+        foreach (var item in root.EnumerateArray())
+        {
+            var tr = item.GetProperty("translations")[0];
+            result.Add(tr.GetProperty("text").GetString() ?? "");
+        }
+
+        return new TranslateResponse(result.ToArray());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Microsoft translation service with configurable options
- register TranslatorService with resilient HttpClient
- configure translator defaults for API and console apps

## Testing
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln` *(fails: A network-related or instance-specific error occurred while establishing a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_68a82f2741408328a5e8cccf4e3577b5