### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags
+
+      - name: Bump patch tag
+        id: bump
+        run: |
+          set -euo pipefail
+          latest=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          base=${latest#v}
+          IFS='.' read -r major minor patch <<< "$base"
+          new_tag="v$major.$minor.$((patch+1))"
+          git tag "$new_tag"
+          echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Push tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git push origin --tags
+


### PR DESCRIPTION
## Summary
- add release workflow to bump patch tag on push to main

## Testing
- `cd frontend && pnpm -w test` *(fails: expected '02.01.2024' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc4997f5d48328aef385814a20e188