### PR TITLE
feat: configure Minio client via options

### DIFF
--- a/backend/PhotoBank.Api/appsettings.Development.json
+++ b/backend/PhotoBank.Api/appsettings.Development.json
@@ -14,6 +14,11 @@
     "Endpoint": "https://api.cognitive.microsofttranslator.com",
     "Region": "westeurope"
   },
+  "Minio": {
+    "Endpoint": "localhost:9000",
+    "AccessKey": "your-access-key",
+    "SecretKey": "your-secret-key"
+  },
   "Auth": {
     "Telegram": {
       "ServiceKey": "your-super-secret-service-key"

--- a/backend/PhotoBank.DependencyInjection/MinioOptions.cs
+++ b/backend/PhotoBank.DependencyInjection/MinioOptions.cs
@@ -1,0 +1,9 @@
+namespace PhotoBank.DependencyInjection;
+
+public sealed class MinioOptions
+{
+    public string Endpoint { get; init; } = "localhost";
+    public string AccessKey { get; init; } = string.Empty;
+    public string SecretKey { get; init; } = string.Empty;
+}
+


### PR DESCRIPTION
## Summary
- add `MinioOptions` for endpoint and credentials
- bind Minio configuration and register `IMinioClient`
- document Minio settings in development appsettings

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b55f54c9708328a1e4b9a557951700