### PR TITLE
refactor: remove original url fallback

### DIFF
--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -3,9 +3,7 @@ import { formatDate } from "@photobank/shared/index";
 
 import { getPersonName } from "./dictionaries";
 
-type PhotoWithUrls = PhotoDto & { originalUrl?: string | null };
-
-export function formatPhotoMessage(photo: PhotoWithUrls): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
+export function formatPhotoMessage(photo: PhotoDto): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
     const lines: string[] = [];
 
     lines.push(`📸 <b>${photo.name}</b>`);
@@ -31,7 +29,7 @@ export function formatPhotoMessage(photo: PhotoWithUrls): { caption: string; has
         }
     }
 
-    const imageUrl = photo.previewUrl ?? photo.originalUrl ?? undefined;
+    const imageUrl = photo.previewUrl ?? undefined;
 
     return {
         caption: lines.join("\n"),

--- a/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
+++ b/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
@@ -7,7 +7,7 @@ vi.mock('../src/dictionaries', () => ({
 }));
 
 describe('formatPhotoMessage', () => {
-  const basePhoto: PhotoDto & { originalUrl?: string } = {
+  const basePhoto: PhotoDto = {
     id: 1,
     name: 'Test',
     scale: 1,
@@ -36,11 +36,6 @@ describe('formatPhotoMessage', () => {
   it('uses preview url when provided', () => {
     const { imageUrl } = formatPhotoMessage({ ...basePhoto, previewUrl: 'http://example.com/preview.jpg' });
     expect(imageUrl).toBe('http://example.com/preview.jpg');
-  });
-
-  it('falls back to original url', () => {
-    const { imageUrl } = formatPhotoMessage({ ...basePhoto, originalUrl: 'http://example.com/original.jpg' });
-    expect(imageUrl).toBe('http://example.com/original.jpg');
   });
 
   it('replaces missing person with unknown label', () => {


### PR DESCRIPTION
## Summary
- drop `originalUrl` from PhotoWithUrls
- simplify image URL selection to use only `previewUrl`
- update formatPhotoMessage tests
- remove redundant `PhotoWithUrls` type alias

## Testing
- `pnpm --filter @photobank/telegram-bot test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b35f92a1908328942854b30fd296a2