### PR TITLE
feat: add face image to person-group face dto

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PersonGroupFacesController.cs
+++ b/backend/PhotoBank.Api/Controllers/PersonGroupFacesController.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PhotoBank.Services.Api;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Api.Controllers;
+
+[Route("[controller]")]
+[ApiController]
+[Authorize(Roles = "Admin")]
+public class PersonGroupFacesController(IPhotoService photoService) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType(typeof(IEnumerable<PersonGroupFaceDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<PersonGroupFaceDto>>> GetAllAsync()
+    {
+        var links = await photoService.GetAllPersonGroupFacesAsync();
+        return Ok(links);
+    }
+
+    [HttpPost]
+    [ProducesResponseType(typeof(PersonGroupFaceDto), StatusCodes.Status201Created)]
+    public async Task<ActionResult<PersonGroupFaceDto>> CreateAsync(PersonGroupFaceDto dto)
+    {
+        var link = await photoService.CreatePersonGroupFaceAsync(dto);
+        return CreatedAtAction(nameof(GetAllAsync), new { }, link);
+    }
+
+    [HttpPut("{id}")]
+    [ProducesResponseType(typeof(PersonGroupFaceDto), StatusCodes.Status200OK)]
+    public async Task<ActionResult<PersonGroupFaceDto>> UpdateAsync(int id, PersonGroupFaceDto dto)
+    {
+        if (dto.Id != id)
+            return BadRequest();
+        var link = await photoService.UpdatePersonGroupFaceAsync(id, dto);
+        return Ok(link);
+    }
+
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> DeleteAsync(int id)
+    {
+        await photoService.DeletePersonGroupFaceAsync(id);
+        return NoContent();
+    }
+}

--- a/backend/PhotoBank.Services/MappingProfile.cs
+++ b/backend/PhotoBank.Services/MappingProfile.cs
@@ -54,6 +54,14 @@ namespace PhotoBank.Services
             CreateMap<PersonGroup, PersonGroupDto>()
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
+            CreateMap<PersonGroupFace, PersonGroupFaceDto>()
+                .ForMember(dest => dest.FaceImage, opt => opt.MapFrom(src => src.Face.Image))
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
+            CreateMap<PersonGroupFaceDto, PersonGroupFace>()
+                .ForSourceMember(src => src.FaceImage, opt => opt.DoNotValidate())
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
             CreateMap<Face, ViewModel.Dto.FaceDto>()
                 .ForMember(dest => dest.PersonId, opt => opt.MapFrom(src => src.Person == null ? (int?)null : src.Person.Id))
                 .ForMember(dest => dest.FaceBox, opt => opt.MapFrom(src => FaceHelper.GetFaceBox(src.Rectangle, src.Photo)))

--- a/backend/PhotoBank.UnitTests/PersonGroupFaceMappingTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupFaceMappingTests.cs
@@ -1,0 +1,40 @@
+using AutoMapper;
+using FluentAssertions;
+using NUnit.Framework;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services;
+using PhotoBank.ViewModel.Dto;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class PersonGroupFaceMappingTests
+{
+    private IMapper _mapper = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var services = new ServiceCollection();
+        services.AddAutoMapper(cfg => cfg.AddProfile<MappingProfile>());
+        var provider = services.BuildServiceProvider();
+        _mapper = provider.GetRequiredService<IMapper>();
+    }
+
+    [Test]
+    public void MapsFaceImage()
+    {
+        var entity = new PersonGroupFace
+        {
+            Id = 1,
+            PersonId = 2,
+            FaceId = 3,
+            Face = new Face { Image = new byte[] { 1, 2, 3 } }
+        };
+
+        var dto = _mapper.Map<PersonGroupFaceDto>(entity);
+
+        dto.FaceImage.Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
+    }
+}

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -38,18 +38,19 @@ public class PersonGroupServiceTests
         db.PersonGroups.Add(new PersonGroup { Id = 1, Name = "Family" });
         db.SaveChanges();
 
-        _service = new PhotoService(
-            db,
-            _provider.GetRequiredService<IRepository<Photo>>(),
-            _provider.GetRequiredService<IRepository<Person>>(),
-            _provider.GetRequiredService<IRepository<Face>>(),
-            _provider.GetRequiredService<IRepository<Storage>>(),
-            _provider.GetRequiredService<IRepository<Tag>>(),
-            _provider.GetRequiredService<IRepository<PersonGroup>>(),
-            _provider.GetRequiredService<IMapper>(),
-            _provider.GetRequiredService<IMemoryCache>(),
-            _provider.GetRequiredService<ICurrentUser>()
-        );
+            _service = new PhotoService(
+                db,
+                _provider.GetRequiredService<IRepository<Photo>>(),
+                _provider.GetRequiredService<IRepository<Person>>(),
+                _provider.GetRequiredService<IRepository<Face>>(),
+                _provider.GetRequiredService<IRepository<Storage>>(),
+                _provider.GetRequiredService<IRepository<Tag>>(),
+                _provider.GetRequiredService<IRepository<PersonGroup>>(),
+                _provider.GetRequiredService<IRepository<PersonGroupFace>>(),
+                _provider.GetRequiredService<IMapper>(),
+                _provider.GetRequiredService<IMemoryCache>(),
+                _provider.GetRequiredService<ICurrentUser>()
+            );
     }
 
     [TearDown]

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -53,6 +53,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 new Repository<PersonGroup>(provider),
+                new Repository<PersonGroupFace>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser());

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -53,6 +53,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 new Repository<PersonGroup>(provider),
+                new Repository<PersonGroupFace>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser());
@@ -90,6 +91,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 new Repository<PersonGroup>(provider),
+                new Repository<PersonGroupFace>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser());
@@ -131,6 +133,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<Storage>(provider),
                 new Repository<Tag>(provider),
                 new Repository<PersonGroup>(provider),
+                new Repository<PersonGroupFace>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser());

--- a/backend/PhotoBank.ViewModel.Dto/PersonGroupFaceDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/PersonGroupFaceDto.cs
@@ -1,0 +1,19 @@
+namespace PhotoBank.ViewModel.Dto
+{
+    public class PersonGroupFaceDto
+    {
+        public int Id { get; set; }
+
+        [System.ComponentModel.DataAnnotations.Required]
+        public int PersonId { get; set; }
+
+        [System.ComponentModel.DataAnnotations.Required]
+        public int FaceId { get; set; }
+
+        public byte[]? FaceImage { get; set; }
+
+        public string? Provider { get; set; }
+        public string? ExternalId { get; set; }
+        public System.Guid ExternalGuid { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- include `FaceImage` on `PersonGroupFaceDto` and map it from the associated `Face`
- add unit test ensuring person-group face mapping carries image bytes

## Testing
- `dotnet restore backend/PhotoBank.Backend.sln`
- `dotnet build backend/PhotoBank.Backend.sln`
- `dotnet test backend/PhotoBank.Backend.sln --no-build -v m` *(fails: A network-related or instance-specific error occurred while establishing a connection to SQL Server)*

------
https://chatgpt.com/codex/tasks/task_e_68a99eec407483289d6abcbbb6e3c6ee