### PR TITLE
feat: configure vision clients through options

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankConsoleExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankConsoleExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.CognitiveServices.Vision.ComputerVision;
 using Microsoft.Azure.CognitiveServices.Vision.Face;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using PhotoBank.AccessControl;
 using PhotoBank.InsightFaceApiClient;
 using PhotoBank.Services;
@@ -23,23 +24,26 @@ public static partial class ServiceCollectionExtensions
         const string computerVision = "ComputerVision";
         const string face = "Face";
 
+        services.Configure<ComputerVisionOptions>(configuration.GetSection(computerVision));
+        services.Configure<FaceApiOptions>(configuration.GetSection(face));
+
         services.AddSingleton<IComputerVisionClient, ComputerVisionClient>(provider =>
         {
-            var key = configuration.GetSection(computerVision)["Key"];
-            var credentials = new ApiKeyServiceClientCredentials(key);
+            var options = provider.GetRequiredService<IOptions<ComputerVisionOptions>>().Value;
+            var credentials = new ApiKeyServiceClientCredentials(options.Key);
             return new ComputerVisionClient(credentials)
             {
-                Endpoint = configuration.GetSection(computerVision)["Endpoint"]
+                Endpoint = options.Endpoint
             };
         });
 
         services.AddSingleton<IFaceClient, FaceClient>(provider =>
         {
-            var key = configuration.GetSection(face)["Key"];
-            var credentials = new ApiKeyServiceClientCredentials(key);
+            var options = provider.GetRequiredService<IOptions<FaceApiOptions>>().Value;
+            var credentials = new ApiKeyServiceClientCredentials(options.Key);
             return new FaceClient(credentials)
             {
-                Endpoint = configuration.GetSection(face)["Endpoint"]
+                Endpoint = options.Endpoint
             };
         });
 

--- a/backend/PhotoBank.DependencyInjection/ComputerVisionOptions.cs
+++ b/backend/PhotoBank.DependencyInjection/ComputerVisionOptions.cs
@@ -1,0 +1,7 @@
+namespace PhotoBank.DependencyInjection;
+
+public sealed class ComputerVisionOptions
+{
+    public string Endpoint { get; init; } = string.Empty;
+    public string Key { get; init; } = string.Empty;
+}

--- a/backend/PhotoBank.DependencyInjection/FaceApiOptions.cs
+++ b/backend/PhotoBank.DependencyInjection/FaceApiOptions.cs
@@ -1,0 +1,7 @@
+namespace PhotoBank.DependencyInjection;
+
+public sealed class FaceApiOptions
+{
+    public string Endpoint { get; init; } = string.Empty;
+    public string Key { get; init; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- add ComputerVisionOptions and FaceApiOptions classes
- bind console services to configuration sections for vision APIs
- use IOptions when creating ComputerVisionClient and FaceClient

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b55e1a9a748328aed2117c84c979d8