### PR TITLE
fix: normalize photo search filters

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PhotosController.cs
+++ b/backend/PhotoBank.Api/Controllers/PhotosController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PhotoBank.Services.Api;
+using PhotoBank.Services.Search;
 using PhotoBank.ViewModel.Dto;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,7 +13,10 @@ namespace PhotoBank.Api.Controllers
     [Route("[controller]")]
     [Authorize]
     [ApiController]
-    public class PhotosController(ILogger<PhotosController> logger, IPhotoService photoService)
+    public class PhotosController(
+        ILogger<PhotosController> logger,
+        IPhotoService photoService,
+        ISearchFilterNormalizer normalizer)
         : ControllerBase
     {
         [HttpPost("search")]
@@ -21,6 +25,7 @@ namespace PhotoBank.Api.Controllers
         public async Task<ActionResult<PageResponse<PhotoItemDto>>> SearchPhotos([FromBody] FilterDto request)
         {
             logger.LogInformation("Searching photos with filter {@Filter}", request);
+            await normalizer.NormalizeAsync(request);
             var result = await photoService.GetAllPhotosAsync(request);
             logger.LogInformation("Found {Count} photos", result.TotalCount);
             return Ok(result);

--- a/backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj
+++ b/backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\PhotoBank.DbContext\PhotoBank.DbContext.csproj" />
     <ProjectReference Include="..\PhotoBank.Repositories\PhotoBank.Repositories.csproj" />
     <ProjectReference Include="..\PhotoBank.Services\PhotoBank.Services.csproj" />
+    <ProjectReference Include="..\PhotoBank.Api\PhotoBank.Api.csproj" />
   </ItemGroup>
 
 </Project>

--- a/backend/PhotoBank.UnitTests/PhotosControllerTests.cs
+++ b/backend/PhotoBank.UnitTests/PhotosControllerTests.cs
@@ -1,0 +1,55 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.Api.Controllers;
+using PhotoBank.Services.Api;
+using PhotoBank.Services.Search;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class PhotosControllerTests
+{
+    [Test]
+    public async Task SearchPhotos_NormalizesFilter()
+    {
+        // Arrange
+        var logger = Mock.Of<ILogger<PhotosController>>();
+        var filter = new FilterDto { PersonNames = ["John"], TagNames = ["car"] };
+
+        var normalizer = new Mock<ISearchFilterNormalizer>();
+        normalizer
+            .Setup(n => n.NormalizeAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
+            .Callback<FilterDto, CancellationToken>((f, _) =>
+            {
+                f.Persons = new[] { 1 };
+                f.Tags = new[] { 2 };
+            })
+            .ReturnsAsync((FilterDto f, CancellationToken _) => f);
+
+        var page = new PageResponse<PhotoItemDto>();
+        var photoService = new Mock<IPhotoService>();
+        photoService
+            .Setup(s => s.GetAllPhotosAsync(It.IsAny<FilterDto>()))
+            .ReturnsAsync(page);
+
+        var controller = new PhotosController(logger, photoService.Object, normalizer.Object);
+
+        // Act
+        var result = await controller.SearchPhotos(filter);
+
+        // Assert
+        normalizer.Verify(n => n.NormalizeAsync(filter, It.IsAny<CancellationToken>()), Times.Once);
+        photoService.Verify(s => s.GetAllPhotosAsync(It.Is<FilterDto>(f =>
+            f.Persons!.SequenceEqual(new[] { 1 }) && f.Tags!.SequenceEqual(new[] { 2 })
+        )), Times.Once);
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+}
+


### PR DESCRIPTION
## Summary
- inject `ISearchFilterNormalizer` into `PhotosController`
- normalize search filters before querying photo service
- test controller to ensure persons/tags are populated

## Testing
- `dotnet restore PhotoBank.Backend.sln`
- `dotnet build PhotoBank.Backend.sln`
- `dotnet test PhotoBank.Backend.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd87f9308328b789e94b3c7f0e98