### PR TITLE
fix(tv): use photo URLs and placeholder

### DIFF
--- a/frontend/packages/tv/components/PhotoCard.test.tsx
+++ b/frontend/packages/tv/components/PhotoCard.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { describe, it, expect } from 'vitest';
+
+import { PhotoCard } from './PhotoCard';
+import type { PhotoItemDto } from '@photobank/shared/api/photobank';
+
+describe('PhotoCard', () => {
+  const base: PhotoItemDto = {
+    id: 1,
+    name: 'Test',
+    storageName: 's',
+    relativePath: 'r',
+  };
+
+  it('renders image from URL when available', () => {
+    const photo = { ...base, thumbnailUrl: 'http://example.com/thumb.jpg' };
+    let testRenderer: renderer.ReactTestRenderer;
+    act(() => {
+      testRenderer = renderer.create(<PhotoCard photo={photo} />);
+    });
+    const image = testRenderer.root.findByProps({ testID: 'photo-image' });
+    expect(image.props.source.uri).toBe('http://example.com/thumb.jpg');
+  });
+
+  it('renders placeholder when no URL', () => {
+    let testRenderer: renderer.ReactTestRenderer;
+    act(() => {
+      testRenderer = renderer.create(<PhotoCard photo={base} />);
+    });
+    const placeholder = testRenderer.root.findByProps({ testID: 'photo-placeholder' });
+    expect(placeholder).toBeTruthy();
+  });
+});

--- a/frontend/packages/tv/components/PhotoCard.tsx
+++ b/frontend/packages/tv/components/PhotoCard.tsx
@@ -2,22 +2,31 @@ import React from 'react';
 import { View, Image, StyleSheet, Text } from 'react-native';
 import { PhotoItemDto } from '@photobank/shared/api/photobank';
 
-export const PhotoCard = ({ photo }: { photo: PhotoItemDto }) => (
+export const PhotoCard = ({ photo }: { photo: PhotoItemDto }) => {
+  const uri = photo.thumbnailUrl ?? photo.previewUrl;
+
+  return (
     <View style={styles.card}>
-      <Image
-          source={{ uri: `data:image/jpeg;base64,${photo.thumbnail}` }}
+      {uri ? (
+        <Image
+          source={{ uri }}
           style={styles.image}
           resizeMode="cover"
-      />
+          testID="photo-image"
+        />
+      ) : (
+        <View style={[styles.image, styles.placeholder]} testID="photo-placeholder" />
+      )}
       <View style={styles.infoContainer}>
-          <Text style={styles.name}>{photo.name}</Text>
-          {photo.takenDate && <Text style={styles.date}>{photo.takenDate}</Text>}
-          {photo.captions && photo.captions.length > 0 && (
-              <Text style={styles.caption}>{photo.captions[0]}</Text>
-          )}
+        <Text style={styles.name}>{photo.name}</Text>
+        {photo.takenDate && <Text style={styles.date}>{photo.takenDate}</Text>}
+        {photo.captions && photo.captions.length > 0 && (
+          <Text style={styles.caption}>{photo.captions[0]}</Text>
+        )}
       </View>
     </View>
-);
+  );
+};
 
 const styles = StyleSheet.create({
   card: {
@@ -29,6 +38,9 @@ const styles = StyleSheet.create({
     backgroundColor: '#000',
   },
   image: { width: '100%', height: '100%' },
+  placeholder: {
+    backgroundColor: '#333',
+  },
   infoContainer: {
     position: 'absolute',
     bottom: 0,

--- a/frontend/packages/tv/package.json
+++ b/frontend/packages/tv/package.json
@@ -10,7 +10,8 @@
     "web": "expo start --web",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
-    "doctor": "expo-doctor"
+    "doctor": "expo-doctor",
+    "test": "vitest"
   },
   "dependencies": {
     "@photobank/shared": "workspace:*",
@@ -32,6 +33,8 @@
     "@types/node": "24.0.13",
     "typescript": "5.9.2",
     "eslint": "^9.8.0",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "vitest": "^3.2.4",
+    "react-test-renderer": "19.0.0"
   }
 }

--- a/frontend/packages/tv/react-native-stub.ts
+++ b/frontend/packages/tv/react-native-stub.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+
+export const View = (props: any) => React.createElement('View', props, props.children);
+export const Image = (props: any) => React.createElement('Image', props, props.children);
+export const Text = (props: any) => React.createElement('Text', props, props.children);
+export const StyleSheet = { create: (styles: any) => styles };

--- a/frontend/packages/tv/vitest.config.ts
+++ b/frontend/packages/tv/vitest.config.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import { defineConfig, mergeConfig } from 'vitest/config';
+
+import baseConfig from '../vitest.base';
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    resolve: {
+      alias: {
+        'react-native': path.resolve(__dirname, './react-native-stub.ts'),
+      },
+    },
+  })
+);

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -450,9 +450,15 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.6.2
+      react-test-renderer:
+        specifier: 19.0.0
+        version: 19.0.0(react@19.0.0)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.0.13)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.0.13)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
 
 packages:
 
@@ -5643,6 +5649,11 @@ packages:
       '@types/react':
         optional: true
 
+  react-test-renderer@19.0.0:
+    resolution: {integrity: sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==}
+    peerDependencies:
+      react: ^19.0.0
+
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
@@ -8001,12 +8012,34 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@inquirer/confirm@5.1.14(@types/node@24.0.13)':
+    dependencies:
+      '@inquirer/core': 10.1.15(@types/node@24.0.13)
+      '@inquirer/type': 3.0.8(@types/node@24.0.13)
+    optionalDependencies:
+      '@types/node': 24.0.13
+    optional: true
+
   '@inquirer/confirm@5.1.14(@types/node@24.1.0)':
     dependencies:
       '@inquirer/core': 10.1.15(@types/node@24.1.0)
       '@inquirer/type': 3.0.8(@types/node@24.1.0)
     optionalDependencies:
       '@types/node': 24.1.0
+
+  '@inquirer/core@10.1.15(@types/node@24.0.13)':
+    dependencies:
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@24.0.13)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.0.13
+    optional: true
 
   '@inquirer/core@10.1.15(@types/node@24.1.0)':
     dependencies:
@@ -8022,6 +8055,11 @@ snapshots:
       '@types/node': 24.1.0
 
   '@inquirer/figures@1.0.13': {}
+
+  '@inquirer/type@3.0.8(@types/node@24.0.13)':
+    optionalDependencies:
+      '@types/node': 24.0.13
+    optional: true
 
   '@inquirer/type@3.0.8(@types/node@24.1.0)':
     optionalDependencies:
@@ -9606,6 +9644,15 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.2.1
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(msw@2.10.5(@types/node@24.0.13)(typescript@5.9.2))(vite@7.0.6(@types/node@24.0.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.10.5(@types/node@24.0.13)(typescript@5.9.2)
+      vite: 7.0.6(@types/node@24.0.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
 
   '@vitest/mocker@3.2.4(msw@2.10.5(@types/node@24.1.0)(typescript@5.9.2))(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))':
     dependencies:
@@ -12164,6 +12211,32 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  msw@2.10.5(@types/node@24.0.13)(typescript@5.9.2):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 5.1.14(@types/node@24.0.13)
+      '@mswjs/interceptors': 0.39.5
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.6
+      graphql: 16.11.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.41.0
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   msw@2.10.5(@types/node@24.1.0)(typescript@5.9.2):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
@@ -12815,6 +12888,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.8
+
+  react-test-renderer@19.0.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-is: 19.1.0
+      scheduler: 0.25.0
 
   react@19.0.0: {}
 
@@ -13741,6 +13820,27 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@3.2.4(@types/node@24.0.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.0.6(@types/node@24.0.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
@@ -13762,6 +13862,23 @@ snapshots:
       - tsx
       - yaml
 
+  vite@7.0.6(@types/node@24.0.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.8
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.45.1
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 24.0.13
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
+      terser: 5.43.1
+      tsx: 4.20.3
+      yaml: 2.8.1
+
   vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.8
@@ -13778,6 +13895,49 @@ snapshots:
       terser: 5.43.1
       tsx: 4.20.3
       yaml: 2.8.1
+
+  vitest@3.2.4(@types/node@24.0.13)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.0.13)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(msw@2.10.5(@types/node@24.0.13)(typescript@5.9.2))(vite@7.0.6(@types/node@24.0.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.0.6(@types/node@24.0.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.0.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.0.13
+      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/node@24.1.0)(@vitest/ui@3.2.4)(jiti@2.5.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.5(@types/node@24.1.0)(typescript@5.9.2))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.1):
     dependencies:


### PR DESCRIPTION
## Summary
- render `PhotoCard` image from `thumbnailUrl`/`previewUrl`
- show placeholder when no image URL is provided
- test `PhotoCard` rendering with and without URLs

## Testing
- `cd frontend/packages/tv && pnpm lint`
- `cd frontend/packages/tv && pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b30b41b9f88328af662fc897c608e4