### PR TITLE
fix: remove unnecessary type assertions in useInfinitePhotos

### DIFF
--- a/frontend/packages/frontend/src/features/photo/useInfinitePhotos.ts
+++ b/frontend/packages/frontend/src/features/photo/useInfinitePhotos.ts
@@ -4,7 +4,6 @@ import { photosSearchPhotos } from '@photobank/shared/api/photobank';
 import type {
   FilterDto,
   photosSearchPhotosResponse,
-  PhotoItemDto,
 } from '@photobank/shared/api/photobank';
 
 export const useInfinitePhotos = (filter: FilterDto) => {
@@ -17,7 +16,7 @@ export const useInfinitePhotos = (filter: FilterDto) => {
       photosSearchPhotos({
         ...filter,
         thisDay: filter.thisDay ?? undefined,
-        page: pageParam as number,
+        page: pageParam,
         pageSize,
       }),
     getNextPageParam: (lastPage, pages) => {
@@ -34,9 +33,9 @@ export const useInfinitePhotos = (filter: FilterDto) => {
 
   const items = useMemo(
     () =>
-      (query.data?.pages.flatMap((p) =>
+      query.data?.pages.flatMap((p) =>
         p.status === 200 ? p.data.items ?? [] : []
-      ) ?? []) as PhotoItemDto[],
+      ) ?? [],
     [query.data]
   );
 


### PR DESCRIPTION
## Summary
- simplify photo paging logic by removing redundant type assertions

## Testing
- `pnpm --filter @photobank/frontend lint`
- `pnpm --filter @photobank/frontend test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b358c362008328a4ae9d62ec977644