### PR TITLE
refactor: extract base lookup enricher

### DIFF
--- a/backend/PhotoBank.Services/Enrichers/BaseLookupEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/BaseLookupEnricher.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+using PhotoBank.Services.Models;
+
+namespace PhotoBank.Services.Enrichers
+{
+    public abstract class BaseLookupEnricher<TModel, TLink> : IEnricher
+        where TModel : class, IEntityBase, new()
+    {
+        private readonly IRepository<TModel> _repository;
+        private readonly Func<SourceDataDto, IEnumerable<string>> _namesSelector;
+        private readonly Func<string, TModel> _modelFactory;
+        private readonly Func<Photo, string, TModel, SourceDataDto, TLink> _linkFactory;
+
+        protected BaseLookupEnricher(
+            IRepository<TModel> repository,
+            Func<SourceDataDto, IEnumerable<string>> namesSelector,
+            Func<string, TModel> modelFactory,
+            Func<Photo, string, TModel, SourceDataDto, TLink> linkFactory)
+        {
+            _repository = repository;
+            _namesSelector = namesSelector;
+            _modelFactory = modelFactory;
+            _linkFactory = linkFactory;
+        }
+
+        public virtual Type[] Dependencies => new[] { typeof(AnalyzeEnricher) };
+
+        public abstract EnricherType EnricherType { get; }
+
+        protected abstract ICollection<TLink> GetCollection(Photo photo);
+
+        public async Task EnrichAsync(Photo photo, SourceDataDto sourceData, CancellationToken cancellationToken = default)
+        {
+            var incoming = _namesSelector(sourceData)
+                .Select(n => n?.Trim())
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (incoming.Length == 0)
+            {
+                return;
+            }
+
+            var query = _repository.GetByCondition(m => incoming.Contains(EF.Property<string>(m, "Name")));
+            List<TModel> existing;
+            try
+            {
+                existing = await query.AsNoTracking().ToListAsync(cancellationToken);
+            }
+            catch (InvalidOperationException)
+            {
+                existing = query.AsNoTracking().ToList();
+            }
+
+            var nameProp = typeof(TModel).GetProperty("Name");
+            var map = existing.ToDictionary(e => (string)nameProp.GetValue(e), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var name in incoming)
+            {
+                if (!map.TryGetValue(name, out var model))
+                {
+                    model = _modelFactory(name);
+                    await _repository.InsertAsync(model);
+                    map[name] = model;
+                }
+            }
+
+            var collection = GetCollection(photo);
+
+            foreach (var name in incoming)
+            {
+                var model = map[name];
+                var link = _linkFactory(photo, name, model, sourceData);
+                collection.Add(link);
+            }
+        }
+    }
+}

--- a/backend/PhotoBank.Services/Enrichers/CategoryEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/CategoryEnricher.cs
@@ -1,9 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Repositories;
 using PhotoBank.Services.Models;
@@ -11,61 +8,28 @@ using Category = PhotoBank.DbContext.Models.Category;
 
 namespace PhotoBank.Services.Enrichers
 {
-    public class CategoryEnricher : IEnricher
+    public class CategoryEnricher : BaseLookupEnricher<Category, PhotoCategory>
     {
-        private readonly IRepository<Category> _categoryRepository;
-        public EnricherType EnricherType => EnricherType.Category;
-
         public CategoryEnricher(IRepository<Category> categoryRepository)
+            : base(
+                categoryRepository,
+                src => src.ImageAnalysis.Categories.Select(c => c.Name),
+                name => new Category { Name = name },
+                (photo, name, categoryModel, src) =>
+                {
+                    var cat = src.ImageAnalysis.Categories.First(c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
+                    return new PhotoCategory
+                    {
+                        Photo = photo,
+                        Category = categoryModel,
+                        Score = cat.Score
+                    };
+                })
         {
-            _categoryRepository = categoryRepository;
         }
 
-        public Type[] Dependencies => new[] { typeof(AnalyzeEnricher) };
+        public override EnricherType EnricherType => EnricherType.Category;
 
-        public async Task EnrichAsync(Photo photo, SourceDataDto sourceData, CancellationToken cancellationToken = default)
-        {
-            var incoming = sourceData.ImageAnalysis.Categories
-                .Select(c => c.Name.Trim())
-                .Where(n => !string.IsNullOrWhiteSpace(n))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-
-            var query = _categoryRepository.GetByCondition(c => incoming.Contains(c.Name));
-            List<Category> existing;
-            try
-            {
-                existing = await query.AsNoTracking().ToListAsync(cancellationToken);
-            }
-            catch (InvalidOperationException)
-            {
-                existing = query.AsNoTracking().ToList();
-            }
-
-            var map = existing.ToDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);
-
-            foreach (var name in incoming)
-            {
-                if (!map.TryGetValue(name, out var category))
-                {
-                    category = new Category { Name = name };
-                    await _categoryRepository.InsertAsync(category);
-                    map[name] = category;
-                }
-            }
-
-            photo.PhotoCategories ??= new List<PhotoCategory>();
-
-            foreach (var category in sourceData.ImageAnalysis.Categories)
-            {
-                var catModel = map[category.Name];
-                photo.PhotoCategories.Add(new PhotoCategory
-                {
-                    Photo = photo,
-                    Category = catModel,
-                    Score = category.Score
-                });
-            }
-        }
+        protected override ICollection<PhotoCategory> GetCollection(Photo photo) => photo.PhotoCategories ??= new List<PhotoCategory>();
     }
 }

--- a/backend/PhotoBank.Services/Enrichers/ObjectPropertyEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/ObjectPropertyEnricher.cs
@@ -1,70 +1,35 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
+using PhotoBank.Services;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Repositories;
 using PhotoBank.Services.Models;
 
 namespace PhotoBank.Services.Enrichers
 {
-    public class ObjectPropertyEnricher : IEnricher
+    public class ObjectPropertyEnricher : BaseLookupEnricher<PropertyName, ObjectProperty>
     {
-        private readonly IRepository<PropertyName> _propertyNameRepository;
-
         public ObjectPropertyEnricher(IRepository<PropertyName> propertyNameRepository)
+            : base(
+                propertyNameRepository,
+                src => src.ImageAnalysis.Objects.Select(o => o.ObjectProperty),
+                name => new PropertyName { Name = name },
+                (photo, name, propertyName, src) =>
+                {
+                    var detectedObject = src.ImageAnalysis.Objects.First(o => string.Equals(o.ObjectProperty, name, StringComparison.OrdinalIgnoreCase));
+                    return new ObjectProperty
+                    {
+                        PropertyName = propertyName,
+                        Rectangle = GeoWrapper.GetRectangle(detectedObject.Rectangle, photo.Scale),
+                        Confidence = detectedObject.Confidence
+                    };
+                })
         {
-            _propertyNameRepository = propertyNameRepository;
         }
 
-        public EnricherType EnricherType => EnricherType.ObjectProperty;
-        public Type[] Dependencies => new[] { typeof(AnalyzeEnricher) };
+        public override EnricherType EnricherType => EnricherType.ObjectProperty;
 
-        public async Task EnrichAsync(Photo photo, SourceDataDto sourceData, CancellationToken cancellationToken = default)
-        {
-            var incoming = sourceData.ImageAnalysis.Objects
-                .Select(o => o.ObjectProperty?.Trim())
-                .Where(n => !string.IsNullOrWhiteSpace(n))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-
-            var query = _propertyNameRepository.GetByCondition(p => incoming.Contains(p.Name));
-            List<PropertyName> existing;
-            try
-            {
-                existing = await query.AsNoTracking().ToListAsync(cancellationToken);
-            }
-            catch (InvalidOperationException)
-            {
-                existing = query.AsNoTracking().ToList();
-            }
-
-            var map = existing.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
-
-            foreach (var name in incoming)
-            {
-                if (!map.TryGetValue(name, out var propertyName))
-                {
-                    propertyName = new PropertyName { Name = name };
-                    await _propertyNameRepository.InsertAsync(propertyName);
-                    map[name] = propertyName;
-                }
-            }
-
-            photo.ObjectProperties ??= new List<ObjectProperty>();
-
-            foreach (var detectedObject in sourceData.ImageAnalysis.Objects)
-            {
-                var propertyName = map[detectedObject.ObjectProperty];
-                photo.ObjectProperties.Add(new ObjectProperty
-                {
-                    PropertyName = propertyName,
-                    Rectangle = GeoWrapper.GetRectangle(detectedObject.Rectangle, photo.Scale),
-                    Confidence = detectedObject.Confidence
-                });
-            }
-        }
+        protected override ICollection<ObjectProperty> GetCollection(Photo photo) => photo.ObjectProperties ??= new List<ObjectProperty>();
     }
 }

--- a/backend/PhotoBank.Services/Enrichers/TagEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/TagEnricher.cs
@@ -1,66 +1,29 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Repositories;
 using PhotoBank.Services.Models;
 
 namespace PhotoBank.Services.Enrichers
 {
-    public sealed class TagEnricher : IEnricher
+    public sealed class TagEnricher : BaseLookupEnricher<Tag, PhotoTag>
     {
-        private readonly IRepository<Tag> _repo;
-
         public TagEnricher(IRepository<Tag> repo)
-        {
-            _repo = repo;
-        }
-
-        public EnricherType EnricherType => EnricherType.Tag;
-
-        public Type[] Dependencies => new[] { typeof(AnalyzeEnricher) };
-
-        public async Task EnrichAsync(Photo photo, SourceDataDto src, CancellationToken ct = default)
-        {
-            var incoming = src.ImageAnalysis.Tags
-                .Select(t => t.Name.Trim())
-                .Where(n => !string.IsNullOrWhiteSpace(n))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
-
-            var query = _repo.GetByCondition(t => incoming.Contains(t.Name));
-            List<Tag> existing;
-            try
-            {
-                existing = await query.AsNoTracking().ToListAsync(ct);
-            }
-            catch (InvalidOperationException)
-            {
-                existing = query.AsNoTracking().ToList();
-            }
-
-            var map = existing.ToDictionary(t => t.Name, StringComparer.OrdinalIgnoreCase);
-
-            foreach (var name in incoming)
-            {
-                if (!map.TryGetValue(name, out var tag))
+            : base(
+                repo,
+                src => src.ImageAnalysis.Tags.Select(t => t.Name),
+                name => new Tag { Name = name },
+                (photo, name, tagModel, src) =>
                 {
-                    tag = new Tag { Name = name };
-                    await _repo.InsertAsync(tag);
-                    map[name] = tag;
-                }
-            }
-
-            photo.PhotoTags ??= new List<PhotoTag>();
-
-            foreach (var tag in src.ImageAnalysis.Tags)
-            {
-                var tagModel = map[tag.Name];
-                photo.PhotoTags.Add(new PhotoTag { Photo = photo, Tag = tagModel, Confidence = tag.Confidence });
-            }
+                    var tag = src.ImageAnalysis.Tags.First(t => string.Equals(t.Name, name, StringComparison.OrdinalIgnoreCase));
+                    return new PhotoTag { Photo = photo, Tag = tagModel, Confidence = tag.Confidence };
+                })
+        {
         }
+
+        public override EnricherType EnricherType => EnricherType.Tag;
+
+        protected override ICollection<PhotoTag> GetCollection(Photo photo) => photo.PhotoTags ??= new List<PhotoTag>();
     }
 }


### PR DESCRIPTION
## Summary
- add generic `BaseLookupEnricher` to handle lookup creation and linking
- refactor tag/category/object property enrichers to use new base

## Testing
- `dotnet test PhotoBank.Backend.sln --no-restore -v minimal` *(fails: GetAllPhotosAsync_FilterByMultiplePersons_ReturnsPhotosWithAllPersons: Could not translated)*
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-restore -v minimal --filter Enricher`


------
https://chatgpt.com/codex/tasks/task_e_68b5fedf57388328967deb9a1a9ec817