### PR TITLE
chore: configure path aliases for telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/tsconfig.json
+++ b/frontend/packages/telegram-bot/tsconfig.json
@@ -4,6 +4,8 @@
     "composite": true,
     "outDir": "dist",
     "rootDir": "src",
+    "baseUrl": "src",
+    "paths": { "@/*": ["*"] },
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "target": "ES2022",

--- a/frontend/packages/telegram-bot/vitest.config.ts
+++ b/frontend/packages/telegram-bot/vitest.config.ts
@@ -7,6 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      '@': resolve(__dirname, 'src'),
       '@photobank/shared': resolve(__dirname, '../shared/src'),
       '@photobank/shared/': resolve(__dirname, '../shared/src/'),
       '@photobank/shared/api/photobank/msw': resolve(


### PR DESCRIPTION
## Summary
- add `baseUrl` and `@` path alias to telegram bot TypeScript config
- map `@` alias to source in vitest resolve settings

## Testing
- `cd frontend/packages/telegram-bot && pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b711c59c248328940ff49f2330fb12