### PR TITLE
feat(shared): add AI index re-exports

### DIFF
--- a/frontend/packages/shared/src/ai/index.ts
+++ b/frontend/packages/shared/src/ai/index.ts
@@ -1,0 +1,3 @@
+export * from './openai.js';
+export * from './constants.js';
+export * from './filter.js';


### PR DESCRIPTION
## Summary
- expose AI utilities via new shared entrypoint

## Testing
- `cd frontend/packages/shared && pnpm build`
- `cd frontend/packages/shared && pnpm test` *(fails: format and photos-upload adapter tests)*
- `cd frontend/packages/frontend && node -e "import('@photobank/shared/ai').then(m=>console.log(Object.keys(m)))"`


------
https://chatgpt.com/codex/tasks/task_e_68c07a983b1c8328afc57ab5c3849874