### PR TITLE
refactor: unwrap photo service responses

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -37,12 +37,11 @@ export async function sendPhotosPage({
   const skip = (page - 1) * PHOTOS_PAGE_SIZE;
   let queryResult;
   try {
-    const res = await searchPhotos(ctx, {
+    queryResult = await searchPhotos(ctx, {
       ...filter,
       top: PHOTOS_PAGE_SIZE,
       skip,
     });
-    queryResult = res.data;
   } catch (err) {
     await handleCommandError(ctx, err);
     return;

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -46,7 +46,7 @@ bot.on('inline_query', async (ctx: MyContext) => {
       takenDate?: string | null;
       tags?: { tagId: number }[];
     };
-    const data = resp.data as { photos?: Photo[]; items?: Photo[] };
+    const data = resp as { photos?: Photo[]; items?: Photo[] };
     const items = data.photos ?? data.items ?? [];
 
     const results: InlineQueryResult[] = items.map(

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -24,8 +24,8 @@ export async function deletePhotoMessage(ctx: MyContext) {
 
 async function fetchPhoto(ctx: MyContext, id: number): Promise<PhotoDto | null> {
     try {
-        const { data } = await getPhoto(ctx, id);
-        return data;
+        const photo = await getPhoto(ctx, id);
+        return photo;
     } catch {
         return null;
     }
@@ -35,8 +35,7 @@ export async function sendPhotoById(ctx: MyContext, id: number) {
     let photo: PhotoDto;
 
     try {
-        const res = await getPhoto(ctx, id);
-        photo = res.data;
+        photo = await getPhoto(ctx, id);
     } catch {
         await ctx.reply(ctx.t('photo-not-found'));
         return;

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -13,7 +13,8 @@ export async function searchPhotos(
 ) {
   try {
     setRequestContext(ctx);
-    return await photosSearchPhotos(filter as FilterDto);
+    const res = await photosSearchPhotos(filter as FilterDto);
+    return res.data;
   } catch (err) {
     handleServiceError(err);
     throw err;
@@ -23,7 +24,8 @@ export async function searchPhotos(
 export async function getPhoto(ctx: Context, id: number) {
   try {
     setRequestContext(ctx);
-    return await photosGetPhoto(id);
+    const res = await photosGetPhoto(id);
+    return res.data;
   } catch (err) {
     handleServiceError(err);
     throw err;

--- a/frontend/packages/telegram-bot/test/aiCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/aiCommand.test.ts
@@ -42,7 +42,7 @@ describe('aiCommand', () => {
     vi.spyOn(utils, 'getFilterHash').mockReturnValue('hash');
     const searchSpy = vi
       .spyOn(photoService, 'searchPhotos')
-      .mockResolvedValue({ data: { count: 0, photos: [] } } as any);
+      .mockResolvedValue({ count: 0, photos: [] } as any);
     aiFilters.clear();
 
     await aiCommand(ctx);
@@ -91,7 +91,8 @@ describe('aiCommand', () => {
       });
     vi.spyOn(utils, 'getFilterHash').mockResolvedValue('hash');
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
-      data: { count: 0, photos: [] },
+      count: 0,
+      photos: [],
     } as any);
     aiFilters.clear();
 

--- a/frontend/packages/telegram-bot/test/aiPage.test.ts
+++ b/frontend/packages/telegram-bot/test/aiPage.test.ts
@@ -34,7 +34,8 @@ describe('sendAiPage', () => {
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
-      data: { count: 1, photos: [basePhoto] },
+      count: 1,
+      photos: [basePhoto],
     } as any);
 
     await sendAiPage(ctx, 'hash', 2, true);
@@ -53,7 +54,8 @@ describe('sendAiPage', () => {
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
-      data: { count: 1, photos: [basePhoto] },
+      count: 1,
+      photos: [basePhoto],
     } as any);
 
     await sendAiPage(ctx, 'hash', 1, true);

--- a/frontend/packages/telegram-bot/test/photoInline.test.ts
+++ b/frontend/packages/telegram-bot/test/photoInline.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 });
 
 it('sends new message and stores id', async () => {
-  vi.spyOn(photoService, 'getPhoto').mockResolvedValue({ data: basePhoto } as any);
+  vi.spyOn(photoService, 'getPhoto').mockResolvedValue(basePhoto as any);
   const ctx = {
     chat: { id: 1 },
     replyWithPhoto: vi.fn().mockResolvedValue({ message_id: 42 }),
@@ -37,7 +37,7 @@ it('sends new message and stores id', async () => {
 });
 
 it('edits existing message when available', async () => {
-  vi.spyOn(photoService, 'getPhoto').mockResolvedValue({ data: basePhoto } as any);
+  vi.spyOn(photoService, 'getPhoto').mockResolvedValue(basePhoto as any);
   photoMessages.set(1, 42);
   const ctx = {
     chat: { id: 1 },
@@ -54,7 +54,7 @@ it('edits existing message when available', async () => {
 });
 
 it('adds navigation buttons from current page list', async () => {
-  vi.spyOn(photoService, 'getPhoto').mockResolvedValue({ data: basePhoto } as any);
+  vi.spyOn(photoService, 'getPhoto').mockResolvedValue(basePhoto as any);
   const ctx = {
     chat: { id: 1 },
     replyWithPhoto: vi.fn().mockResolvedValue({ message_id: 1 }),

--- a/frontend/packages/telegram-bot/test/searchCommand.test.ts
+++ b/frontend/packages/telegram-bot/test/searchCommand.test.ts
@@ -36,7 +36,7 @@ describe('handleSearch', () => {
     } as any;
     const searchSpy = vi
       .spyOn(photoService, 'searchPhotos')
-      .mockResolvedValue({ data: { count: 0, photos: [] } } as any);
+      .mockResolvedValue({ count: 0, photos: [] } as any);
 
     await searchCommands.handleSearch(ctx);
 

--- a/frontend/packages/telegram-bot/test/searchPage.test.ts
+++ b/frontend/packages/telegram-bot/test/searchPage.test.ts
@@ -32,7 +32,8 @@ describe('sendSearchPage', () => {
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
-      data: { count: 1, photos: [basePhoto] },
+      count: 1,
+      photos: [basePhoto],
     } as any);
 
     await sendSearchPage(ctx, 'cats', 2, true);
@@ -50,7 +51,8 @@ describe('sendSearchPage', () => {
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
-      data: { count: 1, photos: [basePhoto] },
+      count: 1,
+      photos: [basePhoto],
     } as any);
 
     await sendSearchPage(ctx, 'cats', 1, true);
@@ -62,7 +64,8 @@ describe('sendSearchPage', () => {
     const ctx = { reply: vi.fn(), t: (k: string, p?: any) => i18n.t('en', k, p) } as any;
     const photos = Array.from({ length: 10 }, (_, i) => ({ ...basePhoto, id: i + 1 }));
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
-      data: { count: 30, photos },
+      count: 30,
+      photos,
     } as any);
 
     await sendSearchPage(ctx, 'cats', 2, false);

--- a/frontend/packages/telegram-bot/test/thisdayPage.test.ts
+++ b/frontend/packages/telegram-bot/test/thisdayPage.test.ts
@@ -32,7 +32,8 @@ describe('sendThisDayPage', () => {
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
-      data: { count: 1, photos: [basePhoto] },
+      count: 1,
+      photos: [basePhoto],
     } as any);
 
     await sendThisDayPage(ctx, 2, true);
@@ -50,7 +51,8 @@ describe('sendThisDayPage', () => {
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
-      data: { count: 1, photos: [basePhoto] },
+      count: 1,
+      photos: [basePhoto],
     } as any);
 
     await sendThisDayPage(ctx, 1, true);


### PR DESCRIPTION
## Summary
- return payloads directly from photo service helpers
- adjust commands and inline handler to consume payloads without `data`
- update photo utilities and tests for simplified API results

## Testing
- `pnpm --filter telegram-bot exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b9c022ec588328b274679a2d39570f