### PR TITLE
fix(frontend): add dispatch dependency to photo row rendering

### DIFF
--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -157,7 +157,7 @@ const PhotoListPage = () => {
           </div>
         );
       },
-      [handleOpenDetails, photos, viewerItems]
+      [dispatch, handleOpenDetails, photos, viewerItems]
     );
 
   const renderSkeletonRow = useCallback(

--- a/frontend/packages/frontend/src/pages/list/columns.tsx
+++ b/frontend/packages/frontend/src/pages/list/columns.tsx
@@ -1,11 +1,11 @@
 import type { PhotoItemDto } from '@photobank/shared/api/photobank';
 import { formatDate } from '@photobank/shared/format';
 
-import RowActions from './RowActions';
-import PreviewCell from './PreviewCell';
-
 import i18n from '@/shared/config/i18n';
 import FlagIcon from '@/components/formatters/FlagIcon';
+
+import RowActions from './RowActions';
+import PreviewCell from './PreviewCell';
 
 
 export interface Column<T> {


### PR DESCRIPTION
## Summary
- include dispatch in renderPhotoRow useCallback dependencies
- reorder list column imports for lint compliance

## Testing
- `pnpm lint packages/frontend` *(fails: @photobank/shared lint: eslint "src/**/*.ts" packages/frontend)*
- `pnpm --filter ./packages/frontend lint`


------
https://chatgpt.com/codex/tasks/task_e_68b72fcfa15c8328841f5c164ebb20d9