### PR TITLE
fix: set JWT name claim type

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
 using System.Text.Json.Serialization;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Diagnostics;
@@ -53,6 +54,7 @@ public static partial class ServiceCollectionExtensions
                 ValidateAudience = true,
                 ValidateLifetime = true,
                 ValidateIssuerSigningKey = true,
+                NameClaimType = ClaimTypes.NameIdentifier,
                 ValidIssuer = jwtSection["Issuer"],
                 ValidAudience = jwtSection["Audience"],
                 IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSection["Key"]!))


### PR DESCRIPTION
## Summary
- specify ClaimTypes.NameIdentifier for JWT NameClaimType

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln` *(fails: Docker is either not running or misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d0be0fb883289f7a224690df182a