### PR TITLE
fix: allow overriding current user in tests

### DIFF
--- a/backend/PhotoBank.IntegrationTests/FaceImageEndpointTests.cs
+++ b/backend/PhotoBank.IntegrationTests/FaceImageEndpointTests.cs
@@ -19,6 +19,7 @@ using Minio.DataModel.Args;
 using Moq;
 using NUnit.Framework;
 using PhotoBank.Api.Controllers;
+using PhotoBank.AccessControl;
 using PhotoBank.DbContext.DbContext;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Services;
@@ -57,6 +58,7 @@ public class FaceImageEndpointTests
             }));
         services
             .AddPhotobankCore()
+            .AddScoped<ICurrentUser, DummyCurrentUser>()
             .AddPhotobankApi();
         services.AddLogging();
         services.AddSingleton<IMinioClient>(Mock.Of<IMinioClient>());
@@ -98,6 +100,7 @@ public class FaceImageEndpointTests
             }));
         services
             .AddPhotobankCore()
+            .AddScoped<ICurrentUser, DummyCurrentUser>()
             .AddPhotobankApi();
         services.AddLogging();
         services.AddSingleton(minioClient);

--- a/backend/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
+++ b/backend/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
+using PhotoBank.AccessControl;
 using PhotoBank.DbContext.DbContext;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
@@ -57,6 +58,7 @@ public class GetAllPhotosIntegrationTests
                     }));
             services
                 .AddPhotobankCore(_config)
+                .AddScoped<ICurrentUser, DummyCurrentUser>()
                 .AddPhotobankApi();
 
             services.AddLogging();

--- a/backend/PhotoBank.Services/ServiceCollectionExtensions.cs
+++ b/backend/PhotoBank.Services/ServiceCollectionExtensions.cs
@@ -56,14 +56,13 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddPhotobankApi(this IServiceCollection services, IConfiguration? configuration = null)
     {
         services.AddHttpContextAccessor();
-        services.TryAddScoped<ICurrentUser, DummyCurrentUser>();
         services.AddScoped<IPhotoService, PhotoService>();
         services.AddSingleton<ITokenService, TokenService>();
         services.AddSingleton<IImageService, ImageService>();
         services.AddSingleton<IS3ResourceService, S3ResourceService>();
         services.AddTransient<IFaceStorageService, FaceStorageService>();
         services.AddScoped<IEffectiveAccessProvider, EffectiveAccessProvider>();
-        services.AddScoped<ICurrentUser, CurrentUser>();
+        services.TryAddScoped<ICurrentUser, CurrentUser>();
         return services;
     }
 


### PR DESCRIPTION
## Summary
- avoid hardcoding `ICurrentUser` in API service registrations
- explicitly register `DummyCurrentUser` in integration tests

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b54e28ed308328908c7565edee3688