### PR TITLE
feat(shared): include status and headers in fetcher result

### DIFF
--- a/frontend/packages/shared/src/api/photobank/fetcher.ts
+++ b/frontend/packages/shared/src/api/photobank/fetcher.ts
@@ -79,7 +79,10 @@ export async function customFetcher<T>(url: string, init?: RequestInit): Promise
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
         const response = await fetch(buildUrl(url), finalInit);
-        if (response.ok) return await parseBody<T>(response);
+        if (response.ok) {
+          const data = await parseBody<unknown>(response);
+          return { data, status: response.status, headers: response.headers } as T;
+        }
 
         const errorText = await response.text().catch(() => '');
         let errorData: unknown = undefined;


### PR DESCRIPTION
## Summary
- expose response status and headers alongside parsed data in photobank customFetcher

## Testing
- `pnpm --filter @photobank/shared build` (fails: Could not find a declaration file for module 'object-hash')
- `pnpm --filter @photobank/shared test` (fails: 4 failed tests, including `res.text is not a function`)


------
https://chatgpt.com/codex/tasks/task_e_68bc914c6408832886c9785e560e30a0