### PR TITLE
chore: use NodeNext module settings for telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/tsconfig.build.json
+++ b/frontend/packages/telegram-bot/tsconfig.build.json
@@ -7,11 +7,12 @@
     "emitDeclarationOnly": false,
     "declaration": true,
     "sourceMap": true,
-    "moduleResolution": "Bundler",
-    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
     "target": "ES2022",
     "composite": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "files": ["src/i18n.ts"]
 }


### PR DESCRIPTION
## Summary
- switch telegram-bot build config to NodeNext module resolution
- ensure i18n.ts is explicitly included for compilation

## Testing
- `BOT_TOKEN=1 pnpm test --run`
- `pnpm run build` *(fails: Module '@photobank/shared/api/photobank' has no exported member 'UpdateUserDto' and missing .js extensions)*
- `BOT_TOKEN=1 pnpm start` *(fails: Relative import paths need explicit file extensions and missing exports)*

------
https://chatgpt.com/codex/tasks/task_e_68c10e7c3cbc8328a6ce45c8cde6c1ac