### PR TITLE
chore: add OpenAPI generation workflow

### DIFF
--- a/.github/workflows/generate-api.yml
+++ b/.github/workflows/generate-api.yml
@@ -1,0 +1,35 @@
+name: Generate OpenAPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: windows-latest
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+          cache: true
+          cache-dependency-path: backend/**/*.csproj
+      - name: Restore
+        run: dotnet restore backend/PhotoBank.Api/PhotoBank.Api.csproj
+      - name: Build backend
+        run: dotnet build backend/PhotoBank.Api/PhotoBank.Api.csproj -c Debug --no-restore
+      - name: Generate OpenAPI spec
+        working-directory: backend/PhotoBank.Api
+        run: ./generateApi.bat
+      - name: Commit generated spec
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add openapi.yaml
+          git commit -m "chore: update OpenAPI spec" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
## Summary
- add workflow to build backend and run generateApi.bat on windows
- commit updated OpenAPI spec back to repository
- run OpenAPI generation workflow only when manually triggered

## Testing
- `pnpm -w test` *(fails: `--workspace-root may only be used inside a workspace`)*

------
https://chatgpt.com/codex/tasks/task_e_68b43039824883288f0a7eebcc1d4e96