### PR TITLE
refactor: async file existence check in photo processor

### DIFF
--- a/backend/PhotoBank.Services/PhotoProcessor.cs
+++ b/backend/PhotoBank.Services/PhotoProcessor.cs
@@ -233,8 +233,10 @@ namespace PhotoBank.Services
                 return result;
             }
 
-            var file = _fileRepository.GetByCondition(f => f.Name == result.Name && f.Photo.Id == result.PhotoId);
-            result.DuplicateStatus = file != null ? DuplicateStatus.FileExists : DuplicateStatus.FileNotExists;
+            var fileExists = await _fileRepository
+                .GetByCondition(f => f.Name == result.Name && f.Photo.Id == result.PhotoId)
+                .AnyAsync();
+            result.DuplicateStatus = fileExists ? DuplicateStatus.FileExists : DuplicateStatus.FileNotExists;
             return result;
         }
 


### PR DESCRIPTION
## Summary
- replace direct file retrieval with async existence check in VerifyDuplicates

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln` *(fails: 13, Passed: 0, integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b09fa1c9008328a2a3e0452965e77c