### PR TITLE
refactor: remove S3 key from face dto

### DIFF
--- a/backend/PhotoBank.Services/MappingProfile.cs
+++ b/backend/PhotoBank.Services/MappingProfile.cs
@@ -79,7 +79,6 @@ namespace PhotoBank.Services
                 .ForMember(dest => dest.PersonId, opt => opt.MapFrom(src => src.PersonFace.PersonId))
                 .ForMember(dest => dest.PersonDateOfBirth, opt => opt.MapFrom(src => src.Person.DateOfBirth))
                 .ForMember(dest => dest.PhotoTakenDate, opt => opt.MapFrom(src => src.Photo.TakenDate))
-                .ForMember(dest => dest.S3Key_Image, opt => opt.MapFrom(src => src.S3Key_Image))
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
         }
     }

--- a/backend/PhotoBank.Services/Models/FaceDto.cs
+++ b/backend/PhotoBank.Services/Models/FaceDto.cs
@@ -10,8 +10,6 @@ namespace PhotoBank.Services.Models
         public int Id { get; set; }
         public int? PersonId { get; set; }
         [Required]
-        public string S3Key_Image { get; set; }
-        [Required]
         public IdentityStatus IdentityStatus { get; set; }
         public DateTime? PersonDateOfBirth { get; set; }
         public DateTime? PhotoTakenDate { get; set; }


### PR DESCRIPTION
## Summary
- remove `S3Key_Image` property from `FaceDto`
- query S3 keys directly from the database in `GroupIdentifyAsync`

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Services/PhotoBank.Services.csproj`
- `dotnet build PhotoBank.Backend.sln` *(fails: Xunit namespace not found)*
- `dotnet test PhotoBank.Backend.sln` *(fails: Xunit namespace not found; integration tests skipped due to missing XPlat Code Coverage collector)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f518baa483289b090b6a23bf1d6d