### PR TITLE
fix: type claims in shared auth hooks

### DIFF
--- a/frontend/packages/shared/src/hooks/useCanSeeNsfw.ts
+++ b/frontend/packages/shared/src/hooks/useCanSeeNsfw.ts
@@ -1,12 +1,13 @@
 import { useAuthGetUser } from '../api/photobank';
+import type { Claim, UserWithClaims } from '../types/claims';
 
 export function useCanSeeNsfw(): boolean | null {
   const { data: userResp, isLoading, isError } = useAuthGetUser();
   if (isLoading) return null;
   if (isError) return false;
-  const claims = (userResp?.data as any)?.claims ?? [];
+  const claims = (userResp?.data as UserWithClaims | undefined)?.claims ?? [];
   // поддержим несколько вариантов названий клейма
-  return claims.some((c: { type?: string | null; value?: string | null }) => {
+  return claims.some((c: Claim) => {
     const t = (c.type ?? '').toLowerCase();
     const v = (c.value ?? '').toLowerCase();
     return (t.includes('nsfw') || t.includes('canseensfw')) && (v === 'true' || v === '1');

--- a/frontend/packages/shared/src/hooks/useIsAdmin.ts
+++ b/frontend/packages/shared/src/hooks/useIsAdmin.ts
@@ -1,4 +1,5 @@
 import { useAuthGetUser } from '../api/photobank';
+import type { Claim, UserWithClaims } from '../types/claims';
 
 const ADMIN_ROLE = 'Administrator';
 const ROLE_CLAIM_TYPES = [
@@ -10,9 +11,9 @@ export const useIsAdmin = (): boolean | null => {
   const { data: userResp, isLoading, isError } = useAuthGetUser();
   if (isLoading) return null;
   if (isError) return false;
-  const claims = (userResp?.data as any)?.claims ?? [];
+  const claims = (userResp?.data as UserWithClaims | undefined)?.claims ?? [];
   return claims.some(
-    (c: { type?: string | null; value?: string | null }) =>
+    (c: Claim) =>
       ROLE_CLAIM_TYPES.includes(c.type ?? '') && c.value === ADMIN_ROLE,
   );
 };

--- a/frontend/packages/shared/src/types/claims.ts
+++ b/frontend/packages/shared/src/types/claims.ts
@@ -1,0 +1,10 @@
+import type { UserDto } from '../api/photobank';
+
+export interface Claim {
+  type?: string | null;
+  value?: string | null;
+}
+
+export type UserWithClaims = UserDto & {
+  claims?: Claim[];
+};


### PR DESCRIPTION
## Summary
- add Claim and UserWithClaims types
- use typed claims in `useCanSeeNsfw` and `useIsAdmin`

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b72c6294f88328874bcbbee70e0acd