### PR TITLE
fix: build shared before telegram-bot

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "build": "rimraf dist && tsc -p tsconfig.build.json && cpy \"src/locales/**/*\" dist/locales",
+    "build": "pnpm --filter @photobank/shared build && rimraf dist && tsc -b tsconfig.build.json && cpy \"src/locales/**/*\" dist/locales",
     "prestart": "pnpm run build",
     "start": "node --experimental-specifier-resolution=node dist/index.js",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- build shared package before telegram-bot

## Testing
- `pnpm --filter @photobank/telegram-bot build` *(fails: Module '@photobank/shared/api/photobank' has no exported member 'configureApi')*
- `pnpm --filter @photobank/telegram-bot test` *(fails: Cannot find module '@/types/problem')*

------
https://chatgpt.com/codex/tasks/task_e_68bb1e886b308328addfcb5faf1ed921