### PR TITLE
fix: remove obsolete string input formatter

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
@@ -110,7 +110,6 @@ public static partial class ServiceCollectionExtensions
         services.AddControllers(options =>
             {
                 options.OutputFormatters.RemoveType<StringOutputFormatter>();
-                options.InputFormatters.RemoveType<StringInputFormatter>();
             })
             .AddJsonOptions(options =>
             {


### PR DESCRIPTION
## Summary
- remove StringInputFormatter usage from API setup to fix build under .NET 9

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b72800edd08328b48d0c29f91bc65b