### PR TITLE
fix(shared): emit ai constants

### DIFF
--- a/frontend/packages/shared/src/ai/openai.ts
+++ b/frontend/packages/shared/src/ai/openai.ts
@@ -1,9 +1,9 @@
 import { AzureOpenAI } from 'openai';
 import type { ChatCompletionMessageParam } from 'openai/resources';
 
-import { FEW_SHOTS, SYSTEM_PROMPT } from './constants';
-import type { PhotoFilter } from './filter';
-import { PhotoFilterSchema, photoFilterSchemaForLLM } from './filter';
+import { FEW_SHOTS, SYSTEM_PROMPT } from './constants.js';
+import type { PhotoFilter } from './filter.js';
+import { PhotoFilterSchema, photoFilterSchemaForLLM } from './filter.js';
 
 let client: AzureOpenAI | null = null;
 

--- a/frontend/packages/shared/tsconfig.json
+++ b/frontend/packages/shared/tsconfig.json
@@ -11,11 +11,11 @@
     "declaration": true,
     "emitDeclarationOnly": false
   },
-  "include": ["src"],
+  "include": ["src/**/*"],
   "exclude": [
-    "src/**/*.msw.ts",
     "src/api/photobank/msw.ts",
-    "src/api/photobank/msw.scenarios.ts"
+    "src/api/photobank/msw.scenarios.ts",
+    "src/**/*.msw.ts"
   ]
 }
 


### PR DESCRIPTION
## Summary
- include all shared source files during build so AI constants emit
- use explicit `.js` extensions in AI OpenAI helpers for Node runtime

## Testing
- `pnpm --filter @photobank/shared build`
- `pnpm --filter @photobank/shared test` *(fails: expected "02.01.2024", got "1/2/2024")*
- `pnpm --filter @photobank/telegram-bot build`
- `pnpm --filter @photobank/telegram-bot start` *(fails: Cannot find module '/workspace/PhotoBank/frontend/packages/telegram-bot/dist/i18n')*

------
https://chatgpt.com/codex/tasks/task_e_68c0756779e4832891b2ace5f2641c75