### PR TITLE
fix: wire scroll viewport refs for virtual list

### DIFF
--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -50,6 +50,7 @@ const PhotoListPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const scrollAreaRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   const [detailsId, setDetailsId] = useState<number | null>(null);
@@ -222,7 +223,11 @@ const PhotoListPage = () => {
         </Button>
       </div>
 
-      <ScrollArea className="h-[calc(100vh-240px)]" ref={scrollAreaRef}>
+      <ScrollArea
+        className="h-[calc(100vh-240px)]"
+        ref={scrollAreaRef}
+        viewportRef={viewportRef}
+      >
         <div className="p-6">
           {/* Desktop/Tablet View */}
           <div className="hidden lg:block">
@@ -236,7 +241,7 @@ const PhotoListPage = () => {
             {loading ? (
               <VirtualPhotoList
                 photos={skeletonPhotos}
-                parentRef={scrollAreaRef}
+                parentRef={viewportRef}
                 renderRow={renderSkeletonRow}
               />
             ) : photos.length === 0 ? (
@@ -244,7 +249,7 @@ const PhotoListPage = () => {
             ) : (
               <VirtualPhotoList
                 photos={photos}
-                parentRef={scrollAreaRef}
+                parentRef={viewportRef}
                 renderRow={renderPhotoRow}
               />
             )}

--- a/frontend/packages/frontend/src/pages/list/VirtualPhotoList.test.tsx
+++ b/frontend/packages/frontend/src/pages/list/VirtualPhotoList.test.tsx
@@ -37,7 +37,7 @@ test('renders only a subset of items', async () => {
   const photos = createPhotos(50);
 
   (usePhotoVirtual as unknown as Mock).mockReturnValue({
-    virtualizer: { measureElement: vi.fn() },
+    virtualizer: { measureElement: vi.fn(), measure: vi.fn() },
     items: makeItems(Math.min(photos.length, 10)) as any,
     totalSize: 112 * Math.min(photos.length, 10),
   });

--- a/frontend/packages/frontend/src/pages/list/VirtualPhotoList.tsx
+++ b/frontend/packages/frontend/src/pages/list/VirtualPhotoList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import type { PhotoItemDto } from '@photobank/shared/api/photobank';
 
 import PhotoListItemDesktop from './PhotoListItemDesktop';
@@ -28,9 +28,13 @@ const VirtualPhotoList = ({
 }: VirtualPhotoListProps) => {
   const { items, totalSize, virtualizer } = usePhotoVirtual({
     count: photos.length,
-    parentRef,
+    viewportRef: parentRef,
     estimateSize,
   });
+
+  useLayoutEffect(() => {
+    virtualizer.measure();
+  }, [photos.length, virtualizer]);
 
   const row = renderRow ?? defaultRenderRow;
 

--- a/frontend/packages/frontend/src/pages/list/usePhotoVirtual.ts
+++ b/frontend/packages/frontend/src/pages/list/usePhotoVirtual.ts
@@ -3,25 +3,18 @@ import { RefObject } from 'react';
 
 interface UsePhotoVirtualProps {
   count: number;
-  parentRef: RefObject<HTMLElement | null>;
+  viewportRef: RefObject<HTMLElement | null>;
   estimateSize?: (index: number) => number;
 }
 
 export const usePhotoVirtual = ({
   count,
-  parentRef,
+  viewportRef,
   estimateSize,
 }: UsePhotoVirtualProps) => {
   const virtualizer = useVirtualizer({
     count,
-    getScrollElement: () => {
-      const parent = parentRef.current;
-      if (!parent) return null;
-      const viewport = parent.querySelector<HTMLElement>(
-        '[data-slot="scroll-area-viewport"]'
-      );
-      return viewport ?? (parent);
-    },
+    getScrollElement: () => viewportRef.current,
     estimateSize: estimateSize ?? (() => 112),
     overscan: 8,
   });

--- a/frontend/packages/frontend/src/shared/ui/scroll-area.tsx
+++ b/frontend/packages/frontend/src/shared/ui/scroll-area.tsx
@@ -5,8 +5,12 @@ import { cn } from "@/shared/lib/utils"
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => {
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
+    viewportRef?: React.Ref<
+      React.ElementRef<typeof ScrollAreaPrimitive.Viewport>
+    >;
+  }
+>(({ className, children, viewportRef, ...props }, ref) => {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -15,6 +19,7 @@ const ScrollArea = React.forwardRef<
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >


### PR DESCRIPTION
## Summary
- replace DOM query with explicit viewport ref in virtual photo list
- forward optional viewportRef through ScrollArea and PhotoListPage
- remeasure virtualizer when photo count changes

## Testing
- `corepack pnpm lint`
- `corepack pnpm test` *(fails: Unable to find element /p_1/i; Failed to parse URL from /api/access/profile)*

------
https://chatgpt.com/codex/tasks/task_e_68b83d21a72c8328b6a0888e8c666a5c