### PR TITLE
fix: add .js extensions to telegram-bot imports

### DIFF
--- a/frontend/packages/telegram-bot/src/api/auth.ts
+++ b/frontend/packages/telegram-bot/src/api/auth.ts
@@ -1,6 +1,6 @@
 import { configureApi, customFetcher } from '@photobank/shared/api/photobank';
 
-import { BOT_SERVICE_KEY } from '../config';
+import { BOT_SERVICE_KEY } from '../config.js';
 
 configureApi(process.env.API_BASE_URL ?? '');
 

--- a/frontend/packages/telegram-bot/src/auth.ts
+++ b/frontend/packages/telegram-bot/src/auth.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'grammy';
 
-import { exchangeTelegramUserToken } from './api/auth';
+import { exchangeTelegramUserToken } from './api/auth.js';
 
 type CacheEntry = { token: string; exp: number }; // seconds since epoch
 const tokenCache = new Map<number, CacheEntry>();

--- a/frontend/packages/telegram-bot/src/bot.ts
+++ b/frontend/packages/telegram-bot/src/bot.ts
@@ -1,6 +1,6 @@
 import { Bot } from 'grammy';
 
-import { BOT_TOKEN } from './config';
-import type { MyContext } from './i18n';
+import { BOT_TOKEN } from './config.js';
+import type { MyContext } from './i18n.js';
 
 export const bot = new Bot<MyContext>(BOT_TOKEN);

--- a/frontend/packages/telegram-bot/src/commands/ai.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.ts
@@ -2,9 +2,9 @@ import { parseQueryWithOpenAI } from '@photobank/shared/ai/openai';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 import { getFilterHash } from '@photobank/shared/index';
 
-import type { MyContext } from '../i18n';
-import { sendPhotosPage } from './photosPage';
-import { logger } from '../logger';
+import type { MyContext } from '../i18n.js';
+import { sendPhotosPage } from './photosPage.js';
+import { logger } from '../logger.js';
 
 export const aiFilters = new Map<string, FilterDto>();
 

--- a/frontend/packages/telegram-bot/src/commands/help.ts
+++ b/frontend/packages/telegram-bot/src/commands/help.ts
@@ -1,4 +1,4 @@
-import type { MyContext } from '../i18n';
+import type { MyContext } from '../i18n.js';
 
 export async function helpCommand(ctx: MyContext) {
   await ctx.reply(ctx.t('help'));

--- a/frontend/packages/telegram-bot/src/commands/helpers.ts
+++ b/frontend/packages/telegram-bot/src/commands/helpers.ts
@@ -1,7 +1,7 @@
 import { InlineKeyboard } from "grammy";
 
-import type { MyContext } from "../i18n";
-import { logger } from "../logger";
+import type { MyContext } from "../i18n.js";
+import { logger } from "../logger.js";
 
 export const PAGE_SIZE = 10;
 

--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -1,6 +1,6 @@
-import type { MyContext } from "../i18n";
-import { getAllPersons } from '../dictionaries';
-import { parsePrefix, sendNamedItemsPage } from "./helpers";
+import type { MyContext } from "../i18n.js";
+import { getAllPersons } from '../dictionaries.js';
+import { parsePrefix, sendNamedItemsPage } from "./helpers.js";
 
 export async function sendPersonsPage(
   ctx: MyContext,

--- a/frontend/packages/telegram-bot/src/commands/photoRouter.ts
+++ b/frontend/packages/telegram-bot/src/commands/photoRouter.ts
@@ -1,8 +1,8 @@
 import { Bot, type CommandContext, type HearsContext, type CallbackQueryContext } from "grammy";
 
-import { sendPhotoById, openPhotoInline } from "../photo";
-import { withRegistered } from '../registration';
-import type { MyContext } from '../i18n';
+import { sendPhotoById, openPhotoInline } from "../photo.js";
+import { withRegistered } from '../registration.js';
+import type { MyContext } from '../i18n.js';
 
 // Main command
 export function registerPhotoRoutes(bot: Bot<MyContext>) {

--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -2,10 +2,10 @@ import { InlineKeyboard } from 'grammy';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 import { firstNWords } from '@photobank/shared/index';
 
-import type { MyContext } from '../i18n';
-import { searchPhotos } from '../services/photo';
-import { handleCommandError } from '../errorHandler';
-import { captionCache, currentPagePhotos, deletePhotoMessage } from '../photo';
+import type { MyContext } from '../i18n.js';
+import { searchPhotos } from '../services/photo.js';
+import { handleCommandError } from '../errorHandler.js';
+import { captionCache, currentPagePhotos, deletePhotoMessage } from '../photo.js';
 
 export const PHOTOS_PAGE_SIZE = 10;
 

--- a/frontend/packages/telegram-bot/src/commands/profile.ts
+++ b/frontend/packages/telegram-bot/src/commands/profile.ts
@@ -1,6 +1,6 @@
-import type { MyContext } from "../i18n";
-import { getUser } from "../services/auth";
-import { handleCommandError } from "../errorHandler";
+import type { MyContext } from "../i18n.js";
+import { getUser } from "../services/auth.js";
+import { handleCommandError } from "../errorHandler.js";
 
 export async function profileCommand(ctx: MyContext) {
     const username = ctx.from?.username ?? String(ctx.from?.id ?? "");

--- a/frontend/packages/telegram-bot/src/commands/search.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.ts
@@ -11,7 +11,7 @@ import type { FilterDto } from '@photobank/shared/api/photobank';
 
 import type { MyContext } from '@/i18n.js';
 
-import { sendPhotosPage } from './photosPage';
+import { sendPhotosPage } from './photosPage.js';
 
 /* ===================== токенизация ===================== */
 

--- a/frontend/packages/telegram-bot/src/commands/storages.ts
+++ b/frontend/packages/telegram-bot/src/commands/storages.ts
@@ -1,6 +1,6 @@
-import type { MyContext } from '../i18n';
-import { getAllStoragesWithPaths } from '../dictionaries';
-import { parsePrefix, sendNamedItemsPage } from './helpers';
+import type { MyContext } from '../i18n.js';
+import { getAllStoragesWithPaths } from '../dictionaries.js';
+import { parsePrefix, sendNamedItemsPage } from './helpers.js';
 
 const MAX_PATHS_PER_STORAGE = 20;
 

--- a/frontend/packages/telegram-bot/src/commands/subscribe.ts
+++ b/frontend/packages/telegram-bot/src/commands/subscribe.ts
@@ -1,10 +1,10 @@
 import { Bot } from 'grammy';
 import type { UpdateUserDto } from '@photobank/shared/api/photobank';
 
-import { updateUser } from '../services/auth';
-import type { MyContext } from '../i18n';
-import { i18n } from '../i18n';
-import { sendThisDayPage } from './thisday';
+import { updateUser } from '../services/auth.js';
+import type { MyContext } from '../i18n.js';
+import { i18n } from '../i18n.js';
+import { sendThisDayPage } from './thisday.js';
 
 export const subscriptions = new Map<number, { time: string; locale: string }>();
 

--- a/frontend/packages/telegram-bot/src/commands/tags.ts
+++ b/frontend/packages/telegram-bot/src/commands/tags.ts
@@ -1,6 +1,6 @@
-import type { MyContext } from '../i18n';
-import { getAllTags } from '../dictionaries';
-import { parsePrefix, sendNamedItemsPage } from './helpers';
+import type { MyContext } from '../i18n.js';
+import { getAllTags } from '../dictionaries.js';
+import { parsePrefix, sendNamedItemsPage } from './helpers.js';
 
 export async function sendTagsPage(
   ctx: MyContext,

--- a/frontend/packages/telegram-bot/src/commands/thisday.ts
+++ b/frontend/packages/telegram-bot/src/commands/thisday.ts
@@ -1,5 +1,5 @@
-import type { MyContext } from '../i18n';
-import { sendPhotosPage } from './photosPage';
+import type { MyContext } from '../i18n.js';
+import { sendPhotosPage } from './photosPage.js';
 
 function parsePage(text?: string): number {
     if (!text) return 1;

--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
 import { uploadStorageName } from '@photobank/shared/constants';
 
-import { BOT_TOKEN } from '../config';
-import { getStorageId } from '../dictionaries';
-import { handleCommandError } from '../errorHandler';
-import type { MyContext } from '../i18n';
-import { uploadPhotos } from '../services/photo';
+import { BOT_TOKEN } from '../config.js';
+import { getStorageId } from '../dictionaries.js';
+import { handleCommandError } from '../errorHandler.js';
+import type { MyContext } from '../i18n.js';
+import { uploadPhotos } from '../services/photo.js';
 
 async function fetchFile(ctx: MyContext, fileId: string, fileName: string) {
   const file = await ctx.api.getFile(fileId);

--- a/frontend/packages/telegram-bot/src/errorHandler.ts
+++ b/frontend/packages/telegram-bot/src/errorHandler.ts
@@ -2,8 +2,8 @@ import { BotError, Context } from 'grammy';
 import { apiErrorMsg } from '@photobank/shared/constants';
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
-import type { MyContext } from './i18n';
-import { logger } from './logger';
+import type { MyContext } from './i18n.js';
+import { logger } from './logger.js';
 
 export function handleBotError(err: BotError<Context>) {
   const ctx = err.ctx;

--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -1,7 +1,7 @@
 import type { PhotoDto } from "@photobank/shared/api/photobank";
 import { formatDate } from "@photobank/shared/index";
 
-import { getPersonName } from "./dictionaries";
+import { getPersonName } from "./dictionaries.js";
 
 export function formatPhotoMessage(photo: PhotoDto): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
     const lines: string[] = [];

--- a/frontend/packages/telegram-bot/src/handlers/deeplink.ts
+++ b/frontend/packages/telegram-bot/src/handlers/deeplink.ts
@@ -1,8 +1,8 @@
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
-import { bot } from '../bot';
-import type { MyContext } from '../i18n';
-import { ensureUserAccessToken } from '../auth';
+import { bot } from '../bot.js';
+import type { MyContext } from '../i18n.js';
+import { ensureUserAccessToken } from '../auth.js';
 
 bot.on('message', async (ctx: MyContext, next) => {
   const text = ctx.message?.text ?? '';

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -2,12 +2,12 @@ import type { InlineQueryResult, InlineQueryResultPhoto } from 'grammy/types';
 import { formatDate } from '@photobank/shared/format';
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
-import { bot } from '../bot';
-import { ensureUserAccessToken } from '../auth';
-import { searchPhotos } from '../services/photo';
-import { getTagName } from '../dictionaries';
-import { logger } from '../logger';
-import type { MyContext } from '../i18n';
+import { bot } from '../bot.js';
+import { ensureUserAccessToken } from '../auth.js';
+import { searchPhotos } from '../services/photo.js';
+import { getTagName } from '../dictionaries.js';
+import { logger } from '../logger.js';
+import type { MyContext } from '../i18n.js';
 
 const PAGE_SIZE = 20;
 

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -1,9 +1,9 @@
 import { InlineKeyboard } from 'grammy';
 import type { PhotoDto } from '@photobank/shared/api/photobank';
 
-import { formatPhotoMessage } from './formatPhotoMessage';
-import type { MyContext } from './i18n';
-import { getPhoto } from './services/photo';
+import { formatPhotoMessage } from './formatPhotoMessage.js';
+import type { MyContext } from './i18n.js';
+import { getPhoto } from './services/photo.js';
 
 export const photoMessages = new Map<number, number>();
 export const currentPagePhotos = new Map<number, { page: number; ids: number[] }>();

--- a/frontend/packages/telegram-bot/src/registration.ts
+++ b/frontend/packages/telegram-bot/src/registration.ts
@@ -1,8 +1,8 @@
 import type { MiddlewareFn } from 'grammy';
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
-import { ensureUserAccessToken } from './auth';
-import type { MyContext } from './i18n';
+import { ensureUserAccessToken } from './auth.js';
+import type { MyContext } from './i18n.js';
 
 export async function ensureRegistered(ctx: MyContext): Promise<boolean> {
   try {

--- a/frontend/packages/telegram-bot/src/services/auth.ts
+++ b/frontend/packages/telegram-bot/src/services/auth.ts
@@ -7,7 +7,7 @@ import {
   type UpdateUserDto,
 } from '@photobank/shared/api/photobank';
 
-import { ensureUserAccessToken } from '../auth';
+import { ensureUserAccessToken } from '../auth.js';
 
 async function authorized<T>(ctx: Context, fn: (options?: RequestInit) => Promise<T>): Promise<T> {
   const token = await ensureUserAccessToken(ctx);

--- a/frontend/packages/telegram-bot/src/services/dictionary.ts
+++ b/frontend/packages/telegram-bot/src/services/dictionary.ts
@@ -1,11 +1,11 @@
 import type { Context } from 'grammy';
 
-import { getPaths } from '../api/photobank/paths/paths';
-import { getPersons } from '../api/photobank/persons/persons';
-import { getStorages } from '../api/photobank/storages/storages';
-import { getTags } from '../api/photobank/tags/tags';
-import { setRequestContext } from '../api/axios-instance';
-import { handleServiceError } from '../errorHandler';
+import { getPaths } from '../api/photobank/paths/paths.js';
+import { getPersons } from '../api/photobank/persons/persons.js';
+import { getStorages } from '../api/photobank/storages/storages.js';
+import { getTags } from '../api/photobank/tags/tags.js';
+import { setRequestContext } from '../api/axios-instance.js';
+import { handleServiceError } from '../errorHandler.js';
 
 const { pathsGetAll } = getPaths();
 const { personsGetAll } = getPersons();

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -5,9 +5,9 @@ import {
   getPhotos,
   type PhotosGetPhotoResult,
   type PhotosSearchPhotosResult,
-} from '../api/photobank/photos/photos';
-import { setRequestContext } from '../api/axios-instance';
-import { handleServiceError } from '../errorHandler';
+} from '../api/photobank/photos/photos.js';
+import { setRequestContext } from '../api/axios-instance.js';
+import { handleServiceError } from '../errorHandler.js';
 
 const { photosSearchPhotos, photosGetPhoto, photosUpload } = getPhotos();
 

--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -2,11 +2,11 @@ import type { Context } from 'grammy';
 import type { InputMediaPhoto, Message } from 'grammy/types';
 import { formatDate } from '@photobank/shared/format';
 
-import { throttled } from '../utils/limiter';
-import { getFileId, setFileId, delFileId } from '../cache/fileIdCache';
-import { logger } from '../utils/logger';
-import type { PhotoItemDto } from '../types';
-import { withTelegramRetry } from '../utils/retry';
+import { throttled } from '../utils/limiter.js';
+import { getFileId, setFileId, delFileId } from '../cache/fileIdCache.js';
+import { logger } from '../utils/logger.js';
+import type { PhotoItemDto } from '../types.js';
+import { withTelegramRetry } from '../utils/retry.js';
 
 function buildCaption(p: PhotoItemDto): string {
   const parts = [p.name, p.takenDate ? formatDate(p.takenDate) : null];

--- a/frontend/packages/telegram-bot/src/utils/logger.ts
+++ b/frontend/packages/telegram-bot/src/utils/logger.ts
@@ -1,1 +1,1 @@
-export { logger } from '../logger';
+export { logger } from '../logger.js';


### PR DESCRIPTION
## Summary
- include `.js` extensions on all relative imports in the telegram-bot package
- re-export logger through updated path

## Testing
- `pnpm test --run`
- `rg -n "from ['\"](\./|../)" src/commands/`
- `rg -n "from ['\"](\./|../)" src/services/`
- `rg -n "from ['\"](\./|../)" src/handlers/`
- `rg -n "from ['\"](\./|../)" src/utils/`
- `rg -n "from ['\"](\./|../)" src/telegram/`
- `rg -n "from ['\"](\./|../)" src/*.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c16a27e614832883f7764245f4cec9