### PR TITLE
refactor: remove user claim hook

### DIFF
--- a/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
+++ b/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
@@ -6,12 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { setAuthToken } from '@photobank/shared/auth';
 import { logger } from '@photobank/shared/utils/logger';
 import { useTranslation } from 'react-i18next';
-import {
-  useAuthGetUser,
-  useAuthGetUserClaims,
-  useAuthUpdateUser,
-} from '@photobank/shared/api/photobank';
-import type { ClaimDto } from '@photobank/shared/api/photobank';
+import { useAuthGetUser, useAuthUpdateUser } from '@photobank/shared/api/photobank';
 
 import {Button} from '@/shared/ui/button';
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/shared/ui/form';
@@ -29,8 +24,6 @@ export default function MyProfilePage() {
   const { t } = useTranslation();
   const { data: userResp } = useAuthGetUser();
   const user = userResp?.data;
-  const { data: claimsResp } = useAuthGetUserClaims();
-  const claims = claimsResp?.data ?? [];
   const { mutateAsync: updateUser } = useAuthUpdateUser();
 
   const form = useForm<FormData>({
@@ -108,16 +101,6 @@ export default function MyProfilePage() {
               <Button type="submit" className="w-full">{t('saveButtonText')}</Button>
             </form>
           </Form>
-          {claims.length > 0 && (
-            <div>
-              <h2 className="font-medium">{t('userClaimsTitle')}</h2>
-              <ul className="list-disc list-inside ml-4 space-y-1">
-                {claims.map((c: ClaimDto, idx: number) => (
-                  <li key={idx}>{c.type ?? ''}: {c.value ?? ''}</li>
-                ))}
-              </ul>
-            </div>
-          )}
         </div>
       )}
       <Button

--- a/frontend/packages/frontend/src/shared/config/locales/en.json
+++ b/frontend/packages/frontend/src/shared/config/locales/en.json
@@ -33,7 +33,6 @@
   "telegramLabel": "Telegram",
   "saveButtonText": "Save",
   "rolesTitle": "Roles",
-  "userClaimsTitle": "User Claims",
   "logoutButtonText": "Logout",
   "unassignedLabel": "Unassigned",
   "facePrefix": "Face",

--- a/frontend/packages/frontend/src/shared/config/locales/ru.json
+++ b/frontend/packages/frontend/src/shared/config/locales/ru.json
@@ -33,7 +33,6 @@
   "telegramLabel": "Telegram",
   "saveButtonText": "Сохранить",
   "rolesTitle": "Роли",
-  "userClaimsTitle": "Привилегии пользователя",
   "logoutButtonText": "Выйти",
   "unassignedLabel": "Не назначено",
   "facePrefix": "Лицо",

--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -143,7 +143,6 @@ export const phoneNumberLabel = 'Phone number';
 export const telegramLabel = 'Telegram';
 export const saveButtonText = 'Save';
 export const rolesTitle = 'Roles';
-export const userClaimsTitle = 'User Claims';
 export const logoutButtonText = 'Logout';
 
 // Photo list table headers

--- a/frontend/packages/shared/src/hooks/useCanSeeNsfw.ts
+++ b/frontend/packages/shared/src/hooks/useCanSeeNsfw.ts
@@ -1,11 +1,12 @@
-import { useAuthGetUserClaims } from '../api/photobank';
+import { useAuthGetUser } from '../api/photobank';
+
 export function useCanSeeNsfw(): boolean | null {
-  const { data, isLoading, isError } = useAuthGetUserClaims();
+  const { data: userResp, isLoading, isError } = useAuthGetUser();
   if (isLoading) return null;
   if (isError) return false;
-  const claims = data?.data ?? [];
+  const claims = (userResp?.data as any)?.claims ?? [];
   // поддержим несколько вариантов названий клейма
-  return claims.some(c => {
+  return claims.some((c: { type?: string | null; value?: string | null }) => {
     const t = (c.type ?? '').toLowerCase();
     const v = (c.value ?? '').toLowerCase();
     return (t.includes('nsfw') || t.includes('canseensfw')) && (v === 'true' || v === '1');

--- a/frontend/packages/shared/src/hooks/useIsAdmin.ts
+++ b/frontend/packages/shared/src/hooks/useIsAdmin.ts
@@ -1,4 +1,4 @@
-import * as AuthApi from '../api/photobank/auth/auth';
+import { useAuthGetUser } from '../api/photobank';
 
 const ADMIN_ROLE = 'Administrator';
 const ROLE_CLAIM_TYPES = [
@@ -7,12 +7,12 @@ const ROLE_CLAIM_TYPES = [
 ];
 
 export const useIsAdmin = (): boolean | null => {
-  const { data: claims, isLoading, isError } = AuthApi.useAuthGetUserClaims();
+  const { data: userResp, isLoading, isError } = useAuthGetUser();
   if (isLoading) return null;
   if (isError) return false;
-  return (
-    claims?.data.some(
-      (c) => ROLE_CLAIM_TYPES.includes(c.type ?? '') && c.value === ADMIN_ROLE,
-    ) ?? false
+  const claims = (userResp?.data as any)?.claims ?? [];
+  return claims.some(
+    (c: { type?: string | null; value?: string | null }) =>
+      ROLE_CLAIM_TYPES.includes(c.type ?? '') && c.value === ADMIN_ROLE,
   );
 };


### PR DESCRIPTION
## Summary
- drop deprecated `useAuthGetUserClaims` usage and related claim UI
- derive admin & NSFW permissions from user payload
- prune claim translation keys and constants

## Testing
- `pnpm --filter @photobank/shared test`
- `pnpm --filter @photobank/frontend test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6b6ecbc948328a4b4eafbfa3190bd