### PR TITLE
refactor: centralize DbContext registration

### DIFF
--- a/backend/PhotoBank.Console/Program.cs
+++ b/backend/PhotoBank.Console/Program.cs
@@ -1,10 +1,5 @@
-using AutoMapper;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using PhotoBank.DbContext.DbContext;
-using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using Serilog;
@@ -27,19 +22,7 @@ namespace PhotoBank.Console
                     .WriteTo.File("consoleapp.log"))
                 .ConfigureServices((context, services) =>
                 {
-                    var connectionString = context.Configuration.GetConnectionString("DefaultConnection");
-
-                    services.AddDbContext<PhotoBankDbContext>(opts =>
-                    {
-                        opts.UseSqlServer(connectionString, builder =>
-                        {
-                            builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
-                            builder.UseNetTopologySuite();
-                            builder.CommandTimeout(120);
-                        });
-                        opts.EnableSensitiveDataLogging();
-                        opts.EnableDetailedErrors();
-                    });
+                    services.AddPhotobankDbContext(context.Configuration, usePool: false);
 
                     services
                         .AddPhotobankCore(context.Configuration)

--- a/backend/PhotoBank.Services/ServiceCollectionExtensions.cs
+++ b/backend/PhotoBank.Services/ServiceCollectionExtensions.cs
@@ -2,11 +2,15 @@ using Amazon.Rekognition;
 using MediatR;
 using Microsoft.Azure.CognitiveServices.Vision.ComputerVision;
 using Microsoft.Azure.CognitiveServices.Vision.Face;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Minio;
 using PhotoBank.AccessControl;
+using PhotoBank.DbContext.DbContext;
 using PhotoBank.InsightFaceApiClient;
 using PhotoBank.Repositories;
 using PhotoBank.Services.Api;
@@ -139,6 +143,65 @@ public static class ServiceCollectionExtensions
                     });
             };
         });
+        return services;
+    }
+
+    public static IServiceCollection AddPhotobankDbContext(this IServiceCollection services, IConfiguration configuration, bool usePool)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+                               ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+
+        services.AddSingleton<DbTimingInterceptor>();
+
+        if (usePool)
+        {
+            services.AddDbContextPool<PhotoBankDbContext>((sp, options) =>
+            {
+                var env = sp.GetRequiredService<IHostEnvironment>();
+                options.AddInterceptors(sp.GetRequiredService<DbTimingInterceptor>());
+                options
+                    .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+                    .EnableDetailedErrors(env.IsDevelopment())
+                    .EnableSensitiveDataLogging(env.IsDevelopment());
+
+                options.UseLoggerFactory(LoggerFactory.Create(b => b.AddDebug()));
+
+                options.UseSqlServer(
+                    connectionString,
+                    sql =>
+                    {
+                        sql.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
+                        sql.UseNetTopologySuite();
+                        sql.EnableRetryOnFailure(5, TimeSpan.FromSeconds(5), null);
+                        sql.CommandTimeout(60);
+                        sql.MaxBatchSize(128);
+                        sql.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
+                    });
+            });
+        }
+        else
+        {
+            services.AddDbContext<PhotoBankDbContext>((sp, options) =>
+            {
+                var env = sp.GetRequiredService<IHostEnvironment>();
+                options.AddInterceptors(sp.GetRequiredService<DbTimingInterceptor>());
+                options
+                    .EnableDetailedErrors(env.IsDevelopment())
+                    .EnableSensitiveDataLogging(env.IsDevelopment());
+
+                options.UseSqlServer(
+                    connectionString,
+                    sql =>
+                    {
+                        sql.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
+                        sql.UseNetTopologySuite();
+                        sql.CommandTimeout(120);
+                    });
+            });
+        }
+
+        services.AddDbContext<AccessControlDbContext>(opt => { opt.UseSqlServer(connectionString); });
+
         return services;
     }
 


### PR DESCRIPTION
## Summary
- add AddPhotobankDbContext helper for pooled and non-pooled EF Core setup
- switch API and Console to AddPhotobankDbContext

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b550e813848328a13f23a0d0bab6aa