### PR TITLE
refactor: centralize CORS and Swagger configuration

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -1,6 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.AspNetCore.Mvc.Controllers;
 using PhotoBank.DbContext.DbContext;
 using PhotoBank.Services;
 using Microsoft.AspNetCore.Diagnostics;
@@ -34,18 +32,6 @@ namespace PhotoBank.Api
             builder.WebHost.UseUrls("http://0.0.0.0:5066");
 
             // Add services to the container.
-            builder.Services.AddCors(options =>
-            {
-                options.AddPolicy("AllowAll", policy =>
-                {
-                    policy
-                        .SetIsOriginAllowed(_ => true)
-                        .AllowAnyMethod()
-                        .AllowAnyHeader()
-                        .AllowCredentials();
-                });
-            });
-
             builder.Services.AddPhotobankDbContext(builder.Configuration, usePool: true);
 
             builder.Services.Configure<RouteOptions>(options =>
@@ -75,27 +61,12 @@ namespace PhotoBank.Api
                     new BadRequestObjectResult(new ValidationProblemDetails(context.ModelState));
             });
 
-            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-            builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen(c =>
-            {
-                c.CustomOperationIds(apiDesc =>
-                {
-                    if (apiDesc.ActionDescriptor is ControllerActionDescriptor descriptor)
-                    {
-                        var controllerName = descriptor.ControllerName;
-                        var actionName = descriptor.ActionName;
-                        return $"{controllerName}_{actionName}";
-                    }
-
-                    return null;
-                });
-                c.DocumentFilter<ServersDocumentFilter>();
-            });
-
             builder.Services
                 .AddPhotobankCore(builder.Configuration)
-                .AddPhotobankApi(builder.Configuration);
+                .AddPhotobankApi(builder.Configuration, configureCors: true, configureSwagger: c =>
+                {
+                    c.DocumentFilter<ServersDocumentFilter>();
+                });
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.

--- a/backend/PhotoBank.Services/PhotoBank.Services.csproj
+++ b/backend/PhotoBank.Services/PhotoBank.Services.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.8" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />


### PR DESCRIPTION
## Summary
- make AddPhotobankApi optionally wire up CORS and Swagger
- wire Program.cs through AddPhotobankApi and remove duplicate setup
- add Swashbuckle package to services project

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln --no-build` *(fails: SQL Server not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b554e47b388328b1869441adfbb1fe