### PR TITLE
feat: centralize MVC configuration

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -3,14 +3,9 @@ using PhotoBank.DbContext.DbContext;
 using PhotoBank.DependencyInjection;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Serilog;
 using HealthChecks.UI.Client;
-using FluentValidation;
-using FluentValidation.AspNetCore;
-using System.Text.Json.Serialization;
 using PhotoBank.Api.Swagger;
-using PhotoBank.Api.Validators;
 
 namespace PhotoBank.Api
 {
@@ -34,32 +29,7 @@ namespace PhotoBank.Api
             // Add services to the container.
             builder.Services.AddPhotobankDbContext(builder.Configuration, usePool: true);
 
-            builder.Services.Configure<RouteOptions>(options =>
-            {
-                options.LowercaseUrls = true;
-            });
-
-            builder.Services.AddProblemDetails();
-
-            builder.Services.AddHealthChecks()
-                .AddSqlServer(
-                    connectionString: builder.Configuration.GetConnectionString("DefaultConnection")!,
-                    name: "sql",
-                    tags: new[] { "ready" },
-                    failureStatus: HealthStatus.Unhealthy);
-            builder.Services.AddControllers()
-                .AddJsonOptions(options =>
-                {
-                    options.JsonSerializerOptions.NumberHandling = JsonNumberHandling.Strict;
-                });
-
-            builder.Services.AddFluentValidationAutoValidation();
-            builder.Services.AddValidatorsFromAssemblyContaining<LoginRequestDtoValidator>();
-            builder.Services.Configure<ApiBehaviorOptions>(options =>
-            {
-                options.InvalidModelStateResponseFactory = context =>
-                    new BadRequestObjectResult(new ValidationProblemDetails(context.ModelState));
-            });
+            builder.Services.AddPhotobankMvc(builder.Configuration);
 
             builder.Services
                 .AddPhotobankCore(builder.Configuration)

--- a/backend/PhotoBank.DependencyInjection/PhotoBank.DependencyInjection.csproj
+++ b/backend/PhotoBank.DependencyInjection/PhotoBank.DependencyInjection.csproj
@@ -14,4 +14,9 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- centralize MVC-related service registration in `AddPhotobankMvc`
- invoke unified `AddPhotobankMvc` from API bootstrap

## Testing
- `dotnet restore PhotoBank.Backend.sln -v minimal`
- `dotnet build PhotoBank.Backend.sln -v normal`
- `dotnet test PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b56311a35c832891635abe0fa7dc64