### PR TITLE
fix(telegram-bot): compile dictionaries and explicit imports

### DIFF
--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -1,32 +1,32 @@
 import { configureAzureOpenAI } from "@photobank/shared/ai/openai";
 
-import { loadDictionaries, setDictionariesUser } from "./dictionaries";
+import { loadDictionaries, setDictionariesUser } from "./dictionaries.js";
 import {
   AZURE_OPENAI_ENDPOINT,
   AZURE_OPENAI_KEY,
   AZURE_OPENAI_DEPLOYMENT,
   AZURE_OPENAI_API_VERSION,
-} from "./config";
-import { bot } from './bot';
-import { sendThisDayPage, thisDayCommand } from "./commands/thisday";
-import { captionCache } from "./photo";
-import { sendSearchPage, searchCommand, decodeSearchCallback } from "./commands/search";
-import { aiCommand, sendAiPage } from "./commands/ai";
-import { helpCommand } from "./commands/help";
-import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
-import { tagsCommand, sendTagsPage } from "./commands/tags";
-import { personsCommand, sendPersonsPage } from "./commands/persons";
-import { storagesCommand, sendStoragesPage } from "./commands/storages";
-import { tagsCallbackPattern, personsCallbackPattern, storagesCallbackPattern } from "./patterns";
-import { registerPhotoRoutes } from "./commands/photoRouter";
-import { profileCommand } from "./commands/profile";
-import { uploadCommand } from "./commands/upload";
-import { withRegistered } from './registration';
-import { logger } from './logger';
-import { handleBotError } from './errorHandler';
-import './handlers/inline';
-import './handlers/deeplink';
-import { i18n } from './i18n';
+} from "./config.js";
+import { bot } from './bot.js';
+import { sendThisDayPage, thisDayCommand } from "./commands/thisday.js";
+import { captionCache } from "./photo.js";
+import { sendSearchPage, searchCommand, decodeSearchCallback } from "./commands/search.js";
+import { aiCommand, sendAiPage } from "./commands/ai.js";
+import { helpCommand } from "./commands/help.js";
+import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe.js";
+import { tagsCommand, sendTagsPage } from "./commands/tags.js";
+import { personsCommand, sendPersonsPage } from "./commands/persons.js";
+import { storagesCommand, sendStoragesPage } from "./commands/storages.js";
+import { tagsCallbackPattern, personsCallbackPattern, storagesCallbackPattern } from "./patterns.js";
+import { registerPhotoRoutes } from "./commands/photoRouter.js";
+import { profileCommand } from "./commands/profile.js";
+import { uploadCommand } from "./commands/upload.js";
+import { withRegistered } from './registration.js';
+import { logger } from './logger.js';
+import { handleBotError } from './errorHandler.js';
+import './handlers/inline.js';
+import './handlers/deeplink.js';
+import { i18n } from './i18n.js';
 
 const privateCommands = (lang: string) => [
   { command: 'start', description: i18n.t(lang, 'cmd-start') },

--- a/frontend/packages/telegram-bot/tsconfig.build.json
+++ b/frontend/packages/telegram-bot/tsconfig.build.json
@@ -13,5 +13,5 @@
     "composite": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
-  "include": ["src"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- ensure telegram-bot dictionaries are emitted in build output
- switch telegram-bot to explicit `.js` relative imports for ESM

## Testing
- `pnpm --filter @photobank/telegram-bot build`
- `pnpm --filter @photobank/telegram-bot exec vitest run`
- `BOT_TOKEN=dummy API_BASE_URL=http://localhost BOT_SERVICE_KEY=dummy VITE_AZURE_OPENAI_ENDPOINT=http://localhost VITE_AZURE_OPENAI_KEY=dummy VITE_AZURE_OPENAI_DEPLOYMENT=dummy VITE_AZURE_OPENAI_API_VERSION=2023-05-15 pnpm --filter @photobank/telegram-bot run start` *(fails: Cannot find module '.../shared/dist/ai/constants')*

------
https://chatgpt.com/codex/tasks/task_e_68bc176ce53c83288b7ece4cd21f5954