### PR TITLE
refactor(shared): use photobank barrel for DTO imports

### DIFF
--- a/frontend/packages/shared/src/cache/filterResultsCache.ts
+++ b/frontend/packages/shared/src/cache/filterResultsCache.ts
@@ -2,7 +2,7 @@ import Dexie, { type Table } from 'dexie';
 import { LRUCache } from 'lru-cache';
 
 import { isBrowser } from '../utils/isBrowser';
-import type { PhotoItemDto } from '../api/photobank/model';
+import type { PhotoItemDto } from '../api/photobank';
 
 export interface CachedFilterResult {
   hash: string;

--- a/frontend/packages/shared/src/cache/photosCache.ts
+++ b/frontend/packages/shared/src/cache/photosCache.ts
@@ -2,7 +2,7 @@ import Dexie, { type Table } from 'dexie';
 import { LRUCache } from 'lru-cache';
 
 import { isBrowser } from '../utils/isBrowser';
-import type { PhotoDto } from '../api/photobank/model';
+import type { PhotoDto } from '../api/photobank';
 
 export interface CachedPhoto {
   id: number;

--- a/frontend/packages/shared/src/utils/geocode.ts
+++ b/frontend/packages/shared/src/utils/geocode.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import type { GeoPointDto } from '../api/photobank/model';
+import type { GeoPointDto } from '../api/photobank';
 
 /**
  * Returns a human friendly place name for the given coordinates using

--- a/frontend/packages/shared/src/utils/getFilterHash.ts
+++ b/frontend/packages/shared/src/utils/getFilterHash.ts
@@ -1,6 +1,6 @@
 import objectHash from 'object-hash';
 
-import type { FilterDto } from '../api/photobank/model';
+import type { FilterDto } from '../api/photobank';
 
 /**
  * Creates a stable hash for a filter. Works in both Node.js and browser.

--- a/frontend/packages/shared/test/getFilterHash.test.ts
+++ b/frontend/packages/shared/test/getFilterHash.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { getFilterHash } from '../src';
-import type { FilterDto } from '../src/api/photobank/model';
+import type { FilterDto } from '../src/api/photobank';
 
 describe('getFilterHash', () => {
   it('returns stable hash for identical filters', () => {


### PR DESCRIPTION
## Summary
- use `api/photobank` barrel to supply DTO types in utilities, caches, and tests

## Testing
- `pnpm build`
- `CI=1 pnpm -w test`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b339ade1588328aca873f32a2c7985