### PR TITLE
feat: add search filter normalization

### DIFF
--- a/backend/PhotoBank.Services/RegisterServicesForApi.cs
+++ b/backend/PhotoBank.Services/RegisterServicesForApi.cs
@@ -5,6 +5,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services.Api;
 using PhotoBank.AccessControl;
 using PhotoBank.Services.Translator;
+using PhotoBank.Services.Search;
 using Polly;
 
 namespace PhotoBank.Services
@@ -22,6 +23,7 @@ namespace PhotoBank.Services
             services.AddOptions<TranslatorOptions>().BindConfiguration("Translator");
             services.AddHttpClient<ITranslatorService, TranslatorService>()
                 .AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, attempt => TimeSpan.FromMilliseconds(100 * attempt)));
+            services.AddSingleton<ISearchFilterNormalizer, SearchFilterNormalizer>();
         }
     }
 }

--- a/backend/PhotoBank.Services/RegisterServicesForConsole.cs
+++ b/backend/PhotoBank.Services/RegisterServicesForConsole.cs
@@ -12,6 +12,7 @@ using PhotoBank.Services.Enrichers;
 using PhotoBank.Services.Enrichers.Services;
 using PhotoBank.Services.Recognition;
 using PhotoBank.Services.Translator;
+using PhotoBank.Services.Search;
 using PhotoBank.AccessControl;
 using ApiKeyServiceClientCredentials = Microsoft.Azure.CognitiveServices.Vision.ComputerVision.ApiKeyServiceClientCredentials;
 using Polly;
@@ -63,6 +64,7 @@ namespace PhotoBank.Services
             services.AddOptions<TranslatorOptions>().Bind(configuration.GetSection("Translator"));
             services.AddHttpClient<ITranslatorService, TranslatorService>()
                 .AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, attempt => TimeSpan.FromMilliseconds(100 * attempt)));
+            services.AddSingleton<ISearchFilterNormalizer, SearchFilterNormalizer>();
 
             services.AddTransient<IEnricher, MetadataEnricher>();
             services.AddTransient<IEnricher, ThumbnailEnricher>();

--- a/backend/PhotoBank.Services/Search/ISearchFilterNormalizer.cs
+++ b/backend/PhotoBank.Services/Search/ISearchFilterNormalizer.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Services.Search;
+
+public interface ISearchFilterNormalizer
+{
+    Task<FilterDto> NormalizeAsync(FilterDto filter, CancellationToken ct = default);
+}

--- a/backend/PhotoBank.Services/Search/SearchFilterNormalizer.cs
+++ b/backend/PhotoBank.Services/Search/SearchFilterNormalizer.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using PhotoBank.Services.Translator;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Services.Search;
+
+public sealed class SearchFilterNormalizer(
+    ITranslatorService translator,
+    IMemoryCache cache
+) : ISearchFilterNormalizer
+{
+    public async Task<FilterDto> NormalizeAsync(FilterDto filter, CancellationToken ct = default)
+    {
+        var items = new List<(string Value, Action<string> Apply)>(capacity: 1);
+
+        if (!string.IsNullOrWhiteSpace(filter.Caption) && LanguageDetector.DetectRuEn(filter.Caption) == "ru")
+        {
+            var original = filter.Caption!;
+            items.Add((original, translated => filter.Caption = translated));
+        }
+
+        if (items.Count == 0) return filter;
+
+        var unique = items.Select(x => x.Value).Distinct(StringComparer.Ordinal).ToArray();
+
+        var toTranslate = new List<string>(unique.Length);
+        var resolved = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var phrase in unique)
+        {
+            var key = CacheKey(phrase);
+            if (cache.TryGetValue<string>(key, out var cached))
+            {
+                resolved[phrase] = cached;
+            }
+            else
+            {
+                toTranslate.Add(phrase);
+            }
+        }
+
+        if (toTranslate.Count > 0)
+        {
+            var result = await translator.TranslateAsync(
+                new TranslateRequest(
+                    Texts: toTranslate.ToArray(),
+                    To: "en",
+                    From: "ru",
+                    TextType: "plain"
+                ),
+                ct
+            );
+
+            for (int i = 0; i < toTranslate.Count; i++)
+            {
+                var src = toTranslate[i];
+                var dst = result.Translations[i];
+
+                resolved[src] = dst;
+                cache.Set(CacheKey(src), dst, TimeSpan.FromHours(12));
+            }
+        }
+
+        foreach (var (value, apply) in items)
+        {
+            var translated = resolved[value];
+            apply(translated);
+        }
+
+        return filter;
+    }
+
+    private static string CacheKey(string text)
+    {
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes("ru->en|" + text));
+        return "translate:" + Convert.ToHexString(bytes);
+    }
+}

--- a/backend/PhotoBank.UnitTests/Services/SearchFilterNormalizerTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/SearchFilterNormalizerTests.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.Services.Search;
+using PhotoBank.Services.Translator;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.UnitTests.Services;
+
+[TestFixture]
+public class SearchFilterNormalizerTests
+{
+    [Test]
+    public async Task NormalizeAsync_TranslatesAndCachesRussianPhrases()
+    {
+        var translator = new Mock<ITranslatorService>();
+        translator
+            .Setup(t => t.TranslateAsync(It.IsAny<TranslateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TranslateRequest req, CancellationToken _) =>
+                new TranslateResponse(req.Texts.Select(x => x + "_en").ToArray()));
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var normalizer = new SearchFilterNormalizer(translator.Object, cache);
+
+        var normalized1 = await normalizer.NormalizeAsync(new FilterDto { Caption = "Привет" });
+        normalized1.Caption.Should().Be("Привет_en");
+        translator.Verify(t => t.TranslateAsync(It.IsAny<TranslateRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        var normalized2 = await normalizer.NormalizeAsync(new FilterDto { Caption = "Привет" });
+        normalized2.Caption.Should().Be("Привет_en");
+        translator.Verify(t => t.TranslateAsync(It.IsAny<TranslateRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- replace custom search filter types with existing `FilterDto`
- normalize `FilterDto` captions with translation and caching
- adjust unit test for `FilterDto` normalization

## Testing
- `dotnet restore PhotoBank.Backend.sln` *(fails: Failed to download package 'Magick.NET-Q8-AnyCPU.14.7.0')*
- `dotnet build PhotoBank.Backend.sln` *(fails: Restore canceled due to missing packages)*
- `dotnet test PhotoBank.Backend.sln` *(fails: could not complete build due to previous restore errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a83281ba70832899b9dc8fd1a28959