### PR TITLE
feat(shared): expose photobank API schemas

### DIFF
--- a/frontend/packages/shared/src/api/photobank/index.ts
+++ b/frontend/packages/shared/src/api/photobank/index.ts
@@ -6,5 +6,6 @@ export * from './photos/photos';
 export * from './storages/storages';
 export * from './tags/tags';
 export * from './users/users';
+export * from './photoBankApiVersion1000CultureNeutralPublicKeyTokenNull.schemas';
 export * from './model';
 export * from './fetcher';


### PR DESCRIPTION
## Summary
- re-export generated PhotoBank schema types from `@photobank/shared`

## Testing
- `pnpm --filter @photobank/shared build`
- `pnpm --filter @photobank/shared test` *(fails: expected '02.01.2024', received '1/2/2024')*
- `pnpm --filter @photobank/telegram-bot test --run`


------
https://chatgpt.com/codex/tasks/task_e_68bb253e6f0c8328bc22109ec8dea56b