### PR TITLE
feat(frontend): expose row index in VirtualPhotoList

### DIFF
--- a/frontend/packages/frontend/src/pages/list/VirtualPhotoList.test.tsx
+++ b/frontend/packages/frontend/src/pages/list/VirtualPhotoList.test.tsx
@@ -57,5 +57,11 @@ test('renders only a subset of items', async () => {
   if (photos?.length) {
     expect(rows.length).toBeLessThanOrEqual(photos.length);
   }
+
+  rows.forEach((row, i) => {
+    const parent = row.parentElement;
+    expect(parent).not.toBeNull();
+    expect(parent?.getAttribute('data-index')).toBe(String(i));
+  });
 });
 

--- a/frontend/packages/frontend/src/pages/list/VirtualPhotoList.tsx
+++ b/frontend/packages/frontend/src/pages/list/VirtualPhotoList.tsx
@@ -49,6 +49,7 @@ const VirtualPhotoList = ({
           <div
             key={photo.id}
             ref={virtualizer.measureElement}
+            data-index={item.index}
             style={{
               position: 'absolute',
               top: 0,


### PR DESCRIPTION
## Summary
- track item positions with `data-index` on virtual list rows
- test that each rendered row exposes its index

## Testing
- `pnpm -w test frontend` *(fails: No test files found)*
- `pnpm --filter @photobank/frontend test --run src/pages/list/VirtualPhotoList.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b85d5147c88328817736d7a4f0e492