### PR TITLE
refactor: remove claims from admin users page

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/UsersPage.tsx
@@ -1,13 +1,9 @@
-import type { UserWithClaimsDto } from '@photobank/shared/api/photobank';
+import type { UserDto } from '@photobank/shared/api/photobank';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
-import {
-  useUsersGetAll,
-  useUsersUpdate,
-  useUsersSetClaims,
-} from '@photobank/shared/api/photobank';
+import { useUsersGetAll, useUsersUpdate } from '@photobank/shared/api/photobank';
 
 import { Button } from '@/shared/ui/button';
 import {
@@ -19,18 +15,15 @@ import {
   FormMessage,
 } from '@/shared/ui/form';
 import { Input } from '@/shared/ui/input';
-import { Textarea } from '@/shared/ui/textarea';
-
 const schema = z.object({
   phoneNumber: z.string().optional(),
   telegramUserId: z.string().optional(),
-  claims: z.string().optional(),
 });
 
 type FormData = z.infer<typeof schema>;
 
 interface UserEditorProps {
-  user: UserWithClaimsDto & { id: string };
+  user: UserDto & { id: string };
   onSave: (id: string, data: FormData) => Promise<void>;
 }
 
@@ -38,17 +31,13 @@ function UserEditor({ user, onSave }: UserEditorProps) {
   const { t } = useTranslation();
   const defaultValues = {
     phoneNumber: user.phoneNumber ?? '',
-    telegramUserId: user.telegramUserId
-      ? String(user.telegramUserId)
-      : '',
-    claims: user.claims?.map((c) => `${c.type}:${c.value}`).join('\n') ?? '',
+    telegramUserId: user.telegramUserId ? String(user.telegramUserId) : '',
   };
   const form = useForm<FormData>({ resolver: zodResolver(schema), defaultValues });
   return (
     <div className="border p-4 rounded space-y-2">
       <h2 className="font-semibold">{user.email}</h2>
       <Form {...form}>
-        { }
         <form
           onSubmit={(e) => {
             void form.handleSubmit((d) => onSave(user.id, d))(e);
@@ -81,20 +70,7 @@ function UserEditor({ user, onSave }: UserEditorProps) {
               </FormItem>
             )}
           />
-          <FormField
-            control={form.control}
-            name="claims"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Claims (type:value per line)</FormLabel>
-                <FormControl>
-                  <Textarea {...field} className="min-h-24" />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <Button type="submit">{t('saveUserButtonText')}</Button>
+          <Button type="submit">{t('saveButtonText')}</Button>
         </form>
       </Form>
     </div>
@@ -104,10 +80,9 @@ function UserEditor({ user, onSave }: UserEditorProps) {
 export default function UsersPage() {
   const { data: usersResp } = useUsersGetAll();
   const users = (usersResp?.data ?? []).filter(
-    (u): u is UserWithClaimsDto & { id: string } => Boolean(u.id),
+    (u): u is UserDto & { id: string } => Boolean(u.id),
   );
   const { mutateAsync: updateUser } = useUsersUpdate();
-  const { mutateAsync: setClaims } = useUsersSetClaims();
   const { t } = useTranslation();
 
   const handleSave = async (id: string, data: FormData) => {
@@ -120,21 +95,11 @@ export default function UsersPage() {
           : undefined,
       },
     });
-    const claims = (data.claims ?? '')
-      .split('\n')
-      .filter(Boolean)
-      .map((l) => {
-        const [type = '', value = ''] = l.split(':');
-        return { type: type.trim(), value: value.trim() };
-      });
-    if (claims.length) {
-      await setClaims({ id, data: claims });
-    }
   };
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-6">
-      <h1 className="text-2xl font-bold">{t('manageUsersTitle')}</h1>
+      <h1 className="text-2xl font-bold">{t('navbarUsersLabel')}</h1>
       {users.map((u) => (
         <UserEditor key={u.id} user={u} onSave={handleSave} />
       ))}

--- a/frontend/packages/frontend/src/shared/config/locales/en.json
+++ b/frontend/packages/frontend/src/shared/config/locales/en.json
@@ -89,8 +89,6 @@
   "racyContentLabel": "Racy Content",
   "thisDayLabel": "This Day",
   "botRunningText": "Bot is running",
-  "previewModalFallbackTitle": "Preview",
-  "manageUsersTitle": "Manage Users",
-  "saveUserButtonText": "Save User"
+  "previewModalFallbackTitle": "Preview"
 }
 

--- a/frontend/packages/frontend/src/shared/config/locales/ru.json
+++ b/frontend/packages/frontend/src/shared/config/locales/ru.json
@@ -89,8 +89,6 @@
   "racyContentLabel": "Откровенный контент",
   "thisDayLabel": "В этот день",
   "botRunningText": "Бот работает",
-  "previewModalFallbackTitle": "Предпросмотр",
-  "manageUsersTitle": "Управление пользователями",
-  "saveUserButtonText": "Сохранить пользователя"
+  "previewModalFallbackTitle": "Предпросмотр"
 }
 

--- a/frontend/packages/shared/src/constants.ts
+++ b/frontend/packages/shared/src/constants.ts
@@ -154,10 +154,6 @@ export const colStorageLabel = 'Storage';
 export const colFlagsLabel = 'Flags';
 export const colDetailsLabel = 'Details';
 
-// Admin pages
-export const manageUsersTitle = 'Manage Users';
-export const saveUserButtonText = 'Save User';
-
 // Service page
 export const serviceInfoTitle = 'Technical Information';
 


### PR DESCRIPTION
## Summary
- strip claim editing from admin users page
- drop unused translation keys and constants

## Testing
- `pnpm -F @photobank/shared build`
- `pnpm -F @photobank/shared test`
- `pnpm -F @photobank/frontend test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b6bb08c8ac8328beb43d5d1aff5056