### PR TITLE
fix: set API base path

### DIFF
--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -38,6 +38,8 @@ namespace PhotoBank.Api
                 });
             var app = builder.Build();
 
+            app.UsePathBase("/api");
+
             // Configure the HTTP request pipeline.
 //            if (app.Environment.IsDevelopment())
             {


### PR DESCRIPTION
## Summary
- align backend with `/api` base path

## Testing
- `MSBUILDTERMINALLOGGER=FALSE dotnet restore PhotoBank.Backend.sln`
- `MSBUILDTERMINALLOGGER=FALSE dotnet build PhotoBank.Backend.sln`
- `MSBUILDTERMINALLOGGER=FALSE dotnet test PhotoBank.Backend.sln` *(fails: Docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6aeddae4c83289db0fdd2fe66a0fe