### PR TITLE
fix: make repository update async

### DIFF
--- a/backend/PhotoBank.Repositories/Repository.cs
+++ b/backend/PhotoBank.Repositories/Repository.cs
@@ -98,7 +98,7 @@ namespace PhotoBank.Repositories
         }
         public async Task<TTable> UpdateAsync(TTable entity)
         {
-            var recordExists = _entities.Any(a => a.Id == entity.Id);
+            var recordExists = await _entities.AnyAsync(a => a.Id == entity.Id);
 
             if (!recordExists)
             {


### PR DESCRIPTION
## Summary
- use AnyAsync for repository update check

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln` *(fails: Unable to find datacollector 'XPlat Code Coverage'; 13 integration tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b09e043f188328adb1f84cd79de749