### PR TITLE
feat: add person group management endpoints

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PersonGroupsController.cs
+++ b/backend/PhotoBank.Api/Controllers/PersonGroupsController.cs
@@ -1,0 +1,53 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PhotoBank.Services.Api;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Api.Controllers;
+
+[Route("[controller]")]
+[ApiController]
+[Authorize]
+public class PersonGroupsController(IPhotoService photoService) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType(typeof(IEnumerable<PersonGroupDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<PersonGroupDto>>> GetAllAsync()
+    {
+        var groups = await photoService.GetAllPersonGroupsAsync();
+        return Ok(groups);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(PersonGroupDto), StatusCodes.Status201Created)]
+    public async Task<ActionResult<PersonGroupDto>> CreateAsync(PersonGroupDto dto)
+    {
+        var group = await photoService.CreatePersonGroupAsync(dto.Name);
+        return CreatedAtAction(nameof(GetAllAsync), new { }, group);
+    }
+
+    [HttpDelete("{groupId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> DeleteAsync(int groupId)
+    {
+        await photoService.DeletePersonGroupAsync(groupId);
+        return NoContent();
+    }
+
+    [HttpPost("{groupId}/persons/{personId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> AddPersonAsync(int groupId, int personId)
+    {
+        await photoService.AddPersonToGroupAsync(groupId, personId);
+        return NoContent();
+    }
+
+    [HttpDelete("{groupId}/persons/{personId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> RemovePersonAsync(int groupId, int personId)
+    {
+        await photoService.RemovePersonFromGroupAsync(groupId, personId);
+        return NoContent();
+    }
+}
+

--- a/backend/PhotoBank.Services/MappingProfile.cs
+++ b/backend/PhotoBank.Services/MappingProfile.cs
@@ -51,6 +51,9 @@ namespace PhotoBank.Services
             CreateMap<Person, PersonDto>()
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
+            CreateMap<PersonGroup, PersonGroupDto>()
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
             CreateMap<Face, ViewModel.Dto.FaceDto>()
                 .ForMember(dest => dest.PersonId, opt => opt.MapFrom(src => src.Person == null ? (int?)null : src.Person.Id))
                 .ForMember(dest => dest.FaceBox, opt => opt.MapFrom(src => FaceHelper.GetFaceBox(src.Rectangle, src.Photo)))

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Caching.Memory;
+using AutoMapper;
+using NUnit.Framework;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+using PhotoBank.Services;
+using PhotoBank.Services.Api;
+using PhotoBank.AccessControl;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class PersonGroupServiceTests
+{
+    private ServiceProvider _provider = null!;
+    private IPhotoService _service = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<PhotoBankDbContext>(o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
+        services.AddMemoryCache();
+        services.AddAutoMapper(cfg => cfg.AddProfile<MappingProfile>());
+        services.AddScoped<ICurrentUser, DummyCurrentUser>();
+        _provider = services.BuildServiceProvider();
+
+        var db = _provider.GetRequiredService<PhotoBankDbContext>();
+        db.Persons.Add(new Person { Id = 1, Name = "John" });
+        db.PersonGroups.Add(new PersonGroup { Id = 1, Name = "Family" });
+        db.SaveChanges();
+
+        _service = new PhotoService(
+            db,
+            _provider.GetRequiredService<IRepository<Photo>>(),
+            _provider.GetRequiredService<IRepository<Person>>(),
+            _provider.GetRequiredService<IRepository<Face>>(),
+            _provider.GetRequiredService<IRepository<Storage>>(),
+            _provider.GetRequiredService<IRepository<Tag>>(),
+            _provider.GetRequiredService<IRepository<PersonGroup>>(),
+            _provider.GetRequiredService<IMapper>(),
+            _provider.GetRequiredService<IMemoryCache>(),
+            _provider.GetRequiredService<ICurrentUser>()
+        );
+    }
+
+    [TearDown]
+    public void TearDown() => _provider.Dispose();
+
+    [Test]
+    public async Task AddPersonToGroupAsync_AddsLink()
+    {
+        await _service.AddPersonToGroupAsync(1, 1);
+        var db = _provider.GetRequiredService<PhotoBankDbContext>();
+        var person = await db.Persons.Include(p => p.PersonGroups).SingleAsync(p => p.Id == 1);
+        person.PersonGroups.Should().ContainSingle(g => g.Id == 1);
+    }
+
+    [Test]
+    public async Task RemovePersonFromGroupAsync_RemovesLink()
+    {
+        await _service.AddPersonToGroupAsync(1, 1);
+        await _service.RemovePersonFromGroupAsync(1, 1);
+        var db = _provider.GetRequiredService<PhotoBankDbContext>();
+        var person = await db.Persons.Include(p => p.PersonGroups).SingleAsync(p => p.Id == 1);
+        person.PersonGroups.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetAllPersonGroupsAsync_ReturnsGroup()
+    {
+        var groups = await _service.GetAllPersonGroupsAsync();
+        groups.Should().ContainSingle(g => g.Name == "Family");
+    }
+}
+

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -52,6 +52,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Face>(provider),
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
+                new Repository<PersonGroup>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser());

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -52,6 +52,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Face>(provider),
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
+                new Repository<PersonGroup>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser());
@@ -88,6 +89,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Face>(provider),
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
+                new Repository<PersonGroup>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser());
@@ -128,6 +130,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Face>(provider),
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
+                new Repository<PersonGroup>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser());

--- a/backend/PhotoBank.ViewModel.Dto/PersonGroupDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/PersonGroupDto.cs
@@ -1,0 +1,12 @@
+namespace PhotoBank.ViewModel.Dto
+{
+    public class PersonGroupDto
+    {
+        [System.ComponentModel.DataAnnotations.Required]
+        public int Id { get; set; }
+
+        [System.ComponentModel.DataAnnotations.Required]
+        public required string Name { get; set; } = default!;
+    }
+}
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -461,6 +461,114 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PathDto'
+  /persongroups:
+    get:
+      tags:
+        - PersonGroups
+      operationId: PersonGroups_GetAll
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PersonGroupDto'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PersonGroupDto'
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PersonGroupDto'
+    post:
+      tags:
+        - PersonGroups
+      operationId: PersonGroups_Create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PersonGroupDto'
+          text/json:
+            schema:
+              $ref: '#/components/schemas/PersonGroupDto'
+          application/*+json:
+            schema:
+              $ref: '#/components/schemas/PersonGroupDto'
+      responses:
+        '201':
+          description: Created
+          content:
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/PersonGroupDto'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PersonGroupDto'
+            text/json:
+              schema:
+                $ref: '#/components/schemas/PersonGroupDto'
+  '/persongroups/{groupId}':
+    delete:
+      tags:
+        - PersonGroups
+      operationId: PersonGroups_Delete
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '204':
+          description: No Content
+  '/persongroups/{groupId}/persons/{personId}':
+    post:
+      tags:
+        - PersonGroups
+      operationId: PersonGroups_AddPerson
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: personId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '204':
+          description: No Content
+    delete:
+      tags:
+        - PersonGroups
+      operationId: PersonGroups_RemovePerson
+      parameters:
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: personId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '204':
+          description: No Content
   /persons:
     get:
       tags:
@@ -1218,6 +1326,19 @@ components:
           type: string
       additionalProperties: false
     PersonDto:
+      required:
+        - id
+        - name
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          minLength: 1
+          type: string
+      additionalProperties: false
+    PersonGroupDto:
       required:
         - id
         - name


### PR DESCRIPTION
## Summary
- extend service and OpenAPI to expose person group CRUD and membership endpoints
- add controller to manage person groups and person assignments
- cover new service logic with unit tests
- regenerate OpenAPI spec via `dotnet swagger`

## Testing
- `dotnet restore backend/PhotoBank.Backend.sln`
- `dotnet build backend/PhotoBank.Backend.sln`
- `dotnet swagger tofile --yaml --output ../../openapi.yaml bin/Debug/net9.0/PhotoBank.Api.dll v1`
- `dotnet test backend/PhotoBank.Backend.sln` *(fails: A network-related or instance-specific error occurred while establishing a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_68a97a3fcc2483289c3b8b5a78ab8d95