### PR TITLE
fix: ensure unique keys for metadata badges

### DIFF
--- a/frontend/packages/frontend/src/components/MetadataBadgeList.tsx
+++ b/frontend/packages/frontend/src/components/MetadataBadgeList.tsx
@@ -22,8 +22,8 @@ const MetadataBadgeList = ({
   return (
     <div className="flex items-center gap-1 flex-wrap">
       <Icon className="w-3 h-3 text-muted-foreground" />
-      {items.slice(0, maxVisible).map((id) => (
-        <Badge key={id} variant={variant} className="text-xs">
+      {items.slice(0, maxVisible).map((id, index) => (
+        <Badge key={`${id}-${index}`} variant={variant} className="text-xs">
           {map[id] ?? id}
         </Badge>
       ))}


### PR DESCRIPTION
## Summary
- avoid duplicate React keys in MetadataBadgeList

## Testing
- `pnpm test --run src/components/MetadataBadgeList.test.tsx`
- `pnpm test` *(fails: TestingLibraryElementError /api/access/profile)*

------
https://chatgpt.com/codex/tasks/task_e_68b85d3bd0088328a9244a9a10f5bce9