### PR TITLE
fix: return photo DTOs directly

### DIFF
--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -1,7 +1,11 @@
 import type { Context } from 'grammy';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 
-import { getPhotos } from '../api/photobank/photos/photos';
+import {
+  getPhotos,
+  type PhotosGetPhotoResult,
+  type PhotosSearchPhotosResult,
+} from '../api/photobank/photos/photos';
 import { setRequestContext } from '../api/axios-instance';
 import { handleServiceError } from '../errorHandler';
 
@@ -10,22 +14,23 @@ const { photosSearchPhotos, photosGetPhoto, photosUpload } = getPhotos();
 export async function searchPhotos(
   ctx: Context,
   filter: FilterDto & { top?: number; skip?: number },
-) {
+): Promise<PhotosSearchPhotosResult> {
   try {
     setRequestContext(ctx);
-    const res = await photosSearchPhotos(filter as FilterDto);
-    return res.data;
+    return await photosSearchPhotos(filter as FilterDto);
   } catch (err) {
     handleServiceError(err);
     throw err;
   }
 }
 
-export async function getPhoto(ctx: Context, id: number) {
+export async function getPhoto(
+  ctx: Context,
+  id: number,
+): Promise<PhotosGetPhotoResult> {
   try {
     setRequestContext(ctx);
-    const res = await photosGetPhoto(id);
-    return res.data;
+    return await photosGetPhoto(id);
   } catch (err) {
     handleServiceError(err);
     throw err;


### PR DESCRIPTION
## Summary
- return typed photo DTOs from `searchPhotos` and `getPhoto`
- type service methods using generated API DTOs

## Testing
- `pnpm --filter @photobank/telegram-bot build`
- `pnpm --filter @photobank/telegram-bot test --run`


------
https://chatgpt.com/codex/tasks/task_e_68b9d4c2a6bc832880d38067e4fa918c