### PR TITLE
fix: remove Date truncation in photo filter

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -204,8 +204,8 @@ namespace PhotoBank.DbContext.DbContext
                     (
                         AllowedDateRanges.Count == 0
                         || (p.TakenDate != null && AllowedDateRanges.Any(r =>
-                            p.TakenDate.Value.Date >= r.From.ToDateTime(TimeOnly.MinValue).Date &&
-                            p.TakenDate.Value.Date <= r.To.ToDateTime(TimeOnly.MinValue).Date))
+                            p.TakenDate.Value >= r.From.ToDateTime(TimeOnly.MinValue) &&
+                            p.TakenDate.Value <= r.To.ToDateTime(TimeOnly.MaxValue)))
                     ) &&
                     (CanSeeNsfw || (!p.IsAdultContent && !p.IsRacyContent))
                 ));


### PR DESCRIPTION
## Summary
- avoid trimming `TakenDate` to date-only when filtering photos

## Testing
- `dotnet test backend/PhotoBank.UnitTests --filter GetAllPhotosAsync_FilterByIsBW_ReturnsOnlyBW` *(fails: MSB4017 unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b6923d16bc8328ae30b506340cc3f8