### PR TITLE
fix(frontend): resolve shared alias for build

### DIFF
--- a/frontend/packages/frontend/vite.config.ts
+++ b/frontend/packages/frontend/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
-      '@photobank/shared/': path.resolve(__dirname, '../shared/src/'),
+      '@photobank/shared': path.resolve(__dirname, '../shared/src'),
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- fix vite alias so @photobank/shared modules resolve during build

## Testing
- `pnpm --filter @photobank/frontend build`
- `pnpm --filter @photobank/frontend test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68bdda7ed14c8328b72b47c90d002332