### PR TITLE
fix(telegram-bot): always use preview URL

### DIFF
--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -24,7 +24,7 @@ export async function sendPhotoSmart(ctx: Context, p: PhotoItemDto) {
       throttled(() =>
         ctx.api.sendPhoto(
           ctx.chat.id,
-          cached ?? (p.previewUrl ?? p.originalUrl ?? ''),
+          cached ?? (p.previewUrl ?? ''),
           { caption: buildCaption(p) },
         ),
       ),
@@ -33,18 +33,18 @@ export async function sendPhotoSmart(ctx: Context, p: PhotoItemDto) {
     if (newId && newId !== cached) setFileId(p.id, newId);
     return message;
     } catch (e: unknown) {
-      // If cached file_id expired, remove and retry with URL
+      // If cached file_id expired, remove and retry with preview URL
       const err = e as { error_code?: number; description?: string };
       const code = err.error_code;
       const desc = err.description ?? '';
     if (cached && (code === 400 || desc.includes('wrong file identifier'))) {
       delFileId(p.id);
-      logger.warn('file_id invalidated, retry with URL', { photoId: p.id });
+      logger.warn('file_id invalidated, retry with preview URL', { photoId: p.id });
         const message = (await withTelegramRetry(() =>
           throttled(() =>
             ctx.api.sendPhoto(
               ctx.chat.id,
-              p.previewUrl ?? p.originalUrl ?? '',
+              p.previewUrl ?? '',
               { caption: buildCaption(p) },
             ),
           ),
@@ -75,7 +75,7 @@ export async function sendAlbumSmart(ctx: Context, photos: PhotoItemDto[]) {
   for (const group of groups) {
     const medias: InputMediaPhoto[] = group.map((p) => {
       const cached = getFileId(p.id);
-      const media = cached ?? (p.previewUrl ?? p.originalUrl ?? '');
+      const media = cached ?? (p.previewUrl ?? '');
       return {
         type: 'photo',
         media,

--- a/frontend/packages/telegram-bot/test/send.test.ts
+++ b/frontend/packages/telegram-bot/test/send.test.ts
@@ -9,7 +9,6 @@ const basePhoto: PhotoItemDto = {
   name: 'Test',
   takenDate: '2024-01-01',
   previewUrl: 'http://example.com/prev.jpg',
-  originalUrl: 'http://example.com/orig.jpg',
   storageName: 's',
   relativePath: 'r',
 };
@@ -26,6 +25,11 @@ describe('sendPhotoSmart', () => {
     };
     delFileId(basePhoto.id);
     await sendPhotoSmart(ctx, basePhoto);
+    expect(ctx.api.sendPhoto).toHaveBeenCalledWith(
+      ctx.chat.id,
+      basePhoto.previewUrl,
+      { caption: expect.any(String) },
+    );
     expect(ctx.api.sendPhoto).toHaveBeenCalledTimes(1);
     expect(getFileId(basePhoto.id)).toBe('abc');
   });
@@ -44,6 +48,18 @@ describe('sendPhotoSmart', () => {
       },
     };
     await sendPhotoSmart(ctx, photo);
+    expect(ctx.api.sendPhoto).toHaveBeenNthCalledWith(
+      1,
+      ctx.chat.id,
+      'old',
+      { caption: expect.any(String) },
+    );
+    expect(ctx.api.sendPhoto).toHaveBeenNthCalledWith(
+      2,
+      ctx.chat.id,
+      photo.previewUrl,
+      { caption: expect.any(String) },
+    );
     expect(ctx.api.sendPhoto).toHaveBeenCalledTimes(2);
     expect(getFileId(photo.id)).toBe('new');
   });


### PR DESCRIPTION
## Summary
- send photos with preview URLs only
- adjust send tests for preview-only requests

## Testing
- `pnpm -w --filter @photobank/telegram-bot lint`
- `pnpm -w --filter @photobank/telegram-bot test`


------
https://chatgpt.com/codex/tasks/task_e_68b35fbee6d48328b28cca604b4060b1