### PR TITLE
chore: set initial backend version

### DIFF
--- a/backend/version.json
+++ b/backend/version.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0",
+  "version": "1.0.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
-    "^refs/tags/v\\d+\\.\\d+$"
+    "^refs/tags/v\\d+\\.\\d+\\.\\d+$"
   ]
 }


### PR DESCRIPTION
## Summary
- set backend version to 1.0.0
- allow tagging releases using vX.Y.Z

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`

------
https://chatgpt.com/codex/tasks/task_e_68bc4809fc84832891283fb0873c4240