### PR TITLE
chore: regenerate API schemas

### DIFF
--- a/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
+++ b/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
@@ -107,9 +107,9 @@ export interface FilterDto {
   takenDateTo?: string | null;
   thisDay?: ThisDayDto;
   /** @nullable */
-  persons?: number[] | null;
+  personNames?: string[] | null;
   /** @nullable */
-  tags?: number[] | null;
+  tagNames?: string[] | null;
   /** @nullable */
   orderBy?: string | null;
 }

--- a/frontend/packages/telegram-bot/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
@@ -107,9 +107,9 @@ export interface FilterDto {
   takenDateTo?: string | null;
   thisDay?: ThisDayDto;
   /** @nullable */
-  persons?: number[] | null;
+  personNames?: string[] | null;
   /** @nullable */
-  tags?: number[] | null;
+  tagNames?: string[] | null;
   /** @nullable */
   orderBy?: string | null;
 }


### PR DESCRIPTION
## Summary
- regenerate orval API schemas using updated FilterDto properties

## Testing
- `pnpm -w install`
- `pnpm run generate:api`
- `pnpm -w build` *(fails: packages/frontend build failed)*
- `pnpm --filter @photobank/shared test`
- `pnpm --filter @photobank/frontend test:ci`
- `pnpm --filter @photobank/telegram-bot test -- --run` *(tests pass but run requires manual cancellation)*

------
https://chatgpt.com/codex/tasks/task_e_68a8baa0d4588328a766a688e30db5c3