### PR TITLE
refactor: use preview-only viewer

### DIFF
--- a/frontend/packages/frontend/src/features/viewer/Lightbox.tsx
+++ b/frontend/packages/frontend/src/features/viewer/Lightbox.tsx
@@ -58,7 +58,7 @@ const Lightbox = () => {
           >
             <ImageCanvas
               thumbSrc={item.preview}
-              src={item.original}
+              src={item.preview}
               alt={item.title}
               fetchPriority="high"
             />

--- a/frontend/packages/frontend/src/features/viewer/prefetch.ts
+++ b/frontend/packages/frontend/src/features/viewer/prefetch.ts
@@ -12,6 +12,5 @@ export const prefetchAround = (
     const item = items[i];
     if (!item) continue;
     prefetch(item.preview);
-    prefetch(item.original);
   }
 };

--- a/frontend/packages/frontend/src/features/viewer/state.ts
+++ b/frontend/packages/frontend/src/features/viewer/state.ts
@@ -3,7 +3,6 @@ import { create } from 'zustand';
 export interface ViewerItem {
   id: number;
   preview: string;
-  original: string;
   title?: string;
 }
 

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -210,7 +210,6 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                                 {
                                                     id: photoData.id,
                                                     preview: photoData.previewUrl,
-                                                    original: photoData.originalUrl ?? photoData.previewUrl,
                                                     title: photoData.name,
                                                 },
                                             ],

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
@@ -55,7 +55,7 @@ const PhotoListItemDesktop = ({
 
   const [ref, inView] = useInView<HTMLDivElement>();
   const prefetchHandlers = usePrefetchOnHover([
-    photo.originalUrl ?? '',
+    photo.previewUrl ?? '',
   ]);
 
   const base = photo.previewUrl;

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -58,7 +58,6 @@ const PhotoListPage = () => {
       photos.map((p) => ({
         id: p.id,
         preview: p.previewUrl!,
-        original: p.originalUrl!,
         title: p.name,
       })),
     [photos]

--- a/frontend/packages/frontend/test/viewer/Lightbox.test.tsx
+++ b/frontend/packages/frontend/test/viewer/Lightbox.test.tsx
@@ -7,9 +7,9 @@ describe('Lightbox', () => {
   it('navigates and closes', async () => {
     render(<Lightbox />);
     const items = [
-      { id: 1, preview: 'a_p', original: 'a', title: 'a' },
-      { id: 2, preview: 'b_p', original: 'b', title: 'b' },
-      { id: 3, preview: 'c_p', original: 'c', title: 'c' },
+      { id: 1, preview: 'a_p', title: 'a' },
+      { id: 2, preview: 'b_p', title: 'b' },
+      { id: 3, preview: 'c_p', title: 'c' },
     ];
     act(() => {
       useViewer.getState().open(items, 1);

--- a/frontend/packages/frontend/test/viewer/prefetch.test.ts
+++ b/frontend/packages/frontend/test/viewer/prefetch.test.ts
@@ -3,9 +3,9 @@ import { prefetchAround } from '@/features/viewer/prefetch';
 describe('prefetchAround', () => {
   it('loads adjacent images', () => {
     const items = [
-      { id: 1, preview: 'a_p', original: 'a_o' },
-      { id: 2, preview: 'b_p', original: 'b_o' },
-      { id: 3, preview: 'c_p', original: 'c_o' },
+      { id: 1, preview: 'a_p' },
+      { id: 2, preview: 'b_p' },
+      { id: 3, preview: 'c_p' },
     ];
     const loaded: string[] = [];
     // @ts-ignore
@@ -16,10 +16,7 @@ describe('prefetchAround', () => {
     };
     prefetchAround(items, 1);
     expect(loaded).toContain('a_p');
-    expect(loaded).toContain('a_o');
     expect(loaded).toContain('c_p');
-    expect(loaded).toContain('c_o');
     expect(loaded).not.toContain('b_p');
-    expect(loaded).not.toContain('b_o');
   });
 });


### PR DESCRIPTION
## Summary
- remove `original` field from viewer items and rely on preview URL for display and prefetch

## Testing
- `cd frontend && pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b361e96fcc83289549f92c0e5da55a