### PR TITLE
chore: restore dotnet tools in API workflow

### DIFF
--- a/.github/workflows/generate-api.yml
+++ b/.github/workflows/generate-api.yml
@@ -23,6 +23,9 @@ jobs:
         run: dotnet restore backend/PhotoBank.Api/PhotoBank.Api.csproj
       - name: Build backend
         run: dotnet build backend/PhotoBank.Api/PhotoBank.Api.csproj -c Debug --no-restore
+      - name: Restore dotnet tools
+        working-directory: backend/PhotoBank.Api
+        run: dotnet tool restore
       - name: Generate OpenAPI spec
         working-directory: backend/PhotoBank.Api
         run: ./generateApi.bat


### PR DESCRIPTION
## Summary
- restore dotnet tools before generating API spec

## Testing
- `dotnet tool restore --tool-manifest backend/PhotoBank.Api/.config/dotnet-tools.json`
- `dotnet test backend/PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b4374b57e0832880564c6dccf012c9