### PR TITLE
refactor: send Telegram photos via URL

### DIFF
--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -1,10 +1,11 @@
 import type { PhotoDto } from "@photobank/shared/api/photobank";
 import { formatDate } from "@photobank/shared/index";
-import { Buffer } from "buffer";
 
 import { getPersonName } from "./dictionaries";
 
-export function formatPhotoMessage(photo: PhotoDto): { caption: string, hasSpoiler: boolean, image?: Buffer } {
+type PhotoWithUrls = PhotoDto & { previewUrl?: string | null; originalUrl?: string | null };
+
+export function formatPhotoMessage(photo: PhotoWithUrls): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
     const lines: string[] = [];
 
     lines.push(`📸 <b>${photo.name}</b>`);
@@ -30,13 +31,11 @@ export function formatPhotoMessage(photo: PhotoDto): { caption: string, hasSpoil
         }
     }
 
-    const image = photo.previewImage
-        ? Buffer.from(photo.previewImage, "base64")
-        : undefined;
+    const imageUrl = photo.previewUrl ?? photo.originalUrl ?? undefined;
 
     return {
         caption: lines.join("\n"),
         hasSpoiler: photo.adultScore > 0.5 || photo.racyScore > 0.5,
-        image,
+        imageUrl,
     };
 }

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -1,4 +1,4 @@
-import { InputFile, InlineKeyboard } from 'grammy';
+import { InlineKeyboard } from 'grammy';
 import type { PhotoDto } from '@photobank/shared/api/photobank';
 
 import { formatPhotoMessage } from './formatPhotoMessage';
@@ -42,11 +42,10 @@ export async function sendPhotoById(ctx: MyContext, id: number) {
         return;
     }
 
-    const { caption, hasSpoiler, image } = formatPhotoMessage(photo);
+    const { caption, hasSpoiler, imageUrl } = formatPhotoMessage(photo);
 
-    if (image) {
-        const file = new InputFile(image, `${photo.name}.jpg`);
-        await ctx.replyWithPhoto(file, {
+    if (imageUrl) {
+        await ctx.replyWithPhoto(imageUrl, {
             caption,
             parse_mode: "HTML",
             has_spoiler: hasSpoiler,
@@ -64,7 +63,7 @@ export async function openPhotoInline(ctx: MyContext, id: number) {
         return;
     }
 
-    const { caption, hasSpoiler, image } = formatPhotoMessage(photo);
+    const { caption, hasSpoiler, imageUrl } = formatPhotoMessage(photo);
 
     let keyboard: InlineKeyboard | undefined;
     if (chatId) {
@@ -79,9 +78,8 @@ export async function openPhotoInline(ctx: MyContext, id: number) {
     }
 
     if (!chatId) {
-        if (image) {
-            const file = new InputFile(image, `${photo.name}.jpg`);
-            await ctx.replyWithPhoto(file, { caption, parse_mode: "HTML", reply_markup: keyboard, has_spoiler: hasSpoiler });
+        if (imageUrl) {
+            await ctx.replyWithPhoto(imageUrl, { caption, parse_mode: "HTML", reply_markup: keyboard, has_spoiler: hasSpoiler });
         } else {
             await ctx.reply(caption, { parse_mode: "HTML", reply_markup: keyboard });
         }
@@ -91,14 +89,13 @@ export async function openPhotoInline(ctx: MyContext, id: number) {
     const existing = photoMessages.get(chatId);
     if (existing) {
         try {
-            if (image) {
-                const file = new InputFile(image, `${photo.name}.jpg`);
+            if (imageUrl) {
                 await ctx.api.editMessageMedia(
                     chatId,
                     existing,
                     {
                         type: "photo",
-                        media: file,
+                        media: imageUrl,
                         caption,
                         parse_mode: "HTML",
                     },
@@ -113,9 +110,8 @@ export async function openPhotoInline(ctx: MyContext, id: number) {
         }
     }
 
-    if (image) {
-        const file = new InputFile(image, `${photo.name}.jpg`);
-        const msg = await ctx.replyWithPhoto(file, { caption, parse_mode: "HTML", reply_markup: keyboard, has_spoiler: hasSpoiler });
+    if (imageUrl) {
+        const msg = await ctx.replyWithPhoto(imageUrl, { caption, parse_mode: "HTML", reply_markup: keyboard, has_spoiler: hasSpoiler });
         photoMessages.set(chatId, msg.message_id);
     } else {
         const msg = await ctx.reply(caption, { parse_mode: "HTML", reply_markup: keyboard });

--- a/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
+++ b/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
@@ -7,7 +7,7 @@ vi.mock('../src/dictionaries', () => ({
 }));
 
 describe('formatPhotoMessage', () => {
-  const basePhoto: PhotoDto = {
+  const basePhoto: PhotoDto & { previewUrl?: string; originalUrl?: string } = {
     id: 1,
     name: 'Test',
     scale: 1,
@@ -19,7 +19,7 @@ describe('formatPhotoMessage', () => {
   };
 
   it('includes main fields in caption', () => {
-    const { caption, image } = formatPhotoMessage({
+    const { caption, imageUrl } = formatPhotoMessage({
       ...basePhoto,
       takenDate: '2024-01-02T00:00:00Z',
       captions: ['hello'],
@@ -31,14 +31,17 @@ describe('formatPhotoMessage', () => {
     expect(caption).toContain('📝 hello');
     expect(caption).toContain('🏷️ tag1, tag2');
     expect(caption).toContain('👤 Person 2');
-    expect(image).toBeUndefined();
+    expect(imageUrl).toBeUndefined();
   });
 
-  it('decodes preview image when provided', () => {
-    const base64 = Buffer.from('img').toString('base64');
-    const { image } = formatPhotoMessage({ ...basePhoto, previewImage: base64 });
-    expect(image).toBeInstanceOf(Buffer);
-    expect(image?.toString()).toBe('img');
+  it('uses preview url when provided', () => {
+    const { imageUrl } = formatPhotoMessage({ ...basePhoto, previewUrl: 'http://example.com/preview.jpg' });
+    expect(imageUrl).toBe('http://example.com/preview.jpg');
+  });
+
+  it('falls back to original url', () => {
+    const { imageUrl } = formatPhotoMessage({ ...basePhoto, originalUrl: 'http://example.com/original.jpg' });
+    expect(imageUrl).toBe('http://example.com/original.jpg');
   });
 
   it('replaces missing person with unknown label', () => {

--- a/frontend/packages/telegram-bot/test/photoInline.test.ts
+++ b/frontend/packages/telegram-bot/test/photoInline.test.ts
@@ -7,7 +7,7 @@ const basePhoto = {
   id: 1,
   name: 'test',
   scale: 1,
-  previewImage: Buffer.from('img').toString('base64'),
+  previewUrl: 'http://example.com/img.jpg',
   adultScore: 0,
   racyScore: 0,
   height: 100,


### PR DESCRIPTION
## Summary
- use preview/original URLs instead of base64 in `formatPhotoMessage`
- send photos with URLs in `sendPhotoById` and `openPhotoInline`
- update tests to use URL fixtures

## Testing
- `pnpm vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68b3056bf81483288df6ac7858a38d63