### PR TITLE
refactor: drop roles endpoint

### DIFF
--- a/backend/PhotoBank.ViewModel.Dto/RoleDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/RoleDto.cs
@@ -1,6 +1,0 @@
-namespace PhotoBank.ViewModel.Dto;
-
-public class RoleDto
-{
-    public required string Name { get; set; } = string.Empty;
-}

--- a/frontend/packages/frontend/src/app/RequireAdmin.tsx
+++ b/frontend/packages/frontend/src/app/RequireAdmin.tsx
@@ -1,12 +1,11 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import * as AuthApi from '@photobank/shared/api/photobank';
+import { useIsAdmin } from '@photobank/shared';
 
 export default function RequireAdmin() {
   const location = useLocation();
-  const { data: roles, isLoading } = AuthApi.useAuthGetUserRoles();
+  const isAdmin = useIsAdmin();
 
-  if (isLoading) return null;
-  const isAdmin = roles?.data.some((r: AuthApi.RoleDto) => r.name === 'Administrator');
+  if (isAdmin === null) return null;
   if (!isAdmin) return <Navigate to="/filter" state={{ from: location }} replace />;
   return <Outlet />;
 }

--- a/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
+++ b/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
@@ -8,7 +8,6 @@ import { logger } from '@photobank/shared/utils/logger';
 import { useTranslation } from 'react-i18next';
 import {
   useAuthGetUser,
-  useAuthGetUserRoles,
   useAuthGetUserClaims,
   useAuthUpdateUser,
 } from '@photobank/shared/api/photobank';
@@ -30,8 +29,6 @@ export default function MyProfilePage() {
   const { t } = useTranslation();
   const { data: userResp } = useAuthGetUser();
   const user = userResp?.data;
-  const { data: rolesResp } = useAuthGetUserRoles();
-  const roles = rolesResp?.data ?? [];
   const { data: claimsResp } = useAuthGetUserClaims();
   const claims = claimsResp?.data ?? [];
   const { mutateAsync: updateUser } = useAuthUpdateUser();
@@ -111,25 +108,6 @@ export default function MyProfilePage() {
               <Button type="submit" className="w-full">{t('saveButtonText')}</Button>
             </form>
           </Form>
-          {roles.length > 0 && (
-            <div>
-              <h2 className="font-medium">{t('rolesTitle')}</h2>
-              <ul className="list-disc list-inside space-y-1 ml-4">
-                {roles.map((r) => (
-                  <li key={r.name}>
-                    <span className="font-semibold">{r.name}</span>
-                    {r.claims && r.claims.length > 0 && (
-                      <ul className="list-disc list-inside ml-4">
-                  {r.claims?.map((c: ClaimDto, idx: number) => (
-                    <li key={idx}>{c.type ?? ''}: {c.value ?? ''}</li>
-                  ))}
-                      </ul>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
           {claims.length > 0 && (
             <div>
               <h2 className="font-medium">{t('userClaimsTitle')}</h2>

--- a/frontend/packages/frontend/test/FilterFormFields.test.tsx
+++ b/frontend/packages/frontend/test/FilterFormFields.test.tsx
@@ -13,18 +13,15 @@ declare module '@testing-library/react' {
   }
 }
 
-const renderWithRoles = async (roles: any[]) => {
-  const getUserRoles = vi.fn().mockImplementation(() => {
-    console.log('getUserRoles called with', roles);
-    return Promise.resolve({ data: roles });
+const renderWithAdmin = async (isAdmin: boolean) => {
+  vi.doMock('@photobank/shared', async () => {
+    const actual = await vi.importActual<any>('@photobank/shared');
+    return {
+      ...actual,
+      useIsAdmin: () => isAdmin,
+      useCanSeeNsfw: () => false,
+    };
   });
-  vi.doMock('@photobank/shared/auth', () => ({
-    getAuthToken: () => 'token',
-  }));
-  vi.doMock('@photobank/shared/api/photobank', () => ({
-    authGetUserRoles: getUserRoles,
-    useAuthGetUserClaims: () => ({ data: { data: [] }, isLoading: false, isError: false })
-  }));
 
   const { FilterFormFields } = await import('../src/components/FilterFormFields');
 
@@ -73,7 +70,6 @@ const renderWithRoles = async (roles: any[]) => {
   }
 
   render(<Wrapper />);
-  return { getUserRoles };
 };
 
 describe('FilterFormFields', () => {
@@ -83,7 +79,7 @@ describe('FilterFormFields', () => {
   });
 
   it.skip('shows admin checkboxes for administrators', async () => {
-    await renderWithRoles([{ name: 'Administrator' }]);
+    await renderWithAdmin(true);
     expect(await screen.findByText('Adult Content')).toBeTruthy();
   });
 

--- a/frontend/packages/shared/src/api/photobank/auth/auth.msw.ts
+++ b/frontend/packages/shared/src/api/photobank/auth/auth.msw.ts
@@ -17,13 +17,11 @@ import {
 
 export const getAuthLoginResponseMock = (overrideResponse: Partial< LoginResponseDto > = {}): LoginResponseDto => ({token: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), ...overrideResponse})
 
-export const getAuthGetUserResponseMock = (overrideResponse: Partial< UserDto > = {}): UserDto => ({email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), ...overrideResponse})
+export const getAuthGetUserResponseMock = (overrideResponse: Partial< UserDto > = {}): UserDto => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), ...overrideResponse})
+
+export const getAuthGetUserClaimsResponseMock = (): ClaimDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), value: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined])})))
 
 export const getAuthTelegramExchangeResponseMock = (overrideResponse: Partial< TelegramExchangeResponse > = {}): TelegramExchangeResponse => ({accessToken: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), expiresIn: faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), undefined]), ...overrideResponse})
-
-export const getAuthGetUserClaimsResponseMock = (): ClaimDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})))
-
-export const getAuthGetUserRolesResponseMock = (): RoleDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({name: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined])})))
 
 
 export const getAuthLoginMockHandler = (overrideResponse?: LoginResponseDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<LoginResponseDto> | LoginResponseDto)) => {
@@ -70,18 +68,6 @@ export const getAuthUpdateUserMockHandler = (overrideResponse?: null | ((info: P
   })
 }
 
-export const getAuthTelegramExchangeMockHandler = (overrideResponse?: TelegramExchangeResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<TelegramExchangeResponse> | TelegramExchangeResponse)) => {
-  return http.post('/api/auth/telegram/exchange', async (info) => {await delay(1000);
-  
-    return new HttpResponse(overrideResponse !== undefined
-    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
-    : getAuthTelegramExchangeResponseMock(),
-      { status: 200,
-        headers: { 'Content-Type': 'text/plain' }
-      })
-  })
-}
-
 export const getAuthGetUserClaimsMockHandler = (overrideResponse?: ClaimDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<ClaimDto[]> | ClaimDto[])) => {
   return http.get('/api/auth/claims', async (info) => {await delay(1000);
   
@@ -94,12 +80,12 @@ export const getAuthGetUserClaimsMockHandler = (overrideResponse?: ClaimDto[] | 
   })
 }
 
-export const getAuthGetUserRolesMockHandler = (overrideResponse?: RoleDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<RoleDto[]> | RoleDto[])) => {
-  return http.get('/api/auth/roles', async (info) => {await delay(1000);
+export const getAuthTelegramExchangeMockHandler = (overrideResponse?: TelegramExchangeResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<TelegramExchangeResponse> | TelegramExchangeResponse)) => {
+  return http.post('/api/auth/telegram/exchange', async (info) => {await delay(1000);
   
     return new HttpResponse(overrideResponse !== undefined
     ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
-    : getAuthGetUserRolesResponseMock(),
+    : getAuthTelegramExchangeResponseMock(),
       { status: 200,
         headers: { 'Content-Type': 'text/plain' }
       })
@@ -120,8 +106,7 @@ export const getAuthMock = () => [
   getAuthRegisterMockHandler(),
   getAuthGetUserMockHandler(),
   getAuthUpdateUserMockHandler(),
-  getAuthTelegramExchangeMockHandler(),
   getAuthGetUserClaimsMockHandler(),
-  getAuthGetUserRolesMockHandler(),
+  getAuthTelegramExchangeMockHandler(),
   getAuthGetEffectiveMockHandler()
 ]

--- a/frontend/packages/shared/src/api/photobank/auth/auth.ts
+++ b/frontend/packages/shared/src/api/photobank/auth/auth.ts
@@ -24,7 +24,6 @@ import type {
   LoginResponseDto,
   ProblemDetails,
   RegisterRequestDto,
-  RoleDto,
   TelegramExchangeRequest,
   TelegramExchangeResponse,
   UpdateUserDto,
@@ -359,7 +358,83 @@ const {mutation: mutationOptions} = options ?
 
       return useMutation(mutationOptions );
     }
-    export type authTelegramExchangeResponse200 = {
+    export type authGetUserClaimsResponse200 = {
+  data: ClaimDto[]
+  status: 200
+}
+    
+export type authGetUserClaimsResponseComposite = authGetUserClaimsResponse200;
+    
+export type authGetUserClaimsResponse = authGetUserClaimsResponseComposite & {
+  headers: Headers;
+}
+
+export const getAuthGetUserClaimsUrl = () => {
+
+
+  
+
+  return `/auth/claims`
+}
+
+export const authGetUserClaims = async ( options?: RequestInit): Promise<authGetUserClaimsResponse> => {
+  
+  return customFetcher<authGetUserClaimsResponse>(getAuthGetUserClaimsUrl(),
+  {      
+    ...options,
+    method: 'GET'
+    
+    
+  }
+);}
+
+
+
+export const getAuthGetUserClaimsQueryKey = () => {
+    return [`/auth/claims`] as const;
+    }
+
+    
+export const getAuthGetUserClaimsQueryOptions = <TData = Awaited<ReturnType<typeof authGetUserClaims>>, TError = unknown>( options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof authGetUserClaims>>, TError, TData>, }
+) => {
+
+const {query: queryOptions} = options ?? {};
+
+  const queryKey =  queryOptions?.queryKey ?? getAuthGetUserClaimsQueryKey();
+
+  
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof authGetUserClaims>>> = ({ signal }) => authGetUserClaims(signal);
+
+      
+
+      
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof authGetUserClaims>>, TError, TData> & { queryKey: QueryKey }
+}
+
+export type AuthGetUserClaimsQueryResult = NonNullable<Awaited<ReturnType<typeof authGetUserClaims>>>
+export type AuthGetUserClaimsQueryError = unknown
+
+
+
+export function useAuthGetUserClaims<TData = Awaited<ReturnType<typeof authGetUserClaims>>, TError = unknown>(
+  options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof authGetUserClaims>>, TError, TData>, }
+  
+ ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } {
+
+  const queryOptions = getAuthGetUserClaimsQueryOptions(options)
+
+  const query = useQuery(queryOptions ) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey ;
+
+  return query;
+}
+
+
+
+export type authTelegramExchangeResponse200 = {
   data: TelegramExchangeResponse
   status: 200
 }
@@ -445,159 +520,7 @@ const {mutation: mutationOptions} = options ?
 
       return useMutation(mutationOptions );
     }
-    export type authGetUserClaimsResponse200 = {
-  data: ClaimDto[]
-  status: 200
-}
-    
-export type authGetUserClaimsResponseComposite = authGetUserClaimsResponse200;
-    
-export type authGetUserClaimsResponse = authGetUserClaimsResponseComposite & {
-  headers: Headers;
-}
-
-export const getAuthGetUserClaimsUrl = () => {
-
-
-  
-
-  return `/auth/claims`
-}
-
-export const authGetUserClaims = async ( options?: RequestInit): Promise<authGetUserClaimsResponse> => {
-  
-  return customFetcher<authGetUserClaimsResponse>(getAuthGetUserClaimsUrl(),
-  {      
-    ...options,
-    method: 'GET'
-    
-    
-  }
-);}
-
-
-
-export const getAuthGetUserClaimsQueryKey = () => {
-    return [`/auth/claims`] as const;
-    }
-
-    
-export const getAuthGetUserClaimsQueryOptions = <TData = Awaited<ReturnType<typeof authGetUserClaims>>, TError = unknown>( options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof authGetUserClaims>>, TError, TData>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getAuthGetUserClaimsQueryKey();
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof authGetUserClaims>>> = ({ signal }) => authGetUserClaims(signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof authGetUserClaims>>, TError, TData> & { queryKey: QueryKey }
-}
-
-export type AuthGetUserClaimsQueryResult = NonNullable<Awaited<ReturnType<typeof authGetUserClaims>>>
-export type AuthGetUserClaimsQueryError = unknown
-
-
-
-export function useAuthGetUserClaims<TData = Awaited<ReturnType<typeof authGetUserClaims>>, TError = unknown>(
-  options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof authGetUserClaims>>, TError, TData>, }
-  
- ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } {
-
-  const queryOptions = getAuthGetUserClaimsQueryOptions(options)
-
-  const query = useQuery(queryOptions ) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-export type authGetUserRolesResponse200 = {
-  data: RoleDto[]
-  status: 200
-}
-    
-export type authGetUserRolesResponseComposite = authGetUserRolesResponse200;
-    
-export type authGetUserRolesResponse = authGetUserRolesResponseComposite & {
-  headers: Headers;
-}
-
-export const getAuthGetUserRolesUrl = () => {
-
-
-  
-
-  return `/auth/roles`
-}
-
-export const authGetUserRoles = async ( options?: RequestInit): Promise<authGetUserRolesResponse> => {
-  
-  return customFetcher<authGetUserRolesResponse>(getAuthGetUserRolesUrl(),
-  {      
-    ...options,
-    method: 'GET'
-    
-    
-  }
-);}
-
-
-
-export const getAuthGetUserRolesQueryKey = () => {
-    return [`/auth/roles`] as const;
-    }
-
-    
-export const getAuthGetUserRolesQueryOptions = <TData = Awaited<ReturnType<typeof authGetUserRoles>>, TError = unknown>( options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof authGetUserRoles>>, TError, TData>, }
-) => {
-
-const {query: queryOptions} = options ?? {};
-
-  const queryKey =  queryOptions?.queryKey ?? getAuthGetUserRolesQueryKey();
-
-  
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof authGetUserRoles>>> = ({ signal }) => authGetUserRoles(signal);
-
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof authGetUserRoles>>, TError, TData> & { queryKey: QueryKey }
-}
-
-export type AuthGetUserRolesQueryResult = NonNullable<Awaited<ReturnType<typeof authGetUserRoles>>>
-export type AuthGetUserRolesQueryError = unknown
-
-
-
-export function useAuthGetUserRoles<TData = Awaited<ReturnType<typeof authGetUserRoles>>, TError = unknown>(
-  options?: { query?:UseQueryOptions<Awaited<ReturnType<typeof authGetUserRoles>>, TError, TData>, }
-  
- ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } {
-
-  const queryOptions = getAuthGetUserRolesQueryOptions(options)
-
-  const query = useQuery(queryOptions ) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
-
-  query.queryKey = queryOptions.queryKey ;
-
-  return query;
-}
-
-
-
-export type authGetEffectiveResponse200 = {
+    export type authGetEffectiveResponse200 = {
   data: null
   status: 200
 }

--- a/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
+++ b/frontend/packages/shared/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
@@ -44,13 +44,6 @@ export interface AccessProfileStorageAllow {
   profile?: AccessProfile;
 }
 
-export interface ClaimDto {
-  /** @nullable */
-  type: string | null;
-  /** @nullable */
-  value: string | null;
-}
-
 export interface CreateUserDto {
   /** @nullable */
   email: string | null;
@@ -260,16 +253,16 @@ export interface RegisterRequestDto {
   password: string | null;
 }
 
+export interface ClaimDto {
+  /** @nullable */
+  type?: string | null;
+  /** @nullable */
+  value?: string | null;
+}
+
 export interface ResetPasswordDto {
   /** @nullable */
   newPassword: string | null;
-}
-
-export interface RoleDto {
-  /** @nullable */
-  name: string | null;
-  /** @nullable */
-  claims?: ClaimDto[] | null;
 }
 
 export interface SetRolesDto {
@@ -328,17 +321,6 @@ export interface UpdateUserDto {
 
 export interface UserDto {
   /** @nullable */
-  email: string | null;
-  /** @nullable */
-  phoneNumber?: string | null;
-  /** @nullable */
-  telegramUserId?: number | null;
-  /** @nullable */
-  telegramSendTimeUtc?: string | null;
-}
-
-export interface UserWithClaimsDto {
-  /** @nullable */
   id: string | null;
   /** @nullable */
   email: string | null;
@@ -348,8 +330,6 @@ export interface UserWithClaimsDto {
   telegramUserId?: number | null;
   /** @nullable */
   telegramSendTimeUtc?: string | null;
-  /** @nullable */
-  claims?: ClaimDto[] | null;
 }
 
 export type FacesGetParams = {

--- a/frontend/packages/shared/src/api/photobank/users/users.msw.ts
+++ b/frontend/packages/shared/src/api/photobank/users/users.msw.ts
@@ -15,12 +15,12 @@ import {
 } from 'msw';
 
 
-export const getUsersGetAllResponseMock = (): UserWithClaimsDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined])})))
+export const getUsersGetAllResponseMock = (): UserDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined])})))
 
-export const getUsersCreateResponseMock = (overrideResponse: Partial< UserWithClaimsDto > = {}): UserWithClaimsDto => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined]), ...overrideResponse})
+export const getUsersCreateResponseMock = (overrideResponse: Partial< UserDto > = {}): UserDto => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), ...overrideResponse})
 
 
-export const getUsersGetAllMockHandler = (overrideResponse?: UserWithClaimsDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<UserWithClaimsDto[]> | UserWithClaimsDto[])) => {
+export const getUsersGetAllMockHandler = (overrideResponse?: UserDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<UserDto[]> | UserDto[])) => {
   return http.get('/api/admin/users', async (info) => {await delay(1000);
   
     return new HttpResponse(overrideResponse !== undefined
@@ -32,7 +32,7 @@ export const getUsersGetAllMockHandler = (overrideResponse?: UserWithClaimsDto[]
   })
 }
 
-export const getUsersCreateMockHandler = (overrideResponse?: UserWithClaimsDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<UserWithClaimsDto> | UserWithClaimsDto)) => {
+export const getUsersCreateMockHandler = (overrideResponse?: UserDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<UserDto> | UserDto)) => {
   return http.post('/api/admin/users', async (info) => {await delay(1000);
   
     return new HttpResponse(overrideResponse !== undefined
@@ -74,16 +74,6 @@ export const getUsersResetPasswordMockHandler = (overrideResponse?: null | ((inf
   })
 }
 
-export const getUsersSetClaimsMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Promise<null> | null)) => {
-  return http.put('/api/admin/users/:id/claims', async (info) => {await delay(1000);
-  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
-    return new HttpResponse(null,
-      { status: 200,
-        
-      })
-  })
-}
-
 export const getUsersSetRolesMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Promise<null> | null)) => {
   return http.put('/api/admin/users/:id/roles', async (info) => {await delay(1000);
   if (typeof overrideResponse === 'function') {await overrideResponse(info); }
@@ -99,6 +89,5 @@ export const getUsersMock = () => [
   getUsersUpdateMockHandler(),
   getUsersDeleteMockHandler(),
   getUsersResetPasswordMockHandler(),
-  getUsersSetClaimsMockHandler(),
   getUsersSetRolesMockHandler()
 ]

--- a/frontend/packages/shared/src/api/photobank/users/users.ts
+++ b/frontend/packages/shared/src/api/photobank/users/users.ts
@@ -19,13 +19,12 @@ import type {
 } from '@tanstack/react-query';
 
 import type {
-  ClaimDto,
   CreateUserDto,
   ProblemDetails,
   ResetPasswordDto,
   SetRolesDto,
   UpdateUserDto,
-  UserWithClaimsDto
+  UserDto
 } from '../photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas';
 
 import { customFetcher } from '.././fetcher';
@@ -38,7 +37,7 @@ type AwaitedInput<T> = PromiseLike<T> | T;
 
 
 export type usersGetAllResponse200 = {
-  data: UserWithClaimsDto[]
+  data: UserDto[]
   status: 200
 }
     
@@ -114,7 +113,7 @@ export function useUsersGetAll<TData = Awaited<ReturnType<typeof usersGetAll>>, 
 
 
 export type usersCreateResponse201 = {
-  data: UserWithClaimsDto
+  data: UserDto
   status: 201
 }
 
@@ -440,93 +439,6 @@ const {mutation: mutationOptions} = options ?
       > => {
 
       const mutationOptions = getUsersResetPasswordMutationOptions(options);
-
-      return useMutation(mutationOptions );
-    }
-    export type usersSetClaimsResponse200 = {
-  data: null
-  status: 200
-}
-
-export type usersSetClaimsResponse400 = {
-  data: ProblemDetails
-  status: 400
-}
-
-export type usersSetClaimsResponse404 = {
-  data: ProblemDetails
-  status: 404
-}
-    
-export type usersSetClaimsResponseComposite = usersSetClaimsResponse200 | usersSetClaimsResponse400 | usersSetClaimsResponse404;
-    
-export type usersSetClaimsResponse = usersSetClaimsResponseComposite & {
-  headers: Headers;
-}
-
-export const getUsersSetClaimsUrl = (id: string,) => {
-
-
-  
-
-  return `/admin/users/${id}/claims`
-}
-
-export const usersSetClaims = async (id: string,
-    claimDto: ClaimDto[], options?: RequestInit): Promise<usersSetClaimsResponse> => {
-  
-  return customFetcher<usersSetClaimsResponse>(getUsersSetClaimsUrl(id),
-  {      
-    ...options,
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json', ...options?.headers },
-    body: JSON.stringify(
-      claimDto,)
-  }
-);}
-
-
-
-
-export const getUsersSetClaimsMutationOptions = <TError = ProblemDetails | ProblemDetails,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersSetClaims>>, TError,{id: string;data: ClaimDto[]}, TContext>, }
-): UseMutationOptions<Awaited<ReturnType<typeof usersSetClaims>>, TError,{id: string;data: ClaimDto[]}, TContext> => {
-
-const mutationKey = ['usersSetClaims'];
-const {mutation: mutationOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }};
-
-      
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof usersSetClaims>>, {id: string;data: ClaimDto[]}> = (props) => {
-          const {id,data} = props ?? {};
-
-          return  usersSetClaims(id,data,)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type UsersSetClaimsMutationResult = NonNullable<Awaited<ReturnType<typeof usersSetClaims>>>
-    export type UsersSetClaimsMutationBody = ClaimDto[]
-    export type UsersSetClaimsMutationError = ProblemDetails | ProblemDetails
-
-    export const useUsersSetClaims = <TError = ProblemDetails | ProblemDetails,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof usersSetClaims>>, TError,{id: string;data: ClaimDto[]}, TContext>, }
- ): UseMutationResult<
-        Awaited<ReturnType<typeof usersSetClaims>>,
-        TError,
-        {id: string;data: ClaimDto[]},
-        TContext
-      > => {
-
-      const mutationOptions = getUsersSetClaimsMutationOptions(options);
 
       return useMutation(mutationOptions );
     }

--- a/frontend/packages/shared/src/hooks/useIsAdmin.ts
+++ b/frontend/packages/shared/src/hooks/useIsAdmin.ts
@@ -1,8 +1,18 @@
 import * as AuthApi from '../api/photobank/auth/auth';
 
+const ADMIN_ROLE = 'Administrator';
+const ROLE_CLAIM_TYPES = [
+  'role',
+  'http://schemas.microsoft.com/ws/2008/06/identity/claims/role',
+];
+
 export const useIsAdmin = (): boolean | null => {
-  const { data: roles, isLoading, isError } = AuthApi.useAuthGetUserRoles();
+  const { data: claims, isLoading, isError } = AuthApi.useAuthGetUserClaims();
   if (isLoading) return null;
   if (isError) return false;
-  return roles?.data.some((r) => r.name === 'Administrator') ?? false;
+  return (
+    claims?.data.some(
+      (c) => ROLE_CLAIM_TYPES.includes(c.type ?? '') && c.value === ADMIN_ROLE,
+    ) ?? false
+  );
 };

--- a/frontend/packages/telegram-bot/src/api/photobank/auth/auth.msw.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/auth/auth.msw.ts
@@ -17,13 +17,11 @@ import {
 
 export const getAuthLoginResponseMock = (overrideResponse: Partial< LoginResponseDto > = {}): LoginResponseDto => ({token: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), ...overrideResponse})
 
-export const getAuthGetUserResponseMock = (overrideResponse: Partial< UserDto > = {}): UserDto => ({email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), ...overrideResponse})
+export const getAuthGetUserResponseMock = (overrideResponse: Partial< UserDto > = {}): UserDto => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), ...overrideResponse})
+
+export const getAuthGetUserClaimsResponseMock = (): ClaimDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), value: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined])})))
 
 export const getAuthTelegramExchangeResponseMock = (overrideResponse: Partial< TelegramExchangeResponse > = {}): TelegramExchangeResponse => ({accessToken: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), expiresIn: faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), undefined]), ...overrideResponse})
-
-export const getAuthGetUserClaimsResponseMock = (): ClaimDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})))
-
-export const getAuthGetUserRolesResponseMock = (): RoleDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({name: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined])})))
 
 
 export const getAuthLoginMockHandler = (overrideResponse?: LoginResponseDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<LoginResponseDto> | LoginResponseDto)) => {
@@ -70,18 +68,6 @@ export const getAuthUpdateUserMockHandler = (overrideResponse?: null | ((info: P
   })
 }
 
-export const getAuthTelegramExchangeMockHandler = (overrideResponse?: TelegramExchangeResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<TelegramExchangeResponse> | TelegramExchangeResponse)) => {
-  return http.post('/api/auth/telegram/exchange', async (info) => {await delay(1000);
-  
-    return new HttpResponse(overrideResponse !== undefined
-    ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
-    : getAuthTelegramExchangeResponseMock(),
-      { status: 200,
-        headers: { 'Content-Type': 'text/plain' }
-      })
-  })
-}
-
 export const getAuthGetUserClaimsMockHandler = (overrideResponse?: ClaimDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<ClaimDto[]> | ClaimDto[])) => {
   return http.get('/api/auth/claims', async (info) => {await delay(1000);
   
@@ -94,12 +80,12 @@ export const getAuthGetUserClaimsMockHandler = (overrideResponse?: ClaimDto[] | 
   })
 }
 
-export const getAuthGetUserRolesMockHandler = (overrideResponse?: RoleDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<RoleDto[]> | RoleDto[])) => {
-  return http.get('/api/auth/roles', async (info) => {await delay(1000);
+export const getAuthTelegramExchangeMockHandler = (overrideResponse?: TelegramExchangeResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<TelegramExchangeResponse> | TelegramExchangeResponse)) => {
+  return http.post('/api/auth/telegram/exchange', async (info) => {await delay(1000);
   
     return new HttpResponse(overrideResponse !== undefined
     ? (typeof overrideResponse === "function" ? await overrideResponse(info) : overrideResponse)
-    : getAuthGetUserRolesResponseMock(),
+    : getAuthTelegramExchangeResponseMock(),
       { status: 200,
         headers: { 'Content-Type': 'text/plain' }
       })
@@ -120,7 +106,6 @@ export const getAuthMock = () => [
   getAuthRegisterMockHandler(),
   getAuthGetUserMockHandler(),
   getAuthUpdateUserMockHandler(),
-  getAuthTelegramExchangeMockHandler(),
   getAuthGetUserClaimsMockHandler(),
-  getAuthGetUserRolesMockHandler(),
+  getAuthTelegramExchangeMockHandler(),
   getAuthGetEffectiveMockHandler()]

--- a/frontend/packages/telegram-bot/src/api/photobank/auth/auth.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/auth/auth.ts
@@ -9,7 +9,6 @@ import type {
   LoginRequestDto,
   LoginResponseDto,
   RegisterRequestDto,
-  RoleDto,
   TelegramExchangeRequest,
   TelegramExchangeResponse,
   UpdateUserDto,
@@ -61,16 +60,6 @@ const authLogin = (
     },
       options);
     }
-  const authTelegramExchange = (
-    telegramExchangeRequest: TelegramExchangeRequest,
- options?: SecondParameter<typeof photobankAxios>,) => {
-      return photobankAxios<TelegramExchangeResponse>(
-      {url: `/auth/telegram/exchange`, method: 'POST',
-      headers: {'Content-Type': 'application/json', },
-      data: telegramExchangeRequest
-    },
-      options);
-    }
   const authGetUserClaims = (
     
  options?: SecondParameter<typeof photobankAxios>,) => {
@@ -79,11 +68,13 @@ const authLogin = (
     },
       options);
     }
-  const authGetUserRoles = (
-    
+  const authTelegramExchange = (
+    telegramExchangeRequest: TelegramExchangeRequest,
  options?: SecondParameter<typeof photobankAxios>,) => {
-      return photobankAxios<RoleDto[]>(
-      {url: `/auth/roles`, method: 'GET'
+      return photobankAxios<TelegramExchangeResponse>(
+      {url: `/auth/telegram/exchange`, method: 'POST',
+      headers: {'Content-Type': 'application/json', },
+      data: telegramExchangeRequest
     },
       options);
     }
@@ -95,7 +86,7 @@ const authLogin = (
     },
       options);
     }
-  return {authLogin,authRegister,authGetUser,authUpdateUser,authTelegramExchange,authGetUserClaims,authGetUserRoles,authGetEffective}};
+  return {authLogin,authRegister,authGetUser,authUpdateUser,authGetUserClaims,authTelegramExchange,authGetEffective}};
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -105,7 +96,6 @@ export type AuthLoginResult = NonNullable<Awaited<ReturnType<ReturnType<typeof g
 export type AuthRegisterResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authRegister']>>>
 export type AuthGetUserResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authGetUser']>>>
 export type AuthUpdateUserResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authUpdateUser']>>>
-export type AuthTelegramExchangeResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authTelegramExchange']>>>
 export type AuthGetUserClaimsResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authGetUserClaims']>>>
-export type AuthGetUserRolesResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authGetUserRoles']>>>
+export type AuthTelegramExchangeResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authTelegramExchange']>>>
 export type AuthGetEffectiveResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getAuth>['authGetEffective']>>>

--- a/frontend/packages/telegram-bot/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas.ts
@@ -44,13 +44,6 @@ export interface AccessProfileStorageAllow {
   profile?: AccessProfile;
 }
 
-export interface ClaimDto {
-  /** @nullable */
-  type: string | null;
-  /** @nullable */
-  value: string | null;
-}
-
 export interface CreateUserDto {
   /** @nullable */
   email: string | null;
@@ -260,16 +253,16 @@ export interface RegisterRequestDto {
   password: string | null;
 }
 
+export interface ClaimDto {
+  /** @nullable */
+  type?: string | null;
+  /** @nullable */
+  value?: string | null;
+}
+
 export interface ResetPasswordDto {
   /** @nullable */
   newPassword: string | null;
-}
-
-export interface RoleDto {
-  /** @nullable */
-  name: string | null;
-  /** @nullable */
-  claims?: ClaimDto[] | null;
 }
 
 export interface SetRolesDto {
@@ -328,17 +321,6 @@ export interface UpdateUserDto {
 
 export interface UserDto {
   /** @nullable */
-  email: string | null;
-  /** @nullable */
-  phoneNumber?: string | null;
-  /** @nullable */
-  telegramUserId?: number | null;
-  /** @nullable */
-  telegramSendTimeUtc?: string | null;
-}
-
-export interface UserWithClaimsDto {
-  /** @nullable */
   id: string | null;
   /** @nullable */
   email: string | null;
@@ -348,8 +330,6 @@ export interface UserWithClaimsDto {
   telegramUserId?: number | null;
   /** @nullable */
   telegramSendTimeUtc?: string | null;
-  /** @nullable */
-  claims?: ClaimDto[] | null;
 }
 
 export type FacesGetParams = {

--- a/frontend/packages/telegram-bot/src/api/photobank/users/users.msw.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/users/users.msw.ts
@@ -15,12 +15,12 @@ import {
 } from 'msw';
 
 
-export const getUsersGetAllResponseMock = (): UserWithClaimsDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined])})))
+export const getUsersGetAllResponseMock = (): UserDto[] => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined])})))
 
-export const getUsersCreateResponseMock = (overrideResponse: Partial< UserWithClaimsDto > = {}): UserWithClaimsDto => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), claims: faker.helpers.arrayElement([Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({type: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), value: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null])})), undefined]), ...overrideResponse})
+export const getUsersCreateResponseMock = (overrideResponse: Partial< UserDto > = {}): UserDto => ({id: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), email: faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), phoneNumber: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), telegramUserId: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.number.int({min: undefined, max: undefined}), null]), undefined]), telegramSendTimeUtc: faker.helpers.arrayElement([faker.helpers.arrayElement([faker.string.alpha({length: {min: 10, max: 20}}), null]), undefined]), ...overrideResponse})
 
 
-export const getUsersGetAllMockHandler = (overrideResponse?: UserWithClaimsDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<UserWithClaimsDto[]> | UserWithClaimsDto[])) => {
+export const getUsersGetAllMockHandler = (overrideResponse?: UserDto[] | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<UserDto[]> | UserDto[])) => {
   return http.get('/api/admin/users', async (info) => {await delay(1000);
   
     return new HttpResponse(overrideResponse !== undefined
@@ -32,7 +32,7 @@ export const getUsersGetAllMockHandler = (overrideResponse?: UserWithClaimsDto[]
   })
 }
 
-export const getUsersCreateMockHandler = (overrideResponse?: UserWithClaimsDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<UserWithClaimsDto> | UserWithClaimsDto)) => {
+export const getUsersCreateMockHandler = (overrideResponse?: UserDto | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<UserDto> | UserDto)) => {
   return http.post('/api/admin/users', async (info) => {await delay(1000);
   
     return new HttpResponse(overrideResponse !== undefined
@@ -74,16 +74,6 @@ export const getUsersResetPasswordMockHandler = (overrideResponse?: null | ((inf
   })
 }
 
-export const getUsersSetClaimsMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Promise<null> | null)) => {
-  return http.put('/api/admin/users/:id/claims', async (info) => {await delay(1000);
-  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
-    return new HttpResponse(null,
-      { status: 200,
-        
-      })
-  })
-}
-
 export const getUsersSetRolesMockHandler = (overrideResponse?: null | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Promise<null> | null)) => {
   return http.put('/api/admin/users/:id/roles', async (info) => {await delay(1000);
   if (typeof overrideResponse === 'function') {await overrideResponse(info); }
@@ -99,5 +89,4 @@ export const getUsersMock = () => [
   getUsersUpdateMockHandler(),
   getUsersDeleteMockHandler(),
   getUsersResetPasswordMockHandler(),
-  getUsersSetClaimsMockHandler(),
   getUsersSetRolesMockHandler()]

--- a/frontend/packages/telegram-bot/src/api/photobank/users/users.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/users/users.ts
@@ -5,12 +5,11 @@
  * OpenAPI spec version: 1.0
  */
 import type {
-  ClaimDto,
   CreateUserDto,
   ResetPasswordDto,
   SetRolesDto,
   UpdateUserDto,
-  UserWithClaimsDto
+  UserDto
 } from '../photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas';
 
 import { photobankAxios } from '../../axios-instance';
@@ -23,7 +22,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 const usersGetAll = (
     
  options?: SecondParameter<typeof photobankAxios>,) => {
-      return photobankAxios<UserWithClaimsDto[]>(
+      return photobankAxios<UserDto[]>(
       {url: `/admin/users`, method: 'GET'
     },
       options);
@@ -31,7 +30,7 @@ const usersGetAll = (
   const usersCreate = (
     createUserDto: CreateUserDto,
  options?: SecondParameter<typeof photobankAxios>,) => {
-      return photobankAxios<UserWithClaimsDto>(
+      return photobankAxios<UserDto>(
       {url: `/admin/users`, method: 'POST',
       headers: {'Content-Type': 'application/json', },
       data: createUserDto
@@ -68,17 +67,6 @@ const usersGetAll = (
     },
       options);
     }
-  const usersSetClaims = (
-    id: string,
-    claimDto: ClaimDto[],
- options?: SecondParameter<typeof photobankAxios>,) => {
-      return photobankAxios<null>(
-      {url: `/admin/users/${id}/claims`, method: 'PUT',
-      headers: {'Content-Type': 'application/json', },
-      data: claimDto
-    },
-      options);
-    }
   const usersSetRoles = (
     id: string,
     setRolesDto: SetRolesDto,
@@ -90,7 +78,7 @@ const usersGetAll = (
     },
       options);
     }
-  return {usersGetAll,usersCreate,usersUpdate,usersDelete,usersResetPassword,usersSetClaims,usersSetRoles}};
+  return {usersGetAll,usersCreate,usersUpdate,usersDelete,usersResetPassword,usersSetRoles}};
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -101,5 +89,4 @@ export type UsersCreateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof
 export type UsersUpdateResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersUpdate']>>>
 export type UsersDeleteResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersDelete']>>>
 export type UsersResetPasswordResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersResetPassword']>>>
-export type UsersSetClaimsResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersSetClaims']>>>
 export type UsersSetRolesResult = NonNullable<Awaited<ReturnType<ReturnType<typeof getUsers>['usersSetRoles']>>>

--- a/frontend/packages/telegram-bot/src/commands/profile.ts
+++ b/frontend/packages/telegram-bot/src/commands/profile.ts
@@ -1,33 +1,17 @@
 import type { MyContext } from "../i18n";
-import { getUser, getUserRoles, getUserClaims } from "../services/auth";
+import { getUser, getUserClaims } from "../services/auth";
 import { handleCommandError } from "../errorHandler";
 
 export async function profileCommand(ctx: MyContext) {
     const username = ctx.from?.username ?? String(ctx.from?.id ?? "");
     try {
         await getUser(ctx);
-        const [rolesRes, claimsRes] = await Promise.all([
-            getUserRoles(ctx),
-            getUserClaims(ctx),
-        ]);
-        const roles = rolesRes.data;
+        const claimsRes = await getUserClaims(ctx);
         const claims = claimsRes.data;
 
         const lines: string[] = [
             ctx.t('user-info', { username }),
         ];
-
-        if (roles.length) {
-            lines.push(ctx.t('roles-label'));
-            for (const role of roles) {
-                lines.push(`- ${role.name}`);
-                for (const claim of role.claims) {
-                    lines.push(`  • ${claim.type}: ${claim.value}`);
-                }
-            }
-        } else {
-            lines.push(ctx.t('roles-empty'));
-        }
 
         if (claims.length) {
             lines.push(ctx.t('claims-label'));

--- a/frontend/packages/telegram-bot/src/services/auth.ts
+++ b/frontend/packages/telegram-bot/src/services/auth.ts
@@ -1,11 +1,9 @@
 import type { Context } from 'grammy';
 import {
   authGetUser,
-  authGetUserRoles,
   authGetUserClaims,
   authUpdateUser,
   type authGetUserResponse,
-  type authGetUserRolesResponse,
   type authGetUserClaimsResponse,
   type authUpdateUserResponse,
   type UpdateUserDto,
@@ -20,10 +18,6 @@ async function authorized<T>(ctx: Context, fn: (options?: RequestInit) => Promis
 
 export function getUser(ctx: Context): Promise<authGetUserResponse> {
   return authorized(ctx, authGetUser);
-}
-
-export function getUserRoles(ctx: Context): Promise<authGetUserRolesResponse> {
-  return authorized(ctx, authGetUserRoles);
 }
 
 export function getUserClaims(ctx: Context): Promise<authGetUserClaimsResponse> {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -309,6 +309,30 @@ paths:
             text/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  /auth/claims:
+    get:
+      tags:
+        - Auth
+      operationId: Auth_GetUserClaims
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClaimDto'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClaimDto'
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClaimDto'
   /auth/telegram/exchange:
     post:
       tags:
@@ -362,30 +386,6 @@ paths:
             text/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
-  /auth/roles:
-    get:
-      tags:
-        - Auth
-      operationId: Auth_GetUserRoles
-      responses:
-        '200':
-          description: OK
-          content:
-            text/plain:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RoleDto'
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RoleDto'
-            text/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RoleDto'
   /auth/debug/effective-access:
     get:
       tags:
@@ -1776,21 +1776,22 @@ components:
           type: string
           nullable: true
       additionalProperties: false
+    ClaimDto:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        value:
+          type: string
+          nullable: true
+      additionalProperties: false
     ResetPasswordDto:
       required:
         - newPassword
       type: object
       properties:
         newPassword:
-          type: string
-          nullable: true
-      additionalProperties: false
-    RoleDto:
-      required:
-        - name
-      type: object
-      properties:
-        name:
           type: string
           nullable: true
       additionalProperties: false


### PR DESCRIPTION
## Summary
- remove user roles API and DTO
- update clients and frontend to use claims for admin detection

## Testing
- `dotnet test` *(fails: Docker is either not running or misconfigured)*
- `pnpm -r --workspace-concurrency=1 test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68b697be3c7c8328bbabd3a468848c0f