### PR TITLE
test: invoke GetObjectArgs callback with cancellation token

### DIFF
--- a/backend/PhotoBank.UnitTests/MinioObjectServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/MinioObjectServiceTests.cs
@@ -30,7 +30,7 @@ public class MinioObjectServiceTests
                 var field = args.GetType().GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
                     .FirstOrDefault(f => typeof(Delegate).IsAssignableFrom(f.FieldType));
                 var del = field?.GetValue(args) as Delegate;
-                del?.DynamicInvoke(new MemoryStream(data));
+                del?.DynamicInvoke(new MemoryStream(data), CancellationToken.None);
             })
             .ReturnsAsync((ObjectStat)Activator.CreateInstance(typeof(ObjectStat), nonPublic: true)!);
 


### PR DESCRIPTION
## Summary
- ensure delegate from Minio GetObjectArgs is invoked with cancellation token

## Testing
- `dotnet test --filter MinioObjectServiceTests --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68b692642a4883288894efa5a3ee68fb