### PR TITLE
chore: reorder imports in PhotoDetailsModal

### DIFF
--- a/frontend/packages/frontend/src/components/PhotoDetailsModal.tsx
+++ b/frontend/packages/frontend/src/components/PhotoDetailsModal.tsx
@@ -1,6 +1,7 @@
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+
 import PhotoDetailsPage from '@/pages/detail/PhotoDetailsPage';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
-import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 interface PhotoDetailsModalProps {
     photoId: number | null;


### PR DESCRIPTION
## Summary
- reorder imports in `PhotoDetailsModal` so external Radix import precedes local modules

## Testing
- `pnpm lint`
- `pnpm test:ci` *(fails: Photos access policy test)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b56ff4308328a35d70841213de32