### PR TITLE
fix: prefetch preview image for desktop list

### DIFF
--- a/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
@@ -55,7 +55,7 @@ const PhotoListItemDesktop = ({
 
   const [ref, inView] = useInView<HTMLDivElement>();
   const prefetchHandlers = usePrefetchOnHover([
-    photo.originalUrl ?? '',
+    photo.previewUrl ?? '',
   ]);
 
   const base = photo.previewUrl;


### PR DESCRIPTION
## Summary
- prefetch preview image instead of original in PhotoListItemDesktop

## Testing
- `pnpm -F @photobank/frontend test --run`
- `pnpm -F @photobank/frontend build` *(fails: Property 'previewUrl' does not exist on type 'PhotoItemDto')*

------
https://chatgpt.com/codex/tasks/task_e_68b361cc70dc8328a692a286508cd87d