### PR TITLE
fix: add visually hidden dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,9 @@
   "author": "",
   "license": "ISC",
   "packageManager": "pnpm@10.14.0",
+  "dependencies": {
+    "@radix-ui/react-visually-hidden": "^1.0.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.34.0",
     "@faker-js/faker": "^10.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@radix-ui/react-visually-hidden':
+        specifier: ^1.0.0
+        version: 1.2.3(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     devDependencies:
       '@eslint/js':
         specifier: ^9.34.0


### PR DESCRIPTION
## Summary
- add `@radix-ui/react-visually-hidden` to frontend workspace dependencies

## Testing
- `pnpm --dir frontend -w install`
- `pnpm --dir frontend -w build` *(fails: Type 'AbortSignal' has no properties in common with type 'RequestInit')*

------
https://chatgpt.com/codex/tasks/task_e_68b9ddaaf8908328b5b0797275f6f41f