### PR TITLE
chore: remove string formatters from MVC setup

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
@@ -106,7 +107,11 @@ public static partial class ServiceCollectionExtensions
                 tags: new[] { "ready" },
                 failureStatus: HealthStatus.Unhealthy);
 
-        services.AddControllers()
+        services.AddControllers(options =>
+            {
+                options.OutputFormatters.RemoveType<StringOutputFormatter>();
+                options.InputFormatters.RemoveType<StringInputFormatter>();
+            })
             .AddJsonOptions(options =>
             {
                 options.JsonSerializerOptions.NumberHandling = JsonNumberHandling.Strict;


### PR DESCRIPTION
## Summary
- prevent MVC from accepting or returning plain text by removing `StringInputFormatter` and `StringOutputFormatter`

## Testing
- `dotnet restore PhotoBank.Backend.sln` *(fails: current .NET SDK does not support targeting .NET 9.0)*
- `dotnet build PhotoBank.Backend.sln` *(fails: current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test PhotoBank.Backend.sln` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b7259f9f1c8328b151c448d4c4c1f6