### PR TITLE
test(frontend): remove unused originalUrl from PhotoDetailsPage test

### DIFF
--- a/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
+++ b/frontend/packages/frontend/test/PhotoDetailsPage.test.tsx
@@ -10,7 +10,6 @@ const photo = {
   id: 1,
   name: 'Test Photo',
   previewUrl: 'http://example.com/prev.jpg',
-  originalUrl: 'http://example.com/orig.jpg',
   scale: 1,
   takenDate: '2024-01-01T00:00:00Z',
   faces: [


### PR DESCRIPTION
## Summary
- remove unused `originalUrl` field from PhotoDetailsPage test photo stub

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b361c7d5b88328b1bcba39a36bdde5