### PR TITLE
refactor: remove S3 keys from photo DTOs

### DIFF
--- a/backend/PhotoBank.MAUI.Blazor/Components/Pages/PhotoDetail.razor
+++ b/backend/PhotoBank.MAUI.Blazor/Components/Pages/PhotoDetail.razor
@@ -5,9 +5,9 @@
 @using System.Linq
 @if (Photo != null)
 {
-    @if (!string.IsNullOrEmpty(Photo.S3Key_Preview))
+    @if (!string.IsNullOrEmpty(Photo.PreviewUrl))
     {
-        <img src="@Photo.S3Key_Preview" alt="@string.Join(" ", Photo.Captions)" />
+        <img src="@Photo.PreviewUrl" alt="@string.Join(" ", Photo.Captions)" />
     }
 }
 else

--- a/backend/PhotoBank.MAUI.Blazor/Components/Pages/PhotoOverview.razor
+++ b/backend/PhotoBank.MAUI.Blazor/Components/Pages/PhotoOverview.razor
@@ -67,9 +67,9 @@
                 <RadzenLink Path="@string.Format("photodetail/{0}", data.Id)" Text="@data.Id.ToString()" target="_blank" />
             </Template>
         </RadzenDataGridColumn>
-        <RadzenDataGridColumn TItem="PhotoItemDto" Property="S3Key_Thumbnail" Title="Thumbnail" Sortable="false" Filterable="false">
+        <RadzenDataGridColumn TItem="PhotoItemDto" Property="ThumbnailUrl" Title="Thumbnail" Sortable="false" Filterable="false">
             <Template Context="data">
-                @data.S3Key_Thumbnail
+                <img src="@data.ThumbnailUrl" alt="@data.Name" />
             </Template>
         </RadzenDataGridColumn>
         <RadzenDataGridColumn TItem="PhotoItemDto" Property="Name" Title="Name" />

--- a/backend/PhotoBank.Services/MappingProfile.cs
+++ b/backend/PhotoBank.Services/MappingProfile.cs
@@ -21,7 +21,6 @@ namespace PhotoBank.Services
                             Longitude = src.Location.Coordinate.Y
                         }))
                 .ForMember(dest => dest.PreviewUrl, opt => opt.Ignore())
-                .ForMember(dest => dest.ThumbnailUrl, opt => opt.Ignore())
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
             CreateMap<Caption, string>().ConvertUsing(c => c.Text);
@@ -39,9 +38,6 @@ namespace PhotoBank.Services
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
             CreateMap<Photo, PhotoItemDto>()
-                .ForMember(dest => dest.S3Key_Thumbnail, opt => opt.MapFrom(src => src.S3Key_Thumbnail))
-                .ForMember(dest => dest.S3Key_Preview, opt => opt.MapFrom(src => src.S3Key_Preview))
-                .ForMember(dest => dest.PreviewUrl, opt => opt.Ignore())
                 .ForMember(dest => dest.ThumbnailUrl, opt => opt.Ignore())
                 .ForMember(dest => dest.Tags, opt => opt.MapFrom(src => src.PhotoTags))
                 .ForMember(dest => dest.Persons, opt => opt.MapFrom(src => src.Faces))

--- a/backend/PhotoBank.ViewModel.Dto/PhotoDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/PhotoDto.cs
@@ -12,10 +12,7 @@ namespace PhotoBank.ViewModel.Dto
         public required string Name { get; set; }
         public double Scale { get; set; }
         public DateTime? TakenDate { get; set; }
-        public string? S3Key_Preview { get; set; }
-        public string? S3Key_Thumbnail { get; set; }
         public string? PreviewUrl { get; set; }
-        public string? ThumbnailUrl { get; set; }
         public GeoPointDto? Location { get; set; }
         public int? Orientation { get; set; }
         public List<FaceDto>? Faces { get; set; }

--- a/backend/PhotoBank.ViewModel.Dto/PhotoItemDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/PhotoItemDto.cs
@@ -8,10 +8,7 @@ namespace PhotoBank.ViewModel.Dto
         [System.ComponentModel.DataAnnotations.Required]
         public int Id { get; set; }
 
-        public string? S3Key_Thumbnail { get; set; }
-        public string? S3Key_Preview { get; set; }
         public string? ThumbnailUrl { get; set; }
-        public string? PreviewUrl { get; set; }
 
         [System.ComponentModel.DataAnnotations.Required]
         public required string Name { get; set; }

--- a/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoDetail.razor
+++ b/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoDetail.razor
@@ -46,9 +46,9 @@
 else
 {
     <div class="wrapper">
-        @if (!string.IsNullOrEmpty(Photo.S3Key_Preview))
+        @if (!string.IsNullOrEmpty(Photo.PreviewUrl))
         {
-            <img src="@Photo.S3Key_Preview" alt="@string.Join(" ", Photo.Captions ?? Array.Empty<string>())"/>
+            <img src="@Photo.PreviewUrl" alt="@string.Join(" ", Photo.Captions ?? Array.Empty<string>())"/>
         }
         @for (var i = 0; i < (Photo.Faces?.Count ?? 0); i++)
         {

--- a/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoOverview.razor
+++ b/backend/Photobank.ServerBlazorApp/Components/Pages/PhotoOverview.razor
@@ -76,9 +76,9 @@
                     <RadzenLink Path="@string.Format("photodetail/{0}", data.Id)" Text="@data.Id.ToString()" target="_blank" />
                 </Template>
             </RadzenDataGridColumn>
-            <RadzenDataGridColumn TItem="PhotoItemDto" Property="S3Key_Thumbnail" Title="Thumbnail" Sortable="false" Filterable="false">
+            <RadzenDataGridColumn TItem="PhotoItemDto" Property="ThumbnailUrl" Title="Thumbnail" Sortable="false" Filterable="false">
                 <Template Context="data">
-                    @data.S3Key_Thumbnail
+                    <img src="@data.ThumbnailUrl" alt="@data.Name" />
                 </Template>
             </RadzenDataGridColumn>
             <RadzenDataGridColumn TItem="PhotoItemDto" Property="Name" Title="Name" />


### PR DESCRIPTION
## Summary
- drop S3 key fields from photo DTOs
- clean up PhotoItem mapping and fetch S3 keys internally for URLs
- adjust MAUI and Blazor pages to render URLs
- trim unused Thumbnail/Preview URL properties from photo DTOs and services

## Testing
- `dotnet restore PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet build PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*


------
https://chatgpt.com/codex/tasks/task_e_68b3ebd64ea883289d90739f08b25e89