### PR TITLE
refactor: centralize auth setup in service extension

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -2,13 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using PhotoBank.DbContext.DbContext;
-using PhotoBank.DbContext.Models;
-using Microsoft.AspNetCore.Identity;
 using PhotoBank.Services;
-using PhotoBank.Services.FaceRecognition;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.IdentityModel.Tokens;
-using System.Text;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -53,37 +47,6 @@ namespace PhotoBank.Api
             });
 
             builder.Services.AddPhotobankDbContext(builder.Configuration, usePool: true);
-
-            builder.Services.AddDefaultIdentity<ApplicationUser>()
-                .AddRoles<IdentityRole>()
-                .AddEntityFrameworkStores<PhotoBankDbContext>();
-
-            var jwtSection = builder.Configuration.GetSection("Jwt");
-            builder.Services.AddAuthentication(options =>
-            {
-                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-            }).AddJwtBearer(options =>
-            {
-                options.TokenValidationParameters = new TokenValidationParameters
-                {
-                    ValidateIssuer = true,
-                    ValidateAudience = true,
-                    ValidateLifetime = true,
-                    ValidateIssuerSigningKey = true,
-                    ValidIssuer = jwtSection["Issuer"],
-                    ValidAudience = jwtSection["Audience"],
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSection["Key"]!))
-                };
-            });
-
-
-            builder.Services.AddAuthorization(options =>
-            {
-                options.FallbackPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
-                    .RequireAuthenticatedUser()
-                    .Build();
-            });
 
             builder.Services.Configure<RouteOptions>(options =>
             {
@@ -132,7 +95,7 @@ namespace PhotoBank.Api
 
             builder.Services
                 .AddPhotobankCore(builder.Configuration)
-                .AddPhotobankApi();
+                .AddPhotobankApi(builder.Configuration);
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.

--- a/backend/PhotoBank.Services/PhotoBank.Services.csproj
+++ b/backend/PhotoBank.Services/PhotoBank.Services.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.8" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />


### PR DESCRIPTION
## Summary
- centralize identity, JWT authentication, and authorization in `AddPhotobankApi`
- simplify API startup to call the new service extension

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b55312dfe883288ce51fa2151e7f05