### PR TITLE
feat: add face image retrieval

### DIFF
--- a/backend/PhotoBank.IntegrationTests/FaceImageEndpointTests.cs
+++ b/backend/PhotoBank.IntegrationTests/FaceImageEndpointTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Testcontainers.MsSql;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Minio;
+using Minio.DataModel.Args;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.Api.Controllers;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services;
+using PhotoBank.Services.Api;
+using Respawn;
+
+namespace PhotoBank.IntegrationTests;
+
+[TestFixture]
+public class FaceImageEndpointTests
+{
+    private MsSqlContainer _dbContainer = null!;
+    private Respawner _respawner = null!;
+    private string _connectionString = string.Empty;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetup()
+    {
+        try
+        {
+            _dbContainer = new MsSqlBuilder().WithPassword("yourStrong(!)Password").Build();
+            await _dbContainer.StartAsync();
+        }
+        catch (ArgumentException ex) when (ex.Message.Contains("Docker endpoint"))
+        {
+            Assert.Ignore("Docker not available: " + ex.Message);
+        }
+        _connectionString = _dbContainer.GetConnectionString();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<PhotoBankDbContext>(options =>
+            options.UseSqlServer(_connectionString, builder =>
+            {
+                builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
+                builder.UseNetTopologySuite();
+            }));
+        RegisterServicesForApi.Configure(services);
+        services.AddLogging();
+        services.AddAutoMapper(cfg => { cfg.AddProfile<MappingProfile>(); });
+        services.AddSingleton<IMinioClient>(Mock.Of<IMinioClient>());
+        await using var provider = services.BuildServiceProvider();
+        var db = provider.GetRequiredService<PhotoBankDbContext>();
+        await db.Database.MigrateAsync();
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync();
+        _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
+        {
+            DbAdapter = DbAdapter.SqlServer
+        });
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dbContainer != null)
+            await _dbContainer.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await _respawner.ResetAsync(conn);
+    }
+
+    private ServiceProvider BuildProvider(IMinioClient minioClient)
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<PhotoBankDbContext>(options =>
+            options.UseSqlServer(_connectionString, builder =>
+            {
+                builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
+                builder.UseNetTopologySuite();
+            }));
+        RegisterServicesForApi.Configure(services);
+        services.AddLogging();
+        services.AddAutoMapper(cfg => { cfg.AddProfile<MappingProfile>(); });
+        services.AddSingleton(minioClient);
+        return services.BuildServiceProvider();
+    }
+
+    private static void SeedFace(PhotoBankDbContext db, string s3Key, string eTag)
+    {
+        var storage = new Storage { Name = "s", Folder = "f" };
+        db.Storages.Add(storage);
+        var photo = new Photo { Name = "p", Storage = storage };
+        db.Photos.Add(photo);
+        db.Faces.Add(new Face { Photo = photo, S3Key_Image = s3Key, S3ETag_Image = eTag });
+        db.SaveChanges();
+    }
+
+    [Test]
+    public async Task GetImage_ReturnsPresignedUrl_WhenAvailable()
+    {
+        var url = "http://minio/face-key";
+        var minio = new Mock<IMinioClient>();
+        minio.Setup(m => m.PresignedGetObjectAsync(It.IsAny<PresignedGetObjectArgs>()))
+            .ReturnsAsync(url);
+        await using var provider = BuildProvider(minio.Object);
+        var db = provider.GetRequiredService<PhotoBankDbContext>();
+        SeedFace(db, "face-key", "etag");
+        var controller = new FacesController(provider.GetRequiredService<IPhotoService>())
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var faceId = db.Faces.Single().Id;
+        var result = await controller.GetImage(faceId);
+
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(StatusCodes.Status301MovedPermanently);
+        controller.Response.Headers.Location.ToString().Should().Be(url);
+        controller.Response.Headers.ETag.ToString().Should().Be("\"etag\"");
+    }
+
+    [Test]
+    public async Task GetImage_StreamsBytes_WhenPresignFails()
+    {
+        var data = new byte[] { 1, 2, 3 };
+        var minio = new Mock<IMinioClient>();
+        minio.Setup(m => m.PresignedGetObjectAsync(It.IsAny<PresignedGetObjectArgs>()))
+            .ThrowsAsync(new Exception("fail"));
+        minio.Setup(m => m.GetObjectAsync(It.IsAny<GetObjectArgs>(), It.IsAny<CancellationToken>()))
+            .Returns<GetObjectArgs, CancellationToken>((args, ct) =>
+            {
+                var prop = typeof(GetObjectArgs).GetProperty("CallBack", BindingFlags.NonPublic | BindingFlags.Instance);
+                var cb = (Func<Stream, CancellationToken, Task>)prop!.GetValue(args)!;
+                return cb(new MemoryStream(data), ct).ContinueWith(_ => (Minio.DataModel.ObjectStat)null!);
+            });
+
+        await using var provider = BuildProvider(minio.Object);
+        var db = provider.GetRequiredService<PhotoBankDbContext>();
+        SeedFace(db, "face-key", "etag");
+        var controller = new FacesController(provider.GetRequiredService<IPhotoService>())
+        {
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() }
+        };
+
+        var faceId = db.Faces.Single().Id;
+        var result = await controller.GetImage(faceId);
+
+        var file = result as FileContentResult;
+        file.Should().NotBeNull();
+        file!.FileContents.Should().Equal(data);
+        controller.Response.Headers.ETag.ToString().Should().Be("\"etag\"");
+    }
+}
+

--- a/backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj
+++ b/backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj
@@ -17,11 +17,16 @@
     <PackageReference Include="nunit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+    <PackageReference Include="DotNet.Testcontainers" Version="1.6.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="1.6.0" />
+    <PackageReference Include="Respawn" Version="6.2.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PhotoBank.DbContext\PhotoBank.DbContext.csproj" />
     <ProjectReference Include="..\PhotoBank.Repositories\PhotoBank.Repositories.csproj" />
     <ProjectReference Include="..\PhotoBank.Services\PhotoBank.Services.csproj" />
+    <ProjectReference Include="..\PhotoBank.Api\PhotoBank.Api.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- expose `GET /faces/{id}/image` endpoint
- generate pre-signed URLs with MinIO and stream bytes when unavailable
- cover face image retrieval with integration tests

## Testing
- `dotnet build PhotoBank.Backend.sln -c Release`
- `dotnet test PhotoBank.Backend.sln -c Release` *(fails: SQL Server/Docker not available; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bad6e878832881d3f9903a93fb43