### PR TITLE
test: register logging in PersonFaceMappingTests

### DIFF
--- a/backend/PhotoBank.UnitTests/PersonFaceMappingTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonFaceMappingTests.cs
@@ -17,6 +17,7 @@ public class PersonFaceMappingTests
     public void Setup()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddAutoMapper(cfg => cfg.AddProfile<MappingProfile>());
         var provider = services.BuildServiceProvider();
         _mapper = provider.GetRequiredService<IMapper>();


### PR DESCRIPTION
## Summary
- add logging service registration to PersonFaceMappingTests to satisfy AutoMapper dependencies

## Testing
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68aab6b313548328b7c2ef69556c49f1