### PR TITLE
fix: drop base64 photo fields and cache S3 keys

### DIFF
--- a/frontend/packages/shared/src/api/photobank/model/photoDto.ts
+++ b/frontend/packages/shared/src/api/photobank/model/photoDto.ts
@@ -14,7 +14,10 @@ export interface PhotoDto {
   scale?: number;
   /** @nullable */
   takenDate?: string | null;
-  previewImage: string;
+  s3Key_Preview?: string | null;
+  s3Key_Thumbnail?: string | null;
+  previewUrl?: string | null;
+  thumbnailUrl?: string | null;
   location?: GeoPointDto;
   /** @nullable */
   orientation?: number | null;

--- a/frontend/packages/shared/src/api/photobank/model/photoItemDto.ts
+++ b/frontend/packages/shared/src/api/photobank/model/photoItemDto.ts
@@ -9,10 +9,11 @@ import type { PersonItemDto } from './personItemDto';
 
 export interface PhotoItemDto {
   id: number;
-  thumbnail?: string;
-  thumbnailUrl?: string;
-  previewUrl?: string;
-  originalUrl?: string;
+  s3Key_Thumbnail?: string | null;
+  s3Key_Preview?: string | null;
+  thumbnailUrl?: string | null;
+  previewUrl?: string | null;
+  originalUrl?: string | null;
   /** @minLength 1 */
   name: string;
   /** @nullable */

--- a/frontend/packages/shared/src/cache/photosCache.ts
+++ b/frontend/packages/shared/src/cache/photosCache.ts
@@ -4,7 +4,10 @@ import { LRUCache } from 'lru-cache';
 import { isBrowser } from '../utils/isBrowser';
 import type { PhotoDto } from '../api/photobank/model';
 
-export interface CachedPhoto extends PhotoDto {
+export interface CachedPhoto {
+  id: number;
+  s3Key_Preview?: string | null;
+  s3Key_Thumbnail?: string | null;
   added: number;
 }
 
@@ -29,11 +32,12 @@ if (isBrowser()) {
 }
 
 export async function cachePhoto(photo: PhotoDto): Promise<void> {
-  const cached = { ...photo, added: Date.now() };
+  const { id, s3Key_Preview, s3Key_Thumbnail } = photo;
+  const cached: CachedPhoto = { id, s3Key_Preview, s3Key_Thumbnail, added: Date.now() };
   if (isBrowser()) {
     await db?.photos.put(cached);
   } else {
-    photoCache?.set(photo.id, cached);
+    photoCache?.set(id, cached);
   }
 }
 

--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -3,7 +3,7 @@ import { formatDate } from "@photobank/shared/index";
 
 import { getPersonName } from "./dictionaries";
 
-type PhotoWithUrls = PhotoDto & { previewUrl?: string | null; originalUrl?: string | null };
+type PhotoWithUrls = PhotoDto & { originalUrl?: string | null };
 
 export function formatPhotoMessage(photo: PhotoWithUrls): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
     const lines: string[] = [];

--- a/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
+++ b/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
@@ -7,11 +7,10 @@ vi.mock('../src/dictionaries', () => ({
 }));
 
 describe('formatPhotoMessage', () => {
-  const basePhoto: PhotoDto & { previewUrl?: string; originalUrl?: string } = {
+  const basePhoto: PhotoDto & { originalUrl?: string } = {
     id: 1,
     name: 'Test',
     scale: 1,
-    previewImage: '',
     adultScore: 0,
     racyScore: 0,
     height: 100,

--- a/frontend/packages/tv/components/PhotoCard.tsx
+++ b/frontend/packages/tv/components/PhotoCard.tsx
@@ -5,7 +5,7 @@ import { PhotoItemDto } from '@photobank/shared/api/photobank';
 export const PhotoCard = ({ photo }: { photo: PhotoItemDto }) => (
     <View style={styles.card}>
       <Image
-          source={{ uri: `data:image/jpeg;base64,${photo.thumbnail}` }}
+          source={{ uri: photo.thumbnailUrl ?? '' }}
           style={styles.image}
           resizeMode="cover"
       />


### PR DESCRIPTION
## Summary
- update photo models to use S3 keys and URLs instead of base64
- avoid storing presigned URLs in photo cache
- adjust bots and tv components for new fields

## Testing
- `pnpm -F @photobank/shared test`
- `pnpm --filter @photobank/telegram-bot exec vitest run`
- `pnpm --filter @photobank/frontend exec vitest run`
- `pnpm -F photobanktv test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b30b72f4d083289217833089d53aae