### PR TITLE
fix: prefix version with v

### DIFF
--- a/backend/PhotoBank.Api/Controllers/VersionController.cs
+++ b/backend/PhotoBank.Api/Controllers/VersionController.cs
@@ -14,6 +14,6 @@ public class VersionController : ControllerBase
         var version = Assembly.GetExecutingAssembly()
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
             ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
-        return Ok(version);
+        return Ok($"v{version}");
     }
 }

--- a/backend/PhotoBank.Api/Program.cs
+++ b/backend/PhotoBank.Api/Program.cs
@@ -17,7 +17,7 @@ namespace PhotoBank.Api
             var version = Assembly.GetExecutingAssembly()
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
                 ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString();
-            Console.WriteLine($"Start App! Version: {version}");
+            Console.WriteLine($"Start App! Version: v{version}");
 
             var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
## Summary
- prepend `v` to version returned by `VersionController`
- include `v` prefix when logging application startup version

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`

------
https://chatgpt.com/codex/tasks/task_e_68bc4aea02c0832898c1e079d585c4c9