### PR TITLE
chore: add frontend API generation workflow

### DIFF
--- a/.github/workflows/generate-frontend-api.yml
+++ b/.github/workflows/generate-frontend-api.yml
@@ -1,0 +1,42 @@
+name: Generate Frontend API
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate API client
+        working-directory: frontend
+        run: pnpm run generate:api
+
+      - name: Commit generated client
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add frontend/packages/shared/src/api/photobank frontend/packages/telegram-bot/src/api/photobank
+          git commit -m "chore: update frontend API client" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
## Summary
- add GitHub workflow to generate frontend API client and commit changes

## Testing
- `pnpm -w test` *(fails: --workspace-root may only be used inside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68b43637e228832885d0261ee94b6862