### PR TITLE
refactor: simplify inline photo URL handling

### DIFF
--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -43,7 +43,6 @@ bot.on('inline_query', async (ctx: MyContext) => {
       id: number;
       name?: string | null;
       previewUrl?: string | null;
-      originalUrl?: string | null;
       thumbnailUrl?: string | null;
       takenDate?: string | null;
       tags?: { tagId: number }[];
@@ -55,8 +54,8 @@ bot.on('inline_query', async (ctx: MyContext) => {
       (p): InlineQueryResultPhoto => ({
         type: 'photo',
         id: String(p.id),
-        photo_url: p.previewUrl ?? p.originalUrl ?? '',
-        thumbnail_url: p.thumbnailUrl ?? p.previewUrl ?? p.originalUrl ?? '',
+        photo_url: p.previewUrl ?? p.thumbnailUrl ?? '',
+        thumbnail_url: p.thumbnailUrl ?? p.previewUrl ?? '',
         title: p.name ?? `#${p.id}`,
         description: [
           formatDate(p.takenDate),


### PR DESCRIPTION
## Summary
- drop `originalUrl` from inline photo type
- rely on `previewUrl`/`thumbnailUrl` for inline query results

## Testing
- `pnpm --filter @photobank/telegram-bot build` *(fails: Property 'previewUrl' does not exist on type 'PhotoWithUrls')*
- `pnpm --filter @photobank/telegram-bot test -- --run` *(fails: Exit status 130)*

------
https://chatgpt.com/codex/tasks/task_e_68b35fac4bf88328bd3778c871f456c2