### PR TITLE
test: refactor enricher tests

### DIFF
--- a/backend/PhotoBank.UnitTests/Enrichers/AdultEnricherTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichers/AdultEnricherTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.CognitiveServices.Vision.ComputerVision.Models;
 using NUnit.Framework;
@@ -9,43 +10,16 @@ using PhotoBank.Services.Models;
 namespace PhotoBank.UnitTests.Enrichers
 {
     [TestFixture]
-    public class AdultEnricherTests
+    public class AdultEnricherTests : EnricherTestsBase<AdultEnricher>
     {
-        private AdultEnricher _adultEnricher;
-
-        [SetUp]
-        public void Setup()
-        {
-            _adultEnricher = new AdultEnricher();
-        }
-
-        [Test]
-        public void EnricherType_ShouldReturnAdult()
-        {
-            // Act
-            var result = _adultEnricher.EnricherType;
-
-            // Assert
-            result.Should().Be(EnricherType.Adult);
-        }
-
-        [Test]
-        public void Dependencies_ShouldReturnAnalyzeEnricher()
-        {
-            // Act
-            var result = _adultEnricher.Dependencies;
-
-            // Assert
-            result.Should().ContainSingle()
-                .And.Contain(typeof(AnalyzeEnricher));
-        }
+        protected override EnricherType ExpectedEnricherType => EnricherType.Adult;
+        protected override Type[] ExpectedDependencies => new[] { typeof(AnalyzeEnricher) };
 
         [Test]
         [TestCase(true, 0.95, true, 0.85)]
         [TestCase(false, 0.1, false, 0.2)]
         public async Task EnrichAsync_ShouldSetAdultProperties(bool isAdultContent, double adultScore, bool isRacyContent, double racyScore)
         {
-            // Arrange
             var photo = new Photo();
             var sourceData = new SourceDataDto
             {
@@ -61,10 +35,8 @@ namespace PhotoBank.UnitTests.Enrichers
                 }
             };
 
-            // Act
-            await _adultEnricher.EnrichAsync(photo, sourceData);
+            await _enricher.EnrichAsync(photo, sourceData);
 
-            // Assert
             photo.IsAdultContent.Should().Be(isAdultContent);
             photo.AdultScore.Should().Be(adultScore);
             photo.IsRacyContent.Should().Be(isRacyContent);

--- a/backend/PhotoBank.UnitTests/Enrichers/CaptionEnricherTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichers/CaptionEnricherTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -10,41 +11,14 @@ using PhotoBank.Services.Models;
 namespace PhotoBank.UnitTests.Enrichers
 {
     [TestFixture]
-    public class CaptionEnricherTests
+    public class CaptionEnricherTests : EnricherTestsBase<CaptionEnricher>
     {
-        private CaptionEnricher _captionEnricher;
-
-        [SetUp]
-        public void Setup()
-        {
-            _captionEnricher = new CaptionEnricher();
-        }
-
-        [Test]
-        public void EnricherType_ShouldReturnCaption()
-        {
-            // Act
-            var result = _captionEnricher.EnricherType;
-
-            // Assert
-            result.Should().Be(EnricherType.Caption);
-        }
-
-        [Test]
-        public void Dependencies_ShouldReturnAnalyzeEnricher()
-        {
-            // Act
-            var result = _captionEnricher.Dependencies;
-
-            // Assert
-            result.Should().ContainSingle()
-                .And.Contain(typeof(AnalyzeEnricher));
-        }
+        protected override EnricherType ExpectedEnricherType => EnricherType.Caption;
+        protected override Type[] ExpectedDependencies => new[] { typeof(AnalyzeEnricher) };
 
         [Test]
         public async Task EnrichAsync_ShouldSetCaptions()
         {
-            // Arrange
             var photo = new Photo();
             var sourceData = new SourceDataDto
             {
@@ -61,14 +35,11 @@ namespace PhotoBank.UnitTests.Enrichers
                 }
             };
 
-            // Act
-            await _captionEnricher.EnrichAsync(photo, sourceData);
+            await _enricher.EnrichAsync(photo, sourceData);
 
-            // Assert
             photo.Captions.Should().HaveCount(2);
             photo.Captions.Should().Contain(c => c.Text == "A beautiful sunset" && c.Confidence == 0.95);
             photo.Captions.Should().Contain(c => c.Text == "A scenic view" && c.Confidence == 0.85);
         }
     }
 }
-

--- a/backend/PhotoBank.UnitTests/Enrichers/ColorEnricherTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichers/ColorEnricherTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Azure.CognitiveServices.Vision.ComputerVision.Models;
@@ -9,42 +10,16 @@ using PhotoBank.Services.Models;
 namespace PhotoBank.UnitTests.Enrichers
 {
     [TestFixture]
-    public class ColorEnricherTests
+    public class ColorEnricherTests : EnricherTestsBase<ColorEnricher>
     {
-        private ColorEnricher _colorEnricher;
-
-        [SetUp]
-        public void Setup()
-        {
-            _colorEnricher = new ColorEnricher();
-        }
-
-        [Test]
-        public void EnricherType_ShouldReturnColor()
-        {
-            // Act
-            var result = _colorEnricher.EnricherType;
-
-            // Assert
-            result.Should().Be(EnricherType.Color);
-        }
-
-        [Test]
-        public void Dependencies_ShouldReturnAnalyzeEnricher()
-        {
-            // Act
-            var result = _colorEnricher.Dependencies;
-
-            // Assert
-            result.Should().ContainSingle()
-                .And.Contain(typeof(AnalyzeEnricher));
-        }
+        protected override EnricherType ExpectedEnricherType => EnricherType.Color;
+        protected override Type[] ExpectedDependencies => new[] { typeof(AnalyzeEnricher) };
 
         [TestCase(true, "FF5733", "Black", "White", new[] { "Black", "White", "Gray" })]
         [TestCase(false, "00FF00", "Red", "Blue", new[] { "Red", "Blue", "Green" })]
-        public async Task EnrichAsync_ShouldSetColorProperties(bool isBWImg, string accentColor, string dominantColorBackground, string dominantColorForeground, string[] dominantColors)
+        public async Task EnrichAsync_ShouldSetColorProperties(bool isBWImg, string accentColor, string dominantColorBackground,
+            string dominantColorForeground, string[] dominantColors)
         {
-            // Arrange
             var photo = new Photo();
             var sourceData = new SourceDataDto
             {
@@ -61,10 +36,8 @@ namespace PhotoBank.UnitTests.Enrichers
                 }
             };
 
-            // Act
-            await _colorEnricher.EnrichAsync(photo, sourceData);
+            await _enricher.EnrichAsync(photo, sourceData);
 
-            // Assert
             photo.IsBW.Should().Be(isBWImg);
             photo.AccentColor.Should().Be(accentColor);
             photo.DominantColorBackground.Should().Be(dominantColorBackground);
@@ -73,4 +46,3 @@ namespace PhotoBank.UnitTests.Enrichers
         }
     }
 }
-

--- a/backend/PhotoBank.UnitTests/Enrichers/EnricherTestsBase.cs
+++ b/backend/PhotoBank.UnitTests/Enrichers/EnricherTestsBase.cs
@@ -1,0 +1,37 @@
+using System;
+using FluentAssertions;
+using NUnit.Framework;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Enrichers;
+
+namespace PhotoBank.UnitTests.Enrichers
+{
+    public abstract class EnricherTestsBase<TEnricher>
+        where TEnricher : IEnricher, new()
+    {
+        protected TEnricher _enricher;
+
+        protected abstract EnricherType ExpectedEnricherType { get; }
+        protected abstract Type[] ExpectedDependencies { get; }
+
+        [SetUp]
+        public void Setup()
+        {
+            _enricher = new TEnricher();
+        }
+
+        [Test]
+        public void EnricherType_ShouldReturnExpected()
+        {
+            var result = _enricher.EnricherType;
+            result.Should().Be(ExpectedEnricherType);
+        }
+
+        [Test]
+        public void Dependencies_ShouldReturnExpected()
+        {
+            var result = _enricher.Dependencies;
+            result.Should().BeEquivalentTo(ExpectedDependencies);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add generic base class for enricher tests
- simplify caption, color and adult enricher tests

## Testing
- `DOTNET_TERMINAL_WIDTH=80 /usr/share/dotnet/dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --logger "console;verbosity=minimal"` *(failed: MSBuild logger terminated, results not confirmed)*

------
https://chatgpt.com/codex/tasks/task_e_68b60121f1b8832882087994b4970b51