### PR TITLE
fix: include dispatch in renderPhotoRow callback

### DIFF
--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -157,7 +157,7 @@ const PhotoListPage = () => {
           </div>
         );
       },
-      [handleOpenDetails, photos, viewerItems]
+      [dispatch, handleOpenDetails, photos, viewerItems]
     );
 
   const renderSkeletonRow = useCallback(


### PR DESCRIPTION
## Summary
- add missing `dispatch` dependency to `renderPhotoRow`

## Testing
- `pnpm lint packages/frontend` *(fails: @photobank/shared lint script receives unexpected argument)*
- `pnpm --filter frontend lint`


------
https://chatgpt.com/codex/tasks/task_e_68b731564da083289d24c5f32148c110