### PR TITLE
feat(api): expose and log version

### DIFF
--- a/backend/Directory.Build.props
+++ b/backend/Directory.Build.props
@@ -3,4 +3,8 @@
     <Nullable>enable</Nullable>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)coverlet.runsettings</RunSettingsFilePath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/backend/PhotoBank.Api/Controllers/VersionController.cs
+++ b/backend/PhotoBank.Api/Controllers/VersionController.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PhotoBank.Api.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class VersionController : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public ActionResult<string> Get()
+    {
+        var version = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+        return Ok(version);
+    }
+}

--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Serilog;
 using HealthChecks.UI.Client;
 using PhotoBank.Api.Swagger;
+using System.Reflection;
 
 namespace PhotoBank.Api
 {
@@ -13,7 +14,10 @@ namespace PhotoBank.Api
     {
         public static void Main(string[] args)
         {
-            Console.WriteLine("Start App!");
+            var version = Assembly.GetExecutingAssembly()
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString();
+            Console.WriteLine($"Start App! Version: {version}");
 
             var builder = WebApplication.CreateBuilder(args);
 

--- a/backend/version.json
+++ b/backend/version.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$",
+    "^refs/tags/v\\d+\\.\\d+$"
+  ]
+}


### PR DESCRIPTION
## Summary
- derive assembly version from git with Nerdbank.GitVersioning
- log application version at startup
- expose version via endpoint

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln` *(skipped: XPlat Code Coverage collector missing; all tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bc142732a48328b0cb0572568b6c4a