### PR TITLE
fix: use top-level openai import

### DIFF
--- a/frontend/packages/shared/src/ai/constants.ts
+++ b/frontend/packages/shared/src/ai/constants.ts
@@ -1,4 +1,4 @@
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions/completions.mjs';
+import type { ChatCompletionMessageParam } from 'openai/resources';
 
 export const SYSTEM_PROMPT = `
 Ты парсер пользовательских фраз о поиске фотографий.


### PR DESCRIPTION
## Summary
- use top-level import for `ChatCompletionMessageParam`

## Testing
- `pnpm --filter @photobank/shared build` *(fails: Cannot find module 'object-hash', @types/node missing)*
- `pnpm --filter @photobank/shared test` *(fails: locale-sensitive expectations and fetcher test)*

------
https://chatgpt.com/codex/tasks/task_e_68c07f1597e4832891ddcf55111be072