### PR TITLE
refactor: type dictionary maps

### DIFF
--- a/frontend/packages/telegram-bot/src/dictionaries.ts
+++ b/frontend/packages/telegram-bot/src/dictionaries.ts
@@ -36,25 +36,25 @@ function getDict(): DictData {
   const existing = cache.get(currentUser);
   if (existing) return existing;
   return {
-    tagMap: new Map(),
-    personMap: new Map(),
+    tagMap: new Map<number, string>(),
+    personMap: new Map<number, string>(),
     tagList: [],
     personList: [],
     storageList: [],
-    storageMap: new Map(),
-    pathsMap: new Map(),
+    storageMap: new Map<number, string>(),
+    pathsMap: new Map<number, string[]>(),
   };
 }
 
 export async function loadDictionaries(ctx: MyContext) {
   if (cache.has(currentUser)) return;
-  const { data: tagList } = await fetchTags(ctx);
-  const tagMap = new Map(tagList.map(tag => [tag.id, tag.name]));
-  const { data: personList } = await fetchPersons(ctx);
-  const personMap = new Map(personList.map(p => [p.id, p.name]));
-  const { data: storageList } = await fetchStorages(ctx);
-  const storageMap = new Map(storageList.map((s) => [s.id, s.name]));
-  const { data: pathList } = await fetchPaths(ctx);
+  const tagList = await fetchTags(ctx);
+  const tagMap = new Map<number, string>(tagList.map((t) => [t.id, t.name]));
+  const personList = await fetchPersons(ctx);
+  const personMap = new Map<number, string>(personList.map((p) => [p.id, p.name]));
+  const storageList = await fetchStorages(ctx);
+  const storageMap = new Map<number, string>(storageList.map((s) => [s.id, s.name]));
+  const pathList = await fetchPaths(ctx);
   const pathsMap = new Map<number, string[]>();
   for (const p of pathList) {
     const arr = pathsMap.get(p.storageId) ?? [];

--- a/frontend/packages/telegram-bot/test/dictionaries.test.ts
+++ b/frontend/packages/telegram-bot/test/dictionaries.test.ts
@@ -7,10 +7,10 @@ describe('dictionaries', () => {
   });
 
   it('getPersonName returns loaded name', async () => {
-    const getAllPersons = vi.fn().mockResolvedValue({ data: [{ id: 1, name: 'John' }] });
-    const getAllTags = vi.fn().mockResolvedValue({ data: [] });
-    const getAllStorages = vi.fn().mockResolvedValue({ data: [] });
-    const getAllPaths = vi.fn().mockResolvedValue({ data: [] });
+    const getAllPersons = vi.fn().mockResolvedValue([{ id: 1, name: 'John' }]);
+    const getAllTags = vi.fn().mockResolvedValue([]);
+    const getAllStorages = vi.fn().mockResolvedValue([]);
+    const getAllPaths = vi.fn().mockResolvedValue([]);
     vi.doMock('../src/services/dictionary', () => ({
       fetchPersons: getAllPersons,
       fetchTags: getAllTags,
@@ -39,20 +39,16 @@ describe('dictionaries', () => {
   });
 
   it('findBestPersonId and findBestTagId return closest match', async () => {
-    const getAllPersons = vi.fn().mockResolvedValue({
-      data: [
-        { id: 1, name: 'Alice' },
-        { id: 2, name: 'Bob' },
-      ],
-    });
-    const getAllTags = vi.fn().mockResolvedValue({
-      data: [
-        { id: 10, name: 'portrait' },
-        { id: 11, name: 'sea' },
-      ],
-    });
-    const getAllStorages = vi.fn().mockResolvedValue({ data: [] });
-    const getAllPaths = vi.fn().mockResolvedValue({ data: [] });
+    const getAllPersons = vi.fn().mockResolvedValue([
+      { id: 1, name: 'Alice' },
+      { id: 2, name: 'Bob' },
+    ]);
+    const getAllTags = vi.fn().mockResolvedValue([
+      { id: 10, name: 'portrait' },
+      { id: 11, name: 'sea' },
+    ]);
+    const getAllStorages = vi.fn().mockResolvedValue([]);
+    const getAllPaths = vi.fn().mockResolvedValue([]);
     vi.doMock('../src/services/dictionary', () => ({
       fetchPersons: getAllPersons,
       fetchTags: getAllTags,
@@ -66,16 +62,14 @@ describe('dictionaries', () => {
   });
 
   it('getAllStoragesWithPaths returns loaded data', async () => {
-    const getAllStorages = vi.fn().mockResolvedValue({ data: [{ id: 1, name: 'S1' }] });
-    const getAllPaths = vi.fn().mockResolvedValue({
-      data: [
-        { storageId: 1, path: '/a' },
-        { storageId: 1, path: '/b' },
-      ],
-    });
+    const getAllStorages = vi.fn().mockResolvedValue([{ id: 1, name: 'S1' }]);
+    const getAllPaths = vi.fn().mockResolvedValue([
+      { storageId: 1, path: '/a' },
+      { storageId: 1, path: '/b' },
+    ]);
     vi.doMock('../src/services/dictionary', () => ({
-      fetchPersons: vi.fn().mockResolvedValue({ data: [] }),
-      fetchTags: vi.fn().mockResolvedValue({ data: [] }),
+      fetchPersons: vi.fn().mockResolvedValue([]),
+      fetchTags: vi.fn().mockResolvedValue([]),
       fetchStorages: getAllStorages,
       fetchPaths: getAllPaths,
     }));


### PR DESCRIPTION
## Summary
- fetch dictionary data directly and type maps for tags, persons, and storages
- adjust dictionary tests for new fetcher return types

## Testing
- `pnpm lint`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_68b9c6f683b08328938fc22e9346926d