### PR TITLE
fix: type infinite photos page param

### DIFF
--- a/frontend/packages/frontend/src/features/photo/useInfinitePhotos.ts
+++ b/frontend/packages/frontend/src/features/photo/useInfinitePhotos.ts
@@ -9,7 +9,13 @@ import type {
 export const useInfinitePhotos = (filter: FilterDto) => {
   const pageSize = filter.pageSize ?? 10;
 
-  const query = useInfiniteQuery<photosSearchPhotosResponse>({
+  const query = useInfiniteQuery<
+    photosSearchPhotosResponse,
+    Error,
+    photosSearchPhotosResponse,
+    [string, FilterDto],
+    number
+  >({
     queryKey: ['photos', filter],
     initialPageParam: 1,
     queryFn: ({ pageParam }) =>


### PR DESCRIPTION
## Summary
- specify numeric page param in `useInfinitePhotos` query
- query function now receives page numbers directly

## Testing
- `pnpm lint`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_68b452ba6860832890da4cdc1a82f6ec