### PR TITLE
feat: add Minio object service

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -27,6 +27,7 @@ public static partial class ServiceCollectionExtensions
         });
         services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
         services.AddScoped<IFaceStorageService, FaceStorageService>();
+        services.AddScoped<MinioObjectService>();
         services.AddScoped<IPhotoService, PhotoService>();
         services.AddPhotoEvents();
         if (configuration != null)

--- a/backend/PhotoBank.Services/MinioObjectService.cs
+++ b/backend/PhotoBank.Services/MinioObjectService.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using System.Threading.Tasks;
+using Minio;
+using Minio.DataModel.Args;
+
+namespace PhotoBank.Services;
+
+public class MinioObjectService
+{
+    private readonly IMinioClient _minioClient;
+    private const string Bucket = "photobank";
+
+    public MinioObjectService(IMinioClient minioClient)
+    {
+        _minioClient = minioClient;
+    }
+
+    public async Task<byte[]> GetObjectAsync(string key)
+    {
+        using var ms = new MemoryStream();
+        await _minioClient.GetObjectAsync(new GetObjectArgs()
+            .WithBucket(Bucket)
+            .WithObject(key)
+            .WithCallbackStream(stream => stream.CopyTo(ms)));
+        return ms.ToArray();
+    }
+}
+

--- a/backend/PhotoBank.UnitTests/MinioObjectServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/MinioObjectServiceTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Minio;
+using Minio.DataModel;
+using Minio.DataModel.Args;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.Services;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class MinioObjectServiceTests
+{
+    [Test]
+    public async Task GetObjectAsync_ReturnsBytesFromMinio()
+    {
+        var data = new byte[] { 1, 2, 3 };
+        GetObjectArgs? capturedArgs = null;
+        var minio = new Mock<IMinioClient>();
+        minio.Setup(m => m.GetObjectAsync(It.IsAny<GetObjectArgs>(), It.IsAny<CancellationToken>()))
+            .Callback<GetObjectArgs, CancellationToken>((args, ct) =>
+            {
+                capturedArgs = args;
+                var field = args.GetType().GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                    .FirstOrDefault(f => typeof(Delegate).IsAssignableFrom(f.FieldType));
+                var del = field?.GetValue(args) as Delegate;
+                del?.DynamicInvoke(new MemoryStream(data));
+            })
+            .ReturnsAsync((ObjectStat)Activator.CreateInstance(typeof(ObjectStat), nonPublic: true)!);
+
+        var service = new MinioObjectService(minio.Object);
+        var result = await service.GetObjectAsync("key1");
+
+        result.Should().Equal(data);
+        var bucket = (string?)capturedArgs!.GetType().GetProperty("BucketName", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(capturedArgs);
+        var obj = (string?)capturedArgs!.GetType().GetProperty("ObjectName", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!.GetValue(capturedArgs);
+        bucket.Should().Be("photobank");
+        obj.Should().Be("key1");
+    }
+}

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -53,6 +53,7 @@ public class PersonGroupServiceTests
             _provider.GetRequiredService<IMemoryCache>(),
             _provider.GetRequiredService<ICurrentUser>(),
             new Mock<IS3ResourceService>().Object,
+            new MinioObjectService(new Mock<IMinioClient>().Object),
             new Mock<IMinioClient>().Object
         );
     }

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -60,6 +60,7 @@ namespace PhotoBank.UnitTests.Services
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser(),
                 new Mock<IS3ResourceService>().Object,
+                new MinioObjectService(new Mock<IMinioClient>().Object),
                 new Mock<IMinioClient>().Object);
         }
 

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -60,6 +60,7 @@ namespace PhotoBank.UnitTests.Services
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser(),
                 new Mock<IS3ResourceService>().Object,
+                new MinioObjectService(new Mock<IMinioClient>().Object),
                 new Mock<IMinioClient>().Object);
 
             var bytes = new byte[] { 1, 2, 3, 4 };
@@ -100,6 +101,7 @@ namespace PhotoBank.UnitTests.Services
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser(),
                 new Mock<IS3ResourceService>().Object,
+                new MinioObjectService(new Mock<IMinioClient>().Object),
                 new Mock<IMinioClient>().Object);
 
             var bytes = new byte[] { 1, 2, 3, 4 };
@@ -144,6 +146,7 @@ namespace PhotoBank.UnitTests.Services
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser(),
                 new Mock<IS3ResourceService>().Object,
+                new MinioObjectService(new Mock<IMinioClient>().Object),
                 new Mock<IMinioClient>().Object);
 
             var bytes1 = new byte[] { 1, 2, 3, 4 };


### PR DESCRIPTION
## Summary
- extract Minio object service for downloading objects
- use Minio object service in photo and recognition services via DI
- register service and cover with unit tests

## Testing
- `dotnet test PhotoBank.Backend.sln` *(fails: Docker is either not running or misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fdcae9708328836d62e241d92e70