### PR TITLE
feat: restrict person management to admins

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PersonGroupsController.cs
+++ b/backend/PhotoBank.Api/Controllers/PersonGroupsController.cs
@@ -7,7 +7,7 @@ namespace PhotoBank.Api.Controllers;
 
 [Route("[controller]")]
 [ApiController]
-[Authorize]
+[Authorize(Roles = "Admin")]
 public class PersonGroupsController(IPhotoService photoService) : ControllerBase
 {
     [HttpGet]
@@ -24,6 +24,16 @@ public class PersonGroupsController(IPhotoService photoService) : ControllerBase
     {
         var group = await photoService.CreatePersonGroupAsync(dto.Name);
         return CreatedAtAction(nameof(GetAllAsync), new { }, group);
+    }
+
+    [HttpPut("{groupId}")]
+    [ProducesResponseType(typeof(PersonGroupDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<PersonGroupDto>> UpdateAsync(int groupId, PersonGroupDto dto)
+    {
+        if (dto.Id != groupId)
+            return BadRequest();
+        var group = await photoService.UpdatePersonGroupAsync(groupId, dto.Name);
+        return Ok(group);
     }
 
     [HttpDelete("{groupId}")]

--- a/backend/PhotoBank.Api/Controllers/PersonsController.cs
+++ b/backend/PhotoBank.Api/Controllers/PersonsController.cs
@@ -7,7 +7,7 @@ namespace PhotoBank.Api.Controllers;
 
 [Route("[controller]")]
 [ApiController]
-[Authorize]
+[Authorize(Roles = "Admin")]
 public class PersonsController(IPhotoService photoService) : ControllerBase
 {
     [HttpGet]
@@ -16,5 +16,31 @@ public class PersonsController(IPhotoService photoService) : ControllerBase
     {
         var persons = await photoService.GetAllPersonsAsync();
         return Ok(persons);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(PersonDto), StatusCodes.Status201Created)]
+    public async Task<ActionResult<PersonDto>> CreateAsync(PersonDto dto)
+    {
+        var person = await photoService.CreatePersonAsync(dto.Name);
+        return CreatedAtAction(nameof(GetAllAsync), new { }, person);
+    }
+
+    [HttpPut("{personId}")]
+    [ProducesResponseType(typeof(PersonDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<PersonDto>> UpdateAsync(int personId, PersonDto dto)
+    {
+        if (dto.Id != personId)
+            return BadRequest();
+        var person = await photoService.UpdatePersonAsync(personId, dto.Name);
+        return Ok(person);
+    }
+
+    [HttpDelete("{personId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> DeleteAsync(int personId)
+    {
+        await photoService.DeletePersonAsync(personId);
+        return NoContent();
     }
 }


### PR DESCRIPTION
## Summary
- limit person and person-group management endpoints to admin role
- add CRUD endpoints for persons and person groups
- extend photo service with person CRUD and group update helpers

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln` *(fails: Could not open connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_68a98f7ebdb483289bb3ca3344da8045