### PR TITLE
fix: use preview URL for viewer

### DIFF
--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -58,7 +58,7 @@ const PhotoListPage = () => {
       photos.map((p) => ({
         id: p.id,
         preview: p.previewUrl!,
-        original: p.originalUrl!,
+        original: p.previewUrl!,
         title: p.name,
       })),
     [photos]


### PR DESCRIPTION
## Summary
- use previewUrl for viewer original image in photo list

## Testing
- `CI=1 pnpm --filter @photobank/frontend test -- --run`
- `pnpm --filter @photobank/frontend dev`

------
https://chatgpt.com/codex/tasks/task_e_68b361e2dc708328be3e07a2385e4dee