### PR TITLE
chore(telegram-bot): build with config and prestart

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "build": "rimraf dist && tsc -p tsconfig.json && cpy \"src/locales/**/*\" dist/locales",
+    "build": "rimraf dist && tsc -p tsconfig.build.json && cpy \"src/locales/**/*\" dist/locales",
+    "prestart": "pnpm run build",
     "start": "node --experimental-specifier-resolution=node dist/index.js",
     "test": "vitest",
     "test:ui": "vitest --ui",


### PR DESCRIPTION
## Summary
- build telegram bot using dedicated tsconfig
- ensure starting the bot triggers a build

## Testing
- `pnpm test` *(fails: Cannot find module '@/types/problem')*
- `pnpm start` *(fails: TS2835 Relative import paths need explicit file extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1c01d5dc83289956978759bf7a08