### PR TITLE
chore: fetch full history in manual backend CI

### DIFF
--- a/.github/workflows/manual-backend-ci.yml
+++ b/.github/workflows/manual-backend-ci.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-dotnet@v4
         with:


### PR DESCRIPTION
## Summary
- fetch full git history in manual backend CI workflow

## Testing
- `pnpm -w test` (fails: --workspace-root may only be used inside a workspace)
- `dotnet restore backend/PhotoBank.Backend.sln`
- `dotnet build backend/PhotoBank.Backend.sln -c Release -p:TreatWarningsAsErrors=false --no-restore`
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj -c Release --no-build --logger "trx;LogFileName=unittests.trx" --results-directory ./TestResults --collect:"XPlat Code Coverage"`
- `dotnet test backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj -c Release --no-build --logger "trx;LogFileName=integration.trx" --results-directory ./TestResults --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_68bdd110a34483288573c55f8a1900f3