### PR TITLE
fix: use thumbnailUrl for photo list items

### DIFF
--- a/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemDesktop.tsx
@@ -55,10 +55,10 @@ const PhotoListItemDesktop = ({
 
   const [ref, inView] = useInView<HTMLDivElement>();
   const prefetchHandlers = usePrefetchOnHover([
-    photo.previewUrl ?? '',
+    photo.thumbnailUrl ?? '',
   ]);
 
-  const base = photo.previewUrl;
+  const base = photo.thumbnailUrl;
   const srcSet = base
     ? [
         `${base}?w=480 480w`,
@@ -89,7 +89,7 @@ const PhotoListItemDesktop = ({
               <SmartImage
                 alt={photo.name}
                 thumbSrc={photo.thumbnailUrl ?? ''}
-                src={photo.previewUrl ?? ''}
+                src={photo.thumbnailUrl ?? ''}
                 srcSet={srcSet}
                 sizes={sizes}
                 className="w-full h-full rounded-lg"

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -57,10 +57,7 @@ const PhotoListPage = () => {
     () =>
       photos.map((p) => ({
         id: p.id,
-        preview: p.previewUrl!,
-
-
-
+        preview: p.thumbnailUrl!,
         title: p.name,
       })),
     [photos]


### PR DESCRIPTION
## Summary
- replace obsolete `previewUrl` usages with `thumbnailUrl` in photo list components

## Testing
- `pnpm --filter frontend lint`
- `CI=1 pnpm --filter frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68b445f5ade48328b6807879bcc8b157