### PR TITLE
feat: allow filtering by person and tag names

### DIFF
--- a/backend/PhotoBank.UnitTests/FilterDtoTests.cs
+++ b/backend/PhotoBank.UnitTests/FilterDtoTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using PhotoBank.ViewModel.Dto;
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace PhotoBank.Tests.ViewModel.Dto
 {
@@ -55,12 +56,44 @@ namespace PhotoBank.Tests.ViewModel.Dto
         }
 
         [Test]
+        public void IsNotEmpty_ShouldReturnTrue_WhenPersonNamesIsNotEmpty()
+        {
+            // Arrange
+            var filterDto = new FilterDto
+            {
+                PersonNames = new[] { "John" }
+            };
+
+            // Act
+            var result = filterDto.IsNotEmpty();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
         public void IsNotEmpty_ShouldReturnTrue_WhenTagsIsNotEmpty()
         {
             // Arrange
             var filterDto = new FilterDto
             {
                 Tags = new List<int> { 1 }
+            };
+
+            // Act
+            var result = filterDto.IsNotEmpty();
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void IsNotEmpty_ShouldReturnTrue_WhenTagNamesIsNotEmpty()
+        {
+            // Arrange
+            var filterDto = new FilterDto
+            {
+                TagNames = new[] { "Nature" }
             };
 
             // Act
@@ -212,6 +245,38 @@ namespace PhotoBank.Tests.ViewModel.Dto
 
             // Assert
             result.Should().BeTrue();
+        }
+
+        [Test]
+        public void Persons_ShouldBeIgnoredDuringSerialization()
+        {
+            var filterDto = new FilterDto
+            {
+                Persons = new List<int> { 1 }
+            };
+
+            var json = JsonSerializer.Serialize(filterDto, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            });
+
+            json.Should().NotContain("persons").And.NotContain("Persons");
+        }
+
+        [Test]
+        public void Tags_ShouldBeIgnoredDuringSerialization()
+        {
+            var filterDto = new FilterDto
+            {
+                Tags = new List<int> { 1 }
+            };
+
+            var json = JsonSerializer.Serialize(filterDto, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            });
+
+            json.Should().NotContain("tags").And.NotContain("Tags");
         }
     }
 }

--- a/backend/PhotoBank.ViewModel.Dto/FilterDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/FilterDto.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace PhotoBank.ViewModel.Dto
 {
@@ -16,8 +17,12 @@ namespace PhotoBank.ViewModel.Dto
         public DateTime? TakenDateFrom { get; set; }
         public DateTime? TakenDateTo { get; set; }
         public ThisDayDto? ThisDay { get; set; }
+        [JsonIgnore]
         public IEnumerable<int>? Persons { get; set; }
+        public string[]? PersonNames { get; set; }
+        [JsonIgnore]
         public IEnumerable<int>? Tags { get; set; }
+        public string[]? TagNames { get; set; }
 
         public string? OrderBy { get; set; }
 
@@ -25,7 +30,9 @@ namespace PhotoBank.ViewModel.Dto
         {
             return (Storages != null && Storages.Any())
                    || (Persons != null && Persons.Any())
+                   || (PersonNames != null && PersonNames.Any())
                    || (Tags != null && Tags.Any())
+                   || (TagNames != null && TagNames.Any())
                    || (Paths != null && Paths.Any())
                    || !string.IsNullOrEmpty(RelativePath)
                    || IsBW.HasValue


### PR DESCRIPTION
## Summary
- support filtering by person and tag names in FilterDto
- test IsNotEmpty for new person and tag name properties
- ignore tag and person ID filters during serialization

## Testing
- `dotnet restore backend/PhotoBank.Backend.sln`
- `dotnet build backend/PhotoBank.Backend.sln`
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: could not open a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_68a850daf10c8328af91ead2aff2dbe1