### PR TITLE
fix: group photo filter by person using photo id

### DIFF
--- a/backend/PhotoBank.Services/Api/PhotoService.cs
+++ b/backend/PhotoBank.Services/Api/PhotoService.cs
@@ -175,13 +175,14 @@ public class PhotoService : IPhotoService
         if (filter.Persons?.Any() == true)
         {
             var personIds = filter.Persons.ToList();
-            query =
-                from p in query
-                join f in _db.Faces on p.Id equals f.PhotoId
+            var photoIds =
+                from f in _db.Faces
                 where f.PersonId != null && personIds.Contains(f.PersonId.Value)
-                group f by p into g
+                group f by f.PhotoId into g
                 where g.Select(x => x.PersonId).Distinct().Count() == personIds.Count
                 select g.Key;
+
+            query = query.Where(p => photoIds.Contains(p.Id));
         }
 
         if (filter.Tags?.Any() == true)


### PR DESCRIPTION
## Summary
- group person filter by PhotoId to avoid geometry grouping

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln` *(tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b5687c37588328a42b1938e345f7dc