### PR TITLE
feat: add photobank model re-export

### DIFF
--- a/frontend/packages/shared/src/api/photobank/model.ts
+++ b/frontend/packages/shared/src/api/photobank/model.ts
@@ -1,0 +1,1 @@
+export * from './photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas';


### PR DESCRIPTION
## Summary
- re-export photobank schemas via new model file

## Testing
- `pnpm -w build` *(fails: Property 'previewUrl' does not exist on type 'PhotoWithUrls')*
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b33790301483288a21573f156c700f