### PR TITLE
feat: handle unauthenticated current user

### DIFF
--- a/backend/PhotoBank.UnitTests/CurrentUserTests.cs
+++ b/backend/PhotoBank.UnitTests/CurrentUserTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.AccessControl;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class CurrentUserTests
+{
+    [Test]
+    public void Constructor_ShouldPopulateProperties_WhenAuthenticated()
+    {
+        var identity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, "user1") }, "auth");
+        var principal = new ClaimsPrincipal(identity);
+        var httpContext = new DefaultHttpContext { User = principal };
+        var http = new Mock<IHttpContextAccessor>();
+        http.Setup(x => x.HttpContext).Returns(httpContext);
+
+        var access = new EffectiveAccess(
+            new HashSet<int> { 1 },
+            new HashSet<int> { 2 },
+            Array.Empty<(DateOnly, DateOnly)>(),
+            true,
+            true);
+
+        var provider = new Mock<IEffectiveAccessProvider>();
+        provider.Setup(p => p.GetAsync("user1", principal, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(access);
+
+        var current = new CurrentUser(http.Object, provider.Object);
+
+        current.UserId.Should().Be("user1");
+        current.IsAdmin.Should().BeTrue();
+        current.AllowedStorageIds.Should().Contain(1);
+        current.AllowedPersonGroupIds.Should().Contain(2);
+        current.CanSeeNsfw.Should().BeTrue();
+        provider.Verify(p => p.GetAsync("user1", principal, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public void Constructor_ShouldReturnAnonymousUser_WhenUnauthenticated()
+    {
+        var principal = new ClaimsPrincipal(new ClaimsIdentity());
+        var httpContext = new DefaultHttpContext { User = principal };
+        var http = new Mock<IHttpContextAccessor>();
+        http.Setup(x => x.HttpContext).Returns(httpContext);
+
+        var provider = new Mock<IEffectiveAccessProvider>(MockBehavior.Strict);
+
+        var current = new CurrentUser(http.Object, provider.Object);
+
+        current.UserId.Should().BeEmpty();
+        current.IsAdmin.Should().BeFalse();
+        current.AllowedStorageIds.Should().BeEmpty();
+        current.AllowedPersonGroupIds.Should().BeEmpty();
+        current.AllowedDateRanges.Should().BeEmpty();
+        current.CanSeeNsfw.Should().BeFalse();
+        provider.Verify(p => p.GetAsync(It.IsAny<string>(), It.IsAny<ClaimsPrincipal>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public void Constructor_ShouldThrow_WhenAuthenticatedWithoutNameIdentifier()
+    {
+        var identity = new ClaimsIdentity(authenticationType: "auth");
+        var principal = new ClaimsPrincipal(identity);
+        var httpContext = new DefaultHttpContext { User = principal };
+        var http = new Mock<IHttpContextAccessor>();
+        http.Setup(x => x.HttpContext).Returns(httpContext);
+
+        var provider = new Mock<IEffectiveAccessProvider>(MockBehavior.Strict);
+
+        var act = () => new CurrentUser(http.Object, provider.Object);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Authenticated user missing NameIdentifier claim");
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle unauthenticated and missing claim scenarios in CurrentUser
- cover CurrentUser with authenticated, unauthenticated, and missing claim tests

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln` *(fails: Docker is either not running or misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d2d39cb483289b25e52a2865c2dc