### PR TITLE
fix: use previewImage for telegram photos

### DIFF
--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -3,9 +3,11 @@ import { formatDate } from "@photobank/shared/index";
 
 import { getPersonName } from "./dictionaries";
 
-type PhotoWithUrls = PhotoDto & { previewUrl?: string | null; originalUrl?: string | null };
-
-export function formatPhotoMessage(photo: PhotoWithUrls): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
+export function formatPhotoMessage(photo: PhotoDto): {
+    caption: string;
+    hasSpoiler: boolean;
+    previewImage?: string;
+} {
     const lines: string[] = [];
 
     lines.push(`📸 <b>${photo.name}</b>`);
@@ -31,11 +33,9 @@ export function formatPhotoMessage(photo: PhotoWithUrls): { caption: string; has
         }
     }
 
-    const imageUrl = photo.previewUrl ?? photo.originalUrl ?? undefined;
-
     return {
         caption: lines.join("\n"),
         hasSpoiler: photo.adultScore > 0.5 || photo.racyScore > 0.5,
-        imageUrl,
+        previewImage: photo.previewImage || undefined,
     };
 }

--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -7,6 +7,7 @@ import { getFileId, setFileId, delFileId } from '../cache/fileIdCache';
 import { logger } from '../utils/logger';
 import type { PhotoItemDto } from '../types';
 import { withTelegramRetry } from '../utils/retry';
+import { toTelegramFile } from '../utils/image';
 
 function buildCaption(p: PhotoItemDto): string {
   const parts = [p.name, p.takenDate ? formatDate(p.takenDate) : null];
@@ -24,7 +25,7 @@ export async function sendPhotoSmart(ctx: Context, p: PhotoItemDto) {
       throttled(() =>
         ctx.api.sendPhoto(
           ctx.chat.id,
-          cached ?? (p.previewUrl ?? p.originalUrl ?? ''),
+          cached ?? toTelegramFile(p.previewImage) ?? '',
           { caption: buildCaption(p) },
         ),
       ),
@@ -44,7 +45,7 @@ export async function sendPhotoSmart(ctx: Context, p: PhotoItemDto) {
           throttled(() =>
             ctx.api.sendPhoto(
               ctx.chat.id,
-              p.previewUrl ?? p.originalUrl ?? '',
+              toTelegramFile(p.previewImage) ?? '',
               { caption: buildCaption(p) },
             ),
           ),
@@ -75,7 +76,7 @@ export async function sendAlbumSmart(ctx: Context, photos: PhotoItemDto[]) {
   for (const group of groups) {
     const medias: InputMediaPhoto[] = group.map((p) => {
       const cached = getFileId(p.id);
-      const media = cached ?? (p.previewUrl ?? p.originalUrl ?? '');
+      const media = cached ?? (toTelegramFile(p.previewImage) ?? '');
       return {
         type: 'photo',
         media,

--- a/frontend/packages/telegram-bot/src/types.ts
+++ b/frontend/packages/telegram-bot/src/types.ts
@@ -1,3 +1,5 @@
 import type { PhotoItemDto as SharedPhotoItemDto } from '@photobank/shared/api/photobank';
 
-export type PhotoItemDto = SharedPhotoItemDto;
+export interface PhotoItemDto extends SharedPhotoItemDto {
+  previewImage?: string;
+}

--- a/frontend/packages/telegram-bot/src/utils/image.ts
+++ b/frontend/packages/telegram-bot/src/utils/image.ts
@@ -1,0 +1,11 @@
+import { InputFile } from 'grammy';
+
+export function toTelegramFile(src?: string): string | InputFile | undefined {
+    if (!src) return undefined;
+    if (/^https?:\/\//i.test(src)) return src;
+    try {
+        return new InputFile(Buffer.from(src, 'base64'));
+    } catch {
+        return undefined;
+    }
+}

--- a/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
+++ b/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
@@ -7,7 +7,7 @@ vi.mock('../src/dictionaries', () => ({
 }));
 
 describe('formatPhotoMessage', () => {
-  const basePhoto: PhotoDto & { previewUrl?: string; originalUrl?: string } = {
+  const basePhoto: PhotoDto = {
     id: 1,
     name: 'Test',
     scale: 1,
@@ -19,7 +19,7 @@ describe('formatPhotoMessage', () => {
   };
 
   it('includes main fields in caption', () => {
-    const { caption, imageUrl } = formatPhotoMessage({
+    const { caption, previewImage } = formatPhotoMessage({
       ...basePhoto,
       takenDate: '2024-01-02T00:00:00Z',
       captions: ['hello'],
@@ -31,17 +31,12 @@ describe('formatPhotoMessage', () => {
     expect(caption).toContain('📝 hello');
     expect(caption).toContain('🏷️ tag1, tag2');
     expect(caption).toContain('👤 Person 2');
-    expect(imageUrl).toBeUndefined();
+    expect(previewImage).toBeUndefined();
   });
 
-  it('uses preview url when provided', () => {
-    const { imageUrl } = formatPhotoMessage({ ...basePhoto, previewUrl: 'http://example.com/preview.jpg' });
-    expect(imageUrl).toBe('http://example.com/preview.jpg');
-  });
-
-  it('falls back to original url', () => {
-    const { imageUrl } = formatPhotoMessage({ ...basePhoto, originalUrl: 'http://example.com/original.jpg' });
-    expect(imageUrl).toBe('http://example.com/original.jpg');
+  it('returns preview image when provided', () => {
+    const { previewImage } = formatPhotoMessage({ ...basePhoto, previewImage: 'abc' });
+    expect(previewImage).toBe('abc');
   });
 
   it('replaces missing person with unknown label', () => {

--- a/frontend/packages/telegram-bot/test/photoInline.test.ts
+++ b/frontend/packages/telegram-bot/test/photoInline.test.ts
@@ -7,7 +7,7 @@ const basePhoto = {
   id: 1,
   name: 'test',
   scale: 1,
-  previewUrl: 'http://example.com/img.jpg',
+  previewImage: 'aGVsbG8=',
   adultScore: 0,
   racyScore: 0,
   height: 100,

--- a/frontend/packages/telegram-bot/test/send.test.ts
+++ b/frontend/packages/telegram-bot/test/send.test.ts
@@ -8,8 +8,7 @@ const basePhoto: PhotoItemDto = {
   id: 1,
   name: 'Test',
   takenDate: '2024-01-01',
-  previewUrl: 'http://example.com/prev.jpg',
-  originalUrl: 'http://example.com/orig.jpg',
+  previewImage: 'aGVsbG8=',
   storageName: 's',
   relativePath: 'r',
 };


### PR DESCRIPTION
## Summary
- switch caption formatter to previewImage field
- send photos using previewImage with base64/URL handling
- extend PhotoItemDto and add toTelegramFile helper

## Testing
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b34ad0117c83289da5f5cca7209c8c