### PR TITLE
chore: add Node types to telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -27,6 +27,7 @@
     "zod": "^4.1.5"
   },
   "devDependencies": {
+    "@types/node": "^24.3.1",
     "cpy-cli": "^6.0.0",
     "rimraf": "^6.0.1",
     "typescript": "^5.9.2",

--- a/frontend/packages/telegram-bot/tsconfig.json
+++ b/frontend/packages/telegram-bot/tsconfig.json
@@ -12,7 +12,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "target": "ES2022",
-    "types": ["vitest/globals"],
+    "types": ["node", "vitest/globals"],
     "strict": false
   },
   "references": [{ "path": "../shared" }],


### PR DESCRIPTION
## Summary
- add `@types/node` to Telegram bot dev deps
- include Node and Vitest types in Telegram bot `tsconfig`

## Testing
- `pnpm install`
- `pnpm run build` *(fails: Cannot find type definition file for 'node' in shared package)*

------
https://chatgpt.com/codex/tasks/task_e_68c110c51cb483289d81a32bf33b4cfe