### PR TITLE
chore: use bundler module resolution for telegram bot build

### DIFF
--- a/frontend/packages/telegram-bot/tsconfig.build.json
+++ b/frontend/packages/telegram-bot/tsconfig.build.json
@@ -7,8 +7,8 @@
     "emitDeclarationOnly": false,
     "declaration": true,
     "sourceMap": true,
-    "moduleResolution": "node16",
-    "module": "node16",
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
     "target": "ES2022",
     "composite": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo"


### PR DESCRIPTION
## Summary
- use Bundler module resolution for Telegram bot build

## Testing
- `cd frontend/packages/telegram-bot && pnpm run build`
- `cd frontend/packages/telegram-bot && pnpm test` *(fails: runs in watch mode and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68bb27f05da083289ad6ad72f2499f64