### PR TITLE
refactor: require configuration for API setup

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -63,7 +63,9 @@ namespace PhotoBank.Api
 
             builder.Services
                 .AddPhotobankCore(builder.Configuration)
-                .AddPhotobankApi(builder.Configuration, configureCors: true, configureSwagger: c =>
+                .AddPhotobankApi(builder.Configuration)
+                .AddPhotobankCors()
+                .AddPhotobankSwagger(c =>
                 {
                     c.DocumentFilter<ServersDocumentFilter>();
                 });

--- a/backend/PhotoBank.IntegrationTests/FaceImageEndpointTests.cs
+++ b/backend/PhotoBank.IntegrationTests/FaceImageEndpointTests.cs
@@ -25,6 +25,8 @@ using PhotoBank.DbContext.Models;
 using PhotoBank.DependencyInjection;
 using PhotoBank.Services.Api;
 using Respawn;
+using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
 
 namespace PhotoBank.IntegrationTests;
 
@@ -56,10 +58,19 @@ public class FaceImageEndpointTests
                 builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
                 builder.UseNetTopologySuite();
             }));
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Issuer"] = "issuer",
+                ["Jwt:Audience"] = "audience",
+                ["Jwt:Key"] = "secret"
+            })
+            .Build();
         services
-            .AddPhotobankCore()
+            .AddPhotobankCore(config)
             .AddScoped<ICurrentUser, DummyCurrentUser>()
-            .AddPhotobankApi();
+            .AddPhotobankApi(config)
+            .AddPhotobankCors();
         services.AddLogging();
         services.AddSingleton<IMinioClient>(Mock.Of<IMinioClient>());
         await using var provider = services.BuildServiceProvider();
@@ -98,10 +109,19 @@ public class FaceImageEndpointTests
                 builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
                 builder.UseNetTopologySuite();
             }));
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Issuer"] = "issuer",
+                ["Jwt:Audience"] = "audience",
+                ["Jwt:Key"] = "secret"
+            })
+            .Build();
         services
-            .AddPhotobankCore()
+            .AddPhotobankCore(config)
             .AddScoped<ICurrentUser, DummyCurrentUser>()
-            .AddPhotobankApi();
+            .AddPhotobankApi(config)
+            .AddPhotobankCors();
         services.AddLogging();
         services.AddSingleton(minioClient);
         return services.BuildServiceProvider();

--- a/backend/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
+++ b/backend/PhotoBank.IntegrationTests/GetAllPhotosIntegrationTests.cs
@@ -12,6 +12,7 @@ using Minio;
 using Moq;
 using System.Diagnostics;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace PhotoBank.IntegrationTests;
@@ -38,6 +39,12 @@ public class GetAllPhotosIntegrationTests
         _config = new ConfigurationBuilder()
             .SetBasePath(TestContext.CurrentContext.TestDirectory)
             .AddJsonFile("appsettings.json")
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Issuer"] = "issuer",
+                ["Jwt:Audience"] = "audience",
+                ["Jwt:Key"] = "secret"
+            })
             .Build();
     }
 
@@ -59,7 +66,8 @@ public class GetAllPhotosIntegrationTests
             services
                 .AddPhotobankCore(_config)
                 .AddScoped<ICurrentUser, DummyCurrentUser>()
-                .AddPhotobankApi();
+                .AddPhotobankApi(_config)
+                .AddPhotobankCors();
 
             services.AddLogging();
             services.AddSingleton<IMinioClient>(Mock.Of<IMinioClient>());


### PR DESCRIPTION
## Summary
- require `IConfiguration` for `AddPhotobankApi`
- split CORS and Swagger setup into `AddPhotobankCors` and `AddPhotobankSwagger`
- call new extensions in API program and tests

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b560b743408328b93613cc2b36d7fc