### PR TITLE
refactor: centralize retry helper

### DIFF
--- a/backend/PhotoBank.Services/RetryHelper.cs
+++ b/backend/PhotoBank.Services/RetryHelper.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+
+namespace PhotoBank.Services;
+
+public static class RetryHelper
+{
+    public static async Task<T> RetryAsync<T>(
+        Func<Task<T>> action,
+        int attempts,
+        TimeSpan delay,
+        Func<Exception, bool> shouldRetry)
+    {
+        if (action is null) throw new ArgumentNullException(nameof(action));
+        if (shouldRetry is null) throw new ArgumentNullException(nameof(shouldRetry));
+
+        var currentDelay = delay;
+
+        for (var tryNo = 1; ; tryNo++)
+        {
+            try
+            {
+                return await action().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (tryNo < attempts && shouldRetry(ex))
+            {
+            }
+
+            await Task.Delay(currentDelay).ConfigureAwait(false);
+            var nextDelay = Math.Min(currentDelay.TotalMilliseconds * 2, 4000);
+            currentDelay = TimeSpan.FromMilliseconds(nextDelay);
+        }
+    }
+}

--- a/backend/PhotoBank.UnitTests/RetryHelperTests.cs
+++ b/backend/PhotoBank.UnitTests/RetryHelperTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using PhotoBank.Services;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class RetryHelperTests
+{
+    [Test]
+    public async Task RetryAsync_ShouldRetryWhenPredicateTrue()
+    {
+        var callCount = 0;
+
+        var result = await RetryHelper.RetryAsync(
+            action: () =>
+            {
+                callCount++;
+                if (callCount < 3) throw new HttpRequestException();
+                return Task.FromResult("ok");
+            },
+            attempts: 3,
+            delay: TimeSpan.Zero,
+            shouldRetry: ex => ex is HttpRequestException);
+
+        result.Should().Be("ok");
+        callCount.Should().Be(3);
+    }
+
+    [Test]
+    public async Task RetryAsync_ShouldThrowWhenPredicateFalse()
+    {
+        var callCount = 0;
+
+        Func<Task<string>> act = () => RetryHelper.RetryAsync<string>(
+            action: () =>
+            {
+                callCount++;
+                throw new InvalidOperationException();
+            },
+            attempts: 3,
+            delay: TimeSpan.Zero,
+            shouldRetry: ex => ex is HttpRequestException);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        callCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task RetryAsync_ShouldThrowAfterMaxAttempts()
+    {
+        var callCount = 0;
+
+        Func<Task<string>> act = () => RetryHelper.RetryAsync<string>(
+            action: () =>
+            {
+                callCount++;
+                throw new HttpRequestException();
+            },
+            attempts: 2,
+            delay: TimeSpan.Zero,
+            shouldRetry: ex => ex is HttpRequestException);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        callCount.Should().Be(2);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add generic RetryHelper with exponential backoff
- use RetryHelper in AnalyzeEnricher and ThumbnailEnricher
- cover RetryHelper with unit tests

## Testing
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln --no-build` *(fails: Docker is not running)*
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build --logger "console;verbosity=minimal"` *(fails: TerminalLogger error)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fb27cb7083288702d7cf9ac515f7