### PR TITLE
fix: derive OpenAPI version from assembly info

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankApiExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Text.Json.Serialization;
 using System.Security.Claims;
+using System.Reflection;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Diagnostics;
@@ -23,6 +24,7 @@ using PhotoBank.DbContext.Models;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Microsoft.OpenApi.Models;
 
 namespace PhotoBank.DependencyInjection;
 
@@ -137,9 +139,27 @@ public static partial class ServiceCollectionExtensions
         this IServiceCollection services,
         Action<SwaggerGenOptions>? configure = null)
     {
+        var assembly = typeof(ServiceCollectionExtensions).Assembly;
+        var version = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion ?? assembly.GetName().Version?.ToString() ?? "1.0.0";
+        version = version.Split('+')[0];
+        var parts = version.Split('.');
+        if (parts.Length >= 3)
+        {
+            version = string.Join('.', parts[0], parts[1], parts[2]);
+        }
+        const string title = "PhotoBank.Api";
+
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen(options =>
         {
+            options.SwaggerDoc("v1", new OpenApiInfo
+            {
+                Title = title,
+                Version = version
+            });
+
             options.CustomOperationIds(apiDesc =>
             {
                 if (apiDesc.ActionDescriptor is ControllerActionDescriptor descriptor)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.4
 info:
-  title: 'PhotoBank.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
-  version: '1.0'
+  title: PhotoBank.Api
+  version: 1.0.0
 servers:
   - url: /api
 paths:
@@ -1126,6 +1126,21 @@ paths:
             text/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  /version:
+    get:
+      tags:
+        - Version
+      operationId: Version_Get
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+            text/json:
+              schema:
+                type: string
 components:
   schemas:
     AccessProfile:
@@ -1336,9 +1351,6 @@ components:
           type: array
           items:
             type: string
-          nullable: true
-        orderBy:
-          type: string
           nullable: true
       additionalProperties: false
     GeoPointDto:


### PR DESCRIPTION
## Summary
- read `AssemblyInformationalVersion` when configuring Swagger
- regenerate `openapi.yaml` with dynamic version info

## Testing
- `dotnet test backend/PhotoBank.Backend.sln`
- `dotnet swagger tofile --yaml --output ../../openapi.yaml bin/Debug/net9.0/PhotoBank.Api.dll v1`


------
https://chatgpt.com/codex/tasks/task_e_68bc4cfea7d88328b1ee247479d87e42