### PR TITLE
fix: handle metadata load errors

### DIFF
--- a/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
+++ b/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
@@ -114,7 +114,8 @@ export const metadataSlice = createSlice({
             )
             .addCase(loadMetadata.rejected, (state, action) => {
                 state.loading = false;
-                state.error = action.error.message;
+                state.loaded = true;
+                state.error = action.error.message ?? 'Unknown error';
             });
     },
 });

--- a/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
+++ b/frontend/packages/frontend/src/pages/filter/FilterPage.tsx
@@ -27,6 +27,7 @@ function FilterPage() {
   const savedFilter = useAppSelector((state) => state.photo.filter);
   const loaded = useAppSelector((s) => s.metadata.loaded);
   const loading = useAppSelector((s) => s.metadata.loading);
+  const error = useAppSelector((s) => s.metadata.error);
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -106,8 +107,10 @@ function FilterPage() {
     navigate(`/photos?filter=${encodeURIComponent(encoded)}`);
   };
 
-  if (!loaded) {
-    return <p className="p-4">{t('loadingText')}</p>;
+  if (!loaded || error) {
+    return (
+      <p className="p-4">{error ? t('metadataErrorText') : t('loadingText')}</p>
+    );
   }
 
   return (

--- a/frontend/packages/frontend/src/shared/config/locales/en.json
+++ b/frontend/packages/frontend/src/shared/config/locales/en.json
@@ -22,6 +22,7 @@
   "filterFormTitle": "Advanced Filter Form",
   "applyFiltersButton": "Apply Filters",
   "loadingText": "Loading...",
+  "metadataErrorText": "Failed to load metadata.",
   "openAiPageTitle": "OpenAI Chat",
   "openAiSendButton": "Send",
   "openAiPromptPlaceholder": "Enter your request...",

--- a/frontend/packages/frontend/src/shared/config/locales/ru.json
+++ b/frontend/packages/frontend/src/shared/config/locales/ru.json
@@ -22,6 +22,7 @@
   "filterFormTitle": "Расширенная форма фильтра",
   "applyFiltersButton": "Применить фильтры",
   "loadingText": "Загрузка...",
+  "metadataErrorText": "Не удалось загрузить метаданные.",
   "openAiPageTitle": "Чат OpenAI",
   "openAiSendButton": "Отправить",
   "openAiPromptPlaceholder": "Введите запрос...",


### PR DESCRIPTION
## Summary
- persist metadata load errors to state and mark as loaded
- display metadata load error message on filter page
- add translations for metadata load failure

## Testing
- `pnpm --filter @photobank/frontend test -- --run` *(fails: photos access policy test unable to find element p_1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc98d4a18083289e055093f74f6a47