### PR TITLE
fix: use thumbnailUrl for photo items

### DIFF
--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -42,7 +42,6 @@ bot.on('inline_query', async (ctx: MyContext) => {
     type Photo = {
       id: number;
       name?: string | null;
-      previewUrl?: string | null;
       thumbnailUrl?: string | null;
       takenDate?: string | null;
       tags?: { tagId: number }[];
@@ -54,8 +53,8 @@ bot.on('inline_query', async (ctx: MyContext) => {
       (p): InlineQueryResultPhoto => ({
         type: 'photo',
         id: String(p.id),
-        photo_url: p.previewUrl ?? p.thumbnailUrl ?? '',
-        thumbnail_url: p.thumbnailUrl ?? p.previewUrl ?? '',
+        photo_url: p.thumbnailUrl ?? '',
+        thumbnail_url: p.thumbnailUrl ?? '',
         title: p.name ?? `#${p.id}`,
         description: [
           formatDate(p.takenDate),

--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -24,7 +24,7 @@ export async function sendPhotoSmart(ctx: Context, p: PhotoItemDto) {
       throttled(() =>
         ctx.api.sendPhoto(
           ctx.chat.id,
-          cached ?? (p.previewUrl ?? ''),
+          cached ?? (p.thumbnailUrl ?? ''),
           { caption: buildCaption(p) },
         ),
       ),
@@ -33,18 +33,18 @@ export async function sendPhotoSmart(ctx: Context, p: PhotoItemDto) {
     if (newId && newId !== cached) setFileId(p.id, newId);
     return message;
     } catch (e: unknown) {
-      // If cached file_id expired, remove and retry with preview URL
+      // If cached file_id expired, remove and retry with thumbnail URL
       const err = e as { error_code?: number; description?: string };
       const code = err.error_code;
       const desc = err.description ?? '';
     if (cached && (code === 400 || desc.includes('wrong file identifier'))) {
       delFileId(p.id);
-      logger.warn('file_id invalidated, retry with preview URL', { photoId: p.id });
+      logger.warn('file_id invalidated, retry with thumbnail URL', { photoId: p.id });
         const message = (await withTelegramRetry(() =>
           throttled(() =>
             ctx.api.sendPhoto(
               ctx.chat.id,
-              p.previewUrl ?? '',
+              p.thumbnailUrl ?? '',
               { caption: buildCaption(p) },
             ),
           ),
@@ -75,7 +75,7 @@ export async function sendAlbumSmart(ctx: Context, photos: PhotoItemDto[]) {
   for (const group of groups) {
     const medias: InputMediaPhoto[] = group.map((p) => {
       const cached = getFileId(p.id);
-      const media = cached ?? (p.previewUrl ?? '');
+      const media = cached ?? (p.thumbnailUrl ?? '');
       return {
         type: 'photo',
         media,

--- a/frontend/packages/telegram-bot/test/send.test.ts
+++ b/frontend/packages/telegram-bot/test/send.test.ts
@@ -8,7 +8,7 @@ const basePhoto: PhotoItemDto = {
   id: 1,
   name: 'Test',
   takenDate: '2024-01-01',
-  previewUrl: 'http://example.com/prev.jpg',
+  thumbnailUrl: 'http://example.com/thumb.jpg',
   storageName: 's',
   relativePath: 'r',
 };
@@ -27,7 +27,7 @@ describe('sendPhotoSmart', () => {
     await sendPhotoSmart(ctx, basePhoto);
     expect(ctx.api.sendPhoto).toHaveBeenCalledWith(
       ctx.chat.id,
-      basePhoto.previewUrl,
+      basePhoto.thumbnailUrl,
       { caption: expect.any(String) },
     );
     expect(ctx.api.sendPhoto).toHaveBeenCalledTimes(1);
@@ -57,7 +57,7 @@ describe('sendPhotoSmart', () => {
     expect(ctx.api.sendPhoto).toHaveBeenNthCalledWith(
       2,
       ctx.chat.id,
-      photo.previewUrl,
+      photo.thumbnailUrl,
       { caption: expect.any(String) },
     );
     expect(ctx.api.sendPhoto).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary
- replace deprecated previewUrl usage with thumbnailUrl in Telegram bot
- adjust inline handler and send tests for new field

## Testing
- `pnpm --filter telegram-bot build`
- `pnpm --filter telegram-bot test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b482ed1b588328b8b2e08b1b3de3a1