### PR TITLE
refactor: centralize photo service registrations

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
@@ -26,11 +26,9 @@ public static partial class ServiceCollectionExtensions
         Action<SwaggerGenOptions>? configureSwagger = null)
     {
         services.AddHttpContextAccessor();
-        services.AddScoped<IPhotoService, PhotoService>();
         services.AddSingleton<ITokenService, TokenService>();
         services.AddSingleton<IImageService, ImageService>();
         services.AddSingleton<IS3ResourceService, S3ResourceService>();
-        services.AddTransient<IFaceStorageService, FaceStorageService>();
         services.AddScoped<IEffectiveAccessProvider, EffectiveAccessProvider>();
         services.TryAddScoped<ICurrentUser, CurrentUser>();
         services.AddDefaultIdentity<ApplicationUser>()

--- a/backend/PhotoBank.DependencyInjection/AddPhotobankConsoleExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankConsoleExtensions.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using PhotoBank.AccessControl;
 using PhotoBank.InsightFaceApiClient;
 using PhotoBank.Services;
-using PhotoBank.Services.Api;
 using PhotoBank.Services.Enrichers;
 using PhotoBank.Services.Enrichers.Services;
 using PhotoBank.Services.FaceRecognition;
@@ -49,9 +48,7 @@ public static partial class ServiceCollectionExtensions
         services.AddTransient<IFaceService, FaceService>();
         services.AddTransient<IFacePreviewService, FacePreviewService>();
         services.AddTransient<IFaceServiceAws, FaceServiceAws>();
-        services.AddTransient<IFaceStorageService, FaceStorageService>();
         services.AddTransient<IPhotoProcessor, PhotoProcessor>();
-        services.AddTransient<IPhotoService, PhotoService>();
         services.AddSingleton<ICurrentUser, DummyCurrentUser>();
         services.AddTransient<IImageService, ImageService>();
         services.AddTransient<ISyncService, SyncService>();

--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Minio;
 using PhotoBank.Repositories;
 using PhotoBank.Services;
+using PhotoBank.Services.Api;
 using PhotoBank.Services.Search;
 using PhotoBank.Services.Translator;
 using Polly;
@@ -20,6 +21,8 @@ public static partial class ServiceCollectionExtensions
             .WithCredentials("", "")
             .Build());
         services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
+        services.AddScoped<IFaceStorageService, FaceStorageService>();
+        services.AddScoped<IPhotoService, PhotoService>();
         services.AddPhotoEvents();
         if (configuration != null)
         {


### PR DESCRIPTION
## Summary
- register IFaceStorageService and IPhotoService in AddPhotobankCore
- remove duplicated registrations from AddPhotobankApi and AddPhotobankConsole

## Testing
- `dotnet restore PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet build PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test PhotoBank.Backend.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b55c61343c832898f3368ad20c2a26