### PR TITLE
feat(frontend): add hidden title to PhotoDetailsModal

### DIFF
--- a/frontend/packages/frontend/src/components/PhotoDetailsModal.tsx
+++ b/frontend/packages/frontend/src/components/PhotoDetailsModal.tsx
@@ -1,5 +1,6 @@
 import PhotoDetailsPage from '@/pages/detail/PhotoDetailsPage';
-import { Dialog, DialogContent } from '@/shared/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 interface PhotoDetailsModalProps {
     photoId: number | null;
@@ -13,6 +14,11 @@ const PhotoDetailsModal = ({ photoId, onOpenChange }: PhotoDetailsModalProps) =>
                 className="!max-w-none sm:!max-w-none w-screen h-screen top-0 left-0 translate-x-0 translate-y-0 p-0"
                 showCloseButton={true}
             >
+                <DialogHeader>
+                    <VisuallyHidden>
+                        <DialogTitle>Photo details</DialogTitle>
+                    </VisuallyHidden>
+                </DialogHeader>
                 {photoId !== null && <PhotoDetailsPage photoId={photoId} />}
             </DialogContent>
         </Dialog>


### PR DESCRIPTION
## Summary
- add visually hidden dialog title to PhotoDetailsModal for accessibility

## Testing
- `pnpm test` *(fails: Unable to find an element with the text /p_1/i; unhandled fetch to /api/access/profile)*

------
https://chatgpt.com/codex/tasks/task_e_68b85f1caa90832895ab51c8598dc830