### PR TITLE
fix: include identity status when updating face

### DIFF
--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -419,11 +419,12 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                                         personId={face.personId ?? undefined}
                                                         persons={persons}
                                                         disabled={!showFaceBoxes || !isAdmin}
-                                                          onChange={(personId) => {
+                                                      onChange={(personId) => {
                                                               void updateFace({
                                                                   data: {
                                                                       faceId: face.id!,
-                                                                      personId: personId ?? -1,
+                                                                      personId: personId ?? null,
+                                                                      identityStatus: personId == null ? 5 : 3,
                                                                   },
                                                               });
                                                           }}


### PR DESCRIPTION
## Summary
- add required `identityStatus` when updating face identity

## Testing
- `cd frontend && pnpm build`
- `cd frontend && pnpm --filter @photobank/frontend test --run`


------
https://chatgpt.com/codex/tasks/task_e_68aabe14ca5c8328b9411613179163c8