### PR TITLE
refactor: remove face image column

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -151,12 +151,6 @@ namespace PhotoBank.DbContext.DbContext
             modelBuilder.Entity<Face>()
                 .HasIndex(p => new { p.PhotoId, p.Id, p.PersonId });
 
-            modelBuilder.Entity<Face>()
-                .HasIndex(p => p.Id)
-                .HasDatabaseName("IX_Faces_NeedsMigration")
-                .HasFilter("[S3Key_Image] IS NULL")
-                .IncludeProperties(p => new { p.S3Key_Image });
-
             modelBuilder.Entity<Photo>()
                 .HasIndex(p => p.StorageId)
                 .IncludeProperties(p => p.RelativePath);

--- a/backend/PhotoBank.DbContext/Migrations/20250828205508_RemoveFaceImage.Designer.cs
+++ b/backend/PhotoBank.DbContext/Migrations/20250828205508_RemoveFaceImage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using PhotoBank.DbContext.DbContext;
@@ -12,9 +13,11 @@ using PhotoBank.DbContext.DbContext;
 namespace PhotoBank.DbContext.Migrations
 {
     [DbContext(typeof(PhotoBankDbContext))]
-    partial class PhotoBankDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250828205508_RemoveFaceImage")]
+    partial class RemoveFaceImage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/PhotoBank.DbContext/Migrations/20250828205508_RemoveFaceImage.cs
+++ b/backend/PhotoBank.DbContext/Migrations/20250828205508_RemoveFaceImage.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PhotoBank.DbContext.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveFaceImage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Faces_NeedsMigration",
+                table: "Faces");
+
+            migrationBuilder.DropColumn(
+                name: "Image",
+                table: "Faces");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte[]>(
+                name: "Image",
+                table: "Faces",
+                type: "varbinary(max)",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Faces_NeedsMigration",
+                table: "Faces",
+                column: "Id",
+                filter: "[S3Key_Image] IS NULL")
+                .Annotation("SqlServer:Include", new[] { "S3Key_Image" });
+        }
+    }
+}

--- a/backend/PhotoBank.DbContext/Models/Face.cs
+++ b/backend/PhotoBank.DbContext/Models/Face.cs
@@ -13,7 +13,6 @@ namespace PhotoBank.DbContext.Models
         public double? Age { get; set; }
         public bool? Gender { get; set; }
         public double? Smile { get; set; }
-        public byte[]? Image { get; set; }
         [MaxLength(512)]
         public string S3Key_Image { get; set; }
         [MaxLength(128)]

--- a/backend/PhotoBank.Services/Enrichers/FaceEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/FaceEnricher.cs
@@ -89,8 +89,7 @@ namespace PhotoBank.Services.Enrichers
                     else if (IsAbleToIdentify(detectedFace, photo.Scale))
                     {
                         var bytes = await CreateFaceBytes(detectedFace, sourceData.OriginalImage, photo.Scale);
-                        var tempFace = new Face { Image = bytes };
-                        identifyResult = await _faceService.FaceIdentityAsync(tempFace);
+                        identifyResult = await _faceService.FaceIdentityAsync(bytes);
                         (face.S3Key_Image, face.S3ETag_Image) = await _facePreviewService.CreateFacePreview(detectedFace, sourceData.OriginalImage, photo.Scale);
                         IdentifyFace(face, identifyResult, photo.TakenDate);
                     }

--- a/backend/PhotoBank.Services/FaceRecognition/UnifiedFaceService.cs
+++ b/backend/PhotoBank.Services/FaceRecognition/UnifiedFaceService.cs
@@ -78,7 +78,7 @@ public sealed class UnifiedFaceService
 
             var faces = await _faces.GetAll()
                 .Where(f => faceIds.Contains(f.Id))
-                .Select(f => new Face { Id = f.Id, Image = f.Image, S3Key_Image = f.S3Key_Image })
+                .Select(f => new Face { Id = f.Id, S3Key_Image = f.S3Key_Image })
                 .ToListAsync(ct);
 
             var toLink = new List<FaceToLink>();

--- a/backend/PhotoBank.Services/FaceStorageService.cs
+++ b/backend/PhotoBank.Services/FaceStorageService.cs
@@ -25,11 +25,6 @@ public class FaceStorageService : IFaceStorageService
 
     public async Task<Stream> OpenReadStreamAsync(Face face, CancellationToken ct = default)
     {
-        if (face.Image != null)
-        {
-            return new MemoryStream(face.Image, writable: false);
-        }
-
         if (string.IsNullOrEmpty(face.S3Key_Image))
             throw new InvalidOperationException("Face has no image data");
 

--- a/backend/PhotoBank.Services/MappingProfile.cs
+++ b/backend/PhotoBank.Services/MappingProfile.cs
@@ -56,11 +56,9 @@ namespace PhotoBank.Services
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
             CreateMap<PersonFace, PersonFaceDto>()
-                .ForMember(dest => dest.FaceImage, opt => opt.MapFrom(src => src.Face.Image))
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
             CreateMap<PersonFaceDto, PersonFace>()
-                .ForSourceMember(src => src.FaceImage, opt => opt.DoNotValidate())
                 .ForMember(dest => dest.Person, opt => opt.Ignore())
                 .ForMember(dest => dest.Face, opt => opt.Ignore())
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
@@ -80,6 +78,7 @@ namespace PhotoBank.Services
                 .ForMember(dest => dest.PersonId, opt => opt.MapFrom(src => src.PersonFace.PersonId))
                 .ForMember(dest => dest.PersonDateOfBirth, opt => opt.MapFrom(src => src.Person.DateOfBirth))
                 .ForMember(dest => dest.PhotoTakenDate, opt => opt.MapFrom(src => src.Photo.TakenDate))
+                .ForMember(dest => dest.S3Key_Image, opt => opt.MapFrom(src => src.S3Key_Image))
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
         }
     }

--- a/backend/PhotoBank.Services/Models/FaceDto.cs
+++ b/backend/PhotoBank.Services/Models/FaceDto.cs
@@ -10,7 +10,7 @@ namespace PhotoBank.Services.Models
         public int Id { get; set; }
         public int? PersonId { get; set; }
         [Required]
-        public byte[] Image { get; set; }
+        public string S3Key_Image { get; set; }
         [Required]
         public IdentityStatus IdentityStatus { get; set; }
         public DateTime? PersonDateOfBirth { get; set; }

--- a/backend/PhotoBank.Services/Recognition/RecognitionService.cs
+++ b/backend/PhotoBank.Services/Recognition/RecognitionService.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using Minio;
+using Minio.DataModel.Args;
 using PhotoBank.DbContext.Models;
 using PhotoBank.InsightFaceApiClient;
 using PhotoBank.Repositories;
@@ -16,25 +18,43 @@ namespace PhotoBank.Services.Recognition
     {
         private readonly IRepository<Face> _faces;
         private readonly IInsightFaceApiClient _client;
+        private readonly IMinioClient _minioClient;
 
-        public RecognitionService(IRepository<Face> faces, IInsightFaceApiClient client)
+        public RecognitionService(IRepository<Face> faces, IInsightFaceApiClient client, IMinioClient minioClient)
         {
             _faces = faces;
             _client = client;
+            _minioClient = minioClient;
         }
 
         public async Task RegisterPersonsAsync()
         {
             foreach (var face in _faces.GetByCondition(p => p.PersonId == 1))
             {
-                var fileStream = new MemoryStream(face.Image);
-                await _client.RegisterAsync(face.PersonId.Value, fileStream).ContinueWith(task =>
+                if (string.IsNullOrEmpty(face.S3Key_Image))
+                {
+                    continue;
+                }
+
+                var bytes = await GetObjectAsync(face.S3Key_Image);
+                await using var fileStream = new MemoryStream(bytes);
+                await _client.RegisterAsync(face.PersonId!.Value, fileStream).ContinueWith(task =>
                 {
                     Console.WriteLine(task.IsCompletedSuccessfully
                         ? $"Recognized: {task.Result}"
                         : $"Recognition failed for {face.Id}: {task.Exception?.Message}");
                 });
             }
+        }
+
+        private async Task<byte[]> GetObjectAsync(string key)
+        {
+            using var ms = new MemoryStream();
+            await _minioClient.GetObjectAsync(new GetObjectArgs()
+                .WithBucket("photobank")
+                .WithObject(key)
+                .WithCallbackStream(stream => stream.CopyTo(ms)));
+            return ms.ToArray();
         }
 
     }

--- a/backend/PhotoBank.UnitTests/FaceRecognition/UnifiedFaceServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/FaceRecognition/UnifiedFaceServiceTests.cs
@@ -110,8 +110,8 @@ public class UnifiedFaceServiceTests
         ctx.Persons.Add(new Person { Id = 1, Name = "Alice" });
 
         ctx.Faces.AddRange(
-            new Face { Id = 101, PhotoId = 0, Image = null, S3Key_Image = "face101", Rectangle = new Point(0, 0), S3ETag_Image = string.Empty, Sha256_Image = string.Empty, FaceAttributes = string.Empty },
-            new Face { Id = 102, PhotoId = 0, Image = new byte[] { 2 }, Rectangle = new Point(0, 0), S3Key_Image = string.Empty, S3ETag_Image = string.Empty, Sha256_Image = string.Empty, FaceAttributes = string.Empty }
+            new Face { Id = 101, PhotoId = 0, S3Key_Image = "face101", Rectangle = new Point(0, 0), S3ETag_Image = string.Empty, Sha256_Image = string.Empty, FaceAttributes = string.Empty },
+            new Face { Id = 102, PhotoId = 0, S3Key_Image = string.Empty, Rectangle = new Point(0, 0), S3ETag_Image = string.Empty, Sha256_Image = string.Empty, FaceAttributes = string.Empty }
         );
 
         var linkMissing = new PersonFace { Id = -1, PersonId = 1, FaceId = 101, ExternalId = null, Provider = null };

--- a/backend/PhotoBank.UnitTests/PersonFaceMappingTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonFaceMappingTests.cs
@@ -24,18 +24,18 @@ public class PersonFaceMappingTests
     }
 
     [Test]
-    public void MapsFaceImage()
+    public void MapsIds()
     {
         var entity = new PersonFace
         {
             Id = 1,
             PersonId = 2,
-            FaceId = 3,
-            Face = new Face { Image = new byte[] { 1, 2, 3 } }
+            FaceId = 3
         };
 
         var dto = _mapper.Map<PersonFaceDto>(entity);
 
-        dto.FaceImage.Should().BeEquivalentTo(new byte[] { 1, 2, 3 });
+        dto.PersonId.Should().Be(2);
+        dto.FaceId.Should().Be(3);
     }
 }

--- a/backend/PhotoBank.ViewModel.Dto/PersonFaceDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/PersonFaceDto.cs
@@ -10,8 +10,6 @@ namespace PhotoBank.ViewModel.Dto
         [System.ComponentModel.DataAnnotations.Required]
         public int FaceId { get; set; }
 
-        public byte[]? FaceImage { get; set; }
-
         public string? Provider { get; set; }
         public string? ExternalId { get; set; }
         public System.Guid ExternalGuid { get; set; }


### PR DESCRIPTION
## Summary
- remove obsolete Image field from Face entity
- drop Faces.Image column via EF migration
- stream face data from S3 and retire face migration logic

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b0bfedcec0832880399e4fa6b69638