### PR TITLE
test: enable shared path aliases in vitest

### DIFF
--- a/frontend/packages/telegram-bot/tsconfig.json
+++ b/frontend/packages/telegram-bot/tsconfig.json
@@ -5,7 +5,10 @@
     "outDir": "dist",
     "rootDir": "src",
     "baseUrl": "src",
-    "paths": { "@/*": ["*"] },
+    "paths": {
+      "@/*": ["*"],
+      "@photobank/shared/*": ["../shared/src/*"]
+    },
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "target": "ES2022",

--- a/frontend/packages/telegram-bot/vitest.config.ts
+++ b/frontend/packages/telegram-bot/vitest.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, 'src'),
       '@photobank/shared': resolve(__dirname, '../shared/src'),
-      '@photobank/shared/': resolve(__dirname, '../shared/src/'),
       '@photobank/shared/api/photobank/msw': resolve(
         __dirname,
         '../shared/src/api/photobank/msw.ts',


### PR DESCRIPTION
## Summary
- ensure vitest resolves shared package paths
- map @photobank/shared/* types to shared sources

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68bb2934d05483289c7a699eedda352d