### PR TITLE
feat: include user roles in JWT

### DIFF
--- a/backend/PhotoBank.Api/Controllers/AuthController.cs
+++ b/backend/PhotoBank.Api/Controllers/AuthController.cs
@@ -34,7 +34,10 @@ public class AuthController(
         if (user == null)
             return BadRequest();
 
+        var roles = await userManager.GetRolesAsync(user);
+        var roleClaims = roles.Select(r => new Claim(ClaimTypes.Role, r));
         var claims = await userManager.GetClaimsAsync(user);
+        claims = claims.Concat(roleClaims).ToList();
 
         var token = tokenService.CreateToken(user, request.RememberMe, claims);
         return Ok(new LoginResponseDto { Token = token });


### PR DESCRIPTION
## Summary
- include ASP.NET Identity roles in login claims to embed them in JWT tokens

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`
- `dotnet run` (verification console)

------
https://chatgpt.com/codex/tasks/task_e_68b6c36ea76c8328a9c8d58c61923b46