### PR TITLE
chore: add shared package path mapping

### DIFF
--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -11,6 +11,11 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@photobank/shared": ["packages/shared/src"],
+      "@photobank/shared/*": ["packages/shared/src/*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add @photobank/shared path alias to base frontend tsconfig

## Testing
- `pnpm tsc -p packages/shared/tsconfig.json`
- `pnpm tsc -p packages/telegram-bot/tsconfig.json` *(fails: Module '"@photobank/shared/api/photobank"' has no exported member 'authGetUserClaims')*

------
https://chatgpt.com/codex/tasks/task_e_68b6ee557638832880d7d90aa30eefb6