### PR TITLE
refactor: unify ProblemDetails type

### DIFF
--- a/frontend/packages/shared/src/types/problem.ts
+++ b/frontend/packages/shared/src/types/problem.ts
@@ -1,15 +1,12 @@
-export interface ProblemDetails {
-  type?: string;
-  title: string;
-  status: number;
-  detail?: string;
-  instance?: string;
-  [k: string]: unknown;
-}
+import type { ProblemDetails } from '../api/photobank/model/problemDetails';
+export type { ProblemDetails } from '../api/photobank/model/problemDetails';
 
 export class ProblemDetailsError extends Error {
   constructor(public problem: ProblemDetails) {
-    super(problem.title);
+    super(
+      problem.title ??
+        (problem.status != null ? `HTTP ${problem.status}` : 'ProblemDetailsError')
+    );
     this.name = 'ProblemDetailsError';
   }
 }
@@ -22,5 +19,9 @@ export class HttpError extends Error {
 }
 
 export const isProblemDetails = (value: unknown): value is ProblemDetails => {
-  return typeof value === 'object' && value !== null && 'title' in value && 'status' in value;
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  return ['type', 'title', 'status', 'detail', 'instance'].some((k) => k in obj);
 };


### PR DESCRIPTION
## Summary
- replace manual ProblemDetails definition with generated model and adjust helper utilities
- ensure all packages consume shared ProblemDetails type without touching generated schemas
- restore generated schema files to their original form

## Testing
- `pnpm --filter @photobank/shared lint`
- `pnpm --filter @photobank/telegram-bot lint`
- `pnpm --filter @photobank/shared test`
- `pnpm --filter @photobank/telegram-bot test` *(fails: API error)*
- `pnpm --filter @photobank/shared build`
- `pnpm --filter @photobank/telegram-bot build` *(fails: Property 'previewImage' missing in type 'PhotoDto')*

------
https://chatgpt.com/codex/tasks/task_e_68b34c7be9bc8328b1df1c7f258cd738