### PR TITLE
refactor: configure PhotoBankDbContext for pooled usage

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankDbContextExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankDbContextExtensions.cs
@@ -43,6 +43,13 @@ public static partial class ServiceCollectionExtensions
                         sql.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
                     });
             });
+
+            services.AddScoped<PhotoBankDbContext>(sp =>
+            {
+                var context = sp.GetRequiredService<IDbContextFactory<PhotoBankDbContext>>().CreateDbContext();
+                context.ConfigureUser(sp.GetRequiredService<ICurrentUser>());
+                return context;
+            });
         }
         else
         {
@@ -62,6 +69,14 @@ public static partial class ServiceCollectionExtensions
                         sql.UseNetTopologySuite();
                         sql.CommandTimeout(120);
                     });
+            });
+
+            services.AddScoped<PhotoBankDbContext>(sp =>
+            {
+                var options = sp.GetRequiredService<DbContextOptions<PhotoBankDbContext>>();
+                var context = new PhotoBankDbContext(options);
+                context.ConfigureUser(sp.GetRequiredService<ICurrentUser>());
+                return context;
             });
         }
 


### PR DESCRIPTION
## Summary
- allow configuring current user on pooled PhotoBankDbContext and reset state between scopes
- configure DbContext in DI to set user from scoped ICurrentUser

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln` *(fails: Docker is either not running or misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b7b0bcc8832889abf92299442d95