### PR TITLE
fix: filter photos by tag ids without grouping on geometry

### DIFF
--- a/backend/PhotoBank.Services/Api/PhotoService.cs
+++ b/backend/PhotoBank.Services/Api/PhotoService.cs
@@ -188,13 +188,17 @@ public class PhotoService : IPhotoService
         if (filter.Tags?.Any() == true)
         {
             var tagIds = filter.Tags.ToList();
-            query =
-                from p in query
-                join pt in _db.PhotoTags on p.Id equals pt.PhotoId
+            var taggedPhotoIds =
+                from pt in _db.PhotoTags
                 where tagIds.Contains(pt.TagId)
-                group pt by p into g
+                group pt by pt.PhotoId into g
                 where g.Select(x => x.TagId).Distinct().Count() == tagIds.Count
                 select g.Key;
+
+            query =
+                from p in query
+                join pid in taggedPhotoIds on p.Id equals pid
+                select p;
         }
 
         return query;


### PR DESCRIPTION
## Summary
- avoid grouping photos with geometry when filtering by tag ids
- join tag-filtered photo ids back to original query

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln --no-restore`
- `dotnet test PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj --no-build` *(fails: Data collection : Unable to find a datacollector with friendly name 'XPlat Code Coverage'; Skipped: 15)*

------
https://chatgpt.com/codex/tasks/task_e_68b56babf20c8328871615d8fa6cdd83