### PR TITLE
refactor: use image URLs instead of base64

### DIFF
--- a/frontend/packages/frontend/src/components/PhotoPreviewModal.tsx
+++ b/frontend/packages/frontend/src/components/PhotoPreviewModal.tsx
@@ -32,7 +32,7 @@ const PhotoPreviewModal = ({ photoId, onOpenChange }: PhotoPreviewModalProps) =>
                     <p className="p-4">{t('loadingText')}</p>
                 ) : (
                     <img
-                        src={`data:image/jpeg;base64,${photo.previewImage}`}
+                        src={photo.previewUrl ?? ''}
                         alt={photo.name}
                         className="max-h-full max-w-full w-auto h-auto mx-auto object-contain"
                     />

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -74,10 +74,6 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
         [photoData?.takenDate],
     );
 
-    const previewImageSrc = photoData
-        ? `data:image/jpeg;base64,${photoData.previewImage}`
-        : undefined;
-
     const imageNaturalSize = useMemo(() => {
         if (photoData?.width && photoData.height && photoData.scale) {
             return {width: photoData.width * photoData.scale, height: photoData.height * photoData.scale};
@@ -208,13 +204,13 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                 variant="ghost"
                                 aria-label="Open viewer"
                                 onClick={() => {
-                                    if (previewImageSrc) {
+                                    if (photoData?.previewUrl) {
                                         useViewer.getState().open(
                                             [
                                                 {
                                                     id: photoData.id,
-                                                    preview: previewImageSrc,
-                                                    original: previewImageSrc,
+                                                    preview: photoData.previewUrl,
+                                                    original: photoData.originalUrl ?? photoData.previewUrl,
                                                     title: photoData.name,
                                                 },
                                             ],
@@ -234,7 +230,7 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                             >
                                 <img
                                     loading="lazy"
-                                    src={previewImageSrc}
+                                    src={photoData.previewUrl}
                                     alt={photoData.name}
                                     className="max-h-full max-w-full object-contain"
                                 />

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
@@ -34,7 +34,7 @@ const PhotoListItemMobile = ({
     <div className="space-y-3">
       <div className="flex items-start gap-3">
         <PhotoPreview
-          thumbnail={photo.thumbnail ?? ''}
+          thumbnailUrl={photo.thumbnailUrl ?? ''}
           alt={photo.name}
           className="w-20 h-20 flex-shrink-0"
         />

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -67,7 +67,7 @@ const PhotoListPage = () => {
     () =>
       Array.from({ length: 15 }, (_, i) => ({
         id: i,
-        thumbnail: '',
+        thumbnailUrl: '',
         name: '',
         storageName: '',
         relativePath: '',

--- a/frontend/packages/frontend/src/pages/list/PhotoPreview.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoPreview.tsx
@@ -2,12 +2,12 @@ import { useState } from 'react';
 import { Image } from 'lucide-react';
 
 interface PhotoPreviewProps {
-    thumbnail: string;
+    thumbnailUrl: string;
     alt: string;
     className?: string;
 }
 
-const PhotoPreview = ({ thumbnail, alt, className = "" }: PhotoPreviewProps) => {
+const PhotoPreview = ({ thumbnailUrl, alt, className = "" }: PhotoPreviewProps) => {
     const [imageError, setImageError] = useState(false);
 
     return (
@@ -18,7 +18,7 @@ const PhotoPreview = ({ thumbnail, alt, className = "" }: PhotoPreviewProps) => 
                 </div>
             ) : (
                 <img
-                    src={`data:image/jpeg;base64,${thumbnail}`}
+                    src={thumbnailUrl}
                     alt={alt}
                     className="w-full h-full object-cover transition-transform hover:scale-110 duration-200"
                     onError={() => { setImageError(true); }}

--- a/frontend/packages/frontend/src/pages/list/VirtualPhotoList.test.tsx
+++ b/frontend/packages/frontend/src/pages/list/VirtualPhotoList.test.tsx
@@ -26,7 +26,7 @@ import { usePhotoVirtual } from './usePhotoVirtual';
 const createPhotos = (count: number): PhotoItemDto[] =>
   Array.from({ length: count }, (_, i) => ({
     id: i + 1,
-    thumbnail: '',
+    thumbnailUrl: '',
     name: `Photo ${i + 1}`,
     storageName: 's',
     relativePath: 'p',

--- a/frontend/packages/frontend/src/pages/list/columns.tsx
+++ b/frontend/packages/frontend/src/pages/list/columns.tsx
@@ -28,7 +28,7 @@ export const photoColumns: Column<PhotoItemDto>[] = [
     header: i18n.t('colPreviewLabel'),
     width: 'col-span-2',
     render: (r) => (
-      <PreviewCell thumbnail={r.thumbnail ?? ''} alt={r.name} className="w-16 h-16" />
+      <PreviewCell thumbnailUrl={r.thumbnailUrl ?? ''} alt={r.name} className="w-16 h-16" />
     ),
   },
   {

--- a/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
+++ b/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
@@ -9,7 +9,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const photo = {
   id: 1,
   name: 'Test Photo',
-  previewImage: 'fakeImage',
+  previewUrl: 'http://example.com/prev.jpg',
+  originalUrl: 'http://example.com/orig.jpg',
   scale: 1,
   takenDate: '2024-01-01T00:00:00Z',
   faces: [


### PR DESCRIPTION
## Summary
- switch PhotoPreviewModal and PhotoDetailsPage to new previewUrl field
- use thumbnailUrl across photo list components
- update tests to expect URLs instead of base64 strings

## Testing
- `cd frontend/packages/frontend && pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b2fe95a9d88328b1bddfac90749f57