### PR TITLE
refactor: remove .js extensions from imports

### DIFF
--- a/frontend/packages/shared/src/ai/index.ts
+++ b/frontend/packages/shared/src/ai/index.ts
@@ -1,3 +1,3 @@
-export * from './openai.js';
-export * from './constants.js';
-export * from './filter.js';
+export * from './openai';
+export * from './constants';
+export * from './filter';

--- a/frontend/packages/shared/src/ai/openai.ts
+++ b/frontend/packages/shared/src/ai/openai.ts
@@ -1,9 +1,9 @@
 import { AzureOpenAI } from 'openai';
 import type { ChatCompletionMessageParam } from 'openai/resources';
 
-import { FEW_SHOTS, SYSTEM_PROMPT } from './constants.js';
-import type { PhotoFilter } from './filter.js';
-import { PhotoFilterSchema, photoFilterSchemaForLLM } from './filter.js';
+import { FEW_SHOTS, SYSTEM_PROMPT } from './constants';
+import type { PhotoFilter } from './filter';
+import { PhotoFilterSchema, photoFilterSchemaForLLM } from './filter';
 
 let client: AzureOpenAI | null = null;
 

--- a/frontend/packages/telegram-bot/src/api/auth.ts
+++ b/frontend/packages/telegram-bot/src/api/auth.ts
@@ -1,6 +1,6 @@
 import { configureApi, customFetcher } from '@photobank/shared/api/photobank';
 
-import { BOT_SERVICE_KEY } from '../config.js';
+import { BOT_SERVICE_KEY } from '../config';
 
 configureApi(process.env.API_BASE_URL ?? '');
 

--- a/frontend/packages/telegram-bot/src/auth.ts
+++ b/frontend/packages/telegram-bot/src/auth.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'grammy';
 
-import { exchangeTelegramUserToken } from './api/auth.js';
+import { exchangeTelegramUserToken } from './api/auth';
 
 type CacheEntry = { token: string; exp: number }; // seconds since epoch
 const tokenCache = new Map<number, CacheEntry>();

--- a/frontend/packages/telegram-bot/src/bot.ts
+++ b/frontend/packages/telegram-bot/src/bot.ts
@@ -1,6 +1,6 @@
 import { Bot } from 'grammy';
 
-import { BOT_TOKEN } from './config.js';
-import type { MyContext } from './i18n.js';
+import { BOT_TOKEN } from './config';
+import type { MyContext } from './i18n';
 
 export const bot = new Bot<MyContext>(BOT_TOKEN);

--- a/frontend/packages/telegram-bot/src/commands/ai.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.ts
@@ -2,9 +2,9 @@ import { parseQueryWithOpenAI } from '@photobank/shared/ai/openai';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 import { getFilterHash } from '@photobank/shared/index';
 
-import type { MyContext } from '../i18n.js';
-import { sendPhotosPage } from './photosPage.js';
-import { logger } from '../logger.js';
+import type { MyContext } from '../i18n';
+import { sendPhotosPage } from './photosPage';
+import { logger } from '../logger';
 
 export const aiFilters = new Map<string, FilterDto>();
 

--- a/frontend/packages/telegram-bot/src/commands/help.ts
+++ b/frontend/packages/telegram-bot/src/commands/help.ts
@@ -1,4 +1,4 @@
-import type { MyContext } from '../i18n.js';
+import type { MyContext } from '../i18n';
 
 export async function helpCommand(ctx: MyContext) {
   await ctx.reply(ctx.t('help'));

--- a/frontend/packages/telegram-bot/src/commands/helpers.ts
+++ b/frontend/packages/telegram-bot/src/commands/helpers.ts
@@ -1,7 +1,7 @@
 import { InlineKeyboard } from "grammy";
 
-import type { MyContext } from "../i18n.js";
-import { logger } from "../logger.js";
+import type { MyContext } from "../i18n";
+import { logger } from "../logger";
 
 export const PAGE_SIZE = 10;
 

--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -1,6 +1,6 @@
-import type { MyContext } from "../i18n.js";
-import { getAllPersons } from '../dictionaries.js';
-import { parsePrefix, sendNamedItemsPage } from "./helpers.js";
+import type { MyContext } from "../i18n";
+import { getAllPersons } from '../dictionaries';
+import { parsePrefix, sendNamedItemsPage } from "./helpers";
 
 export async function sendPersonsPage(
   ctx: MyContext,

--- a/frontend/packages/telegram-bot/src/commands/photoRouter.ts
+++ b/frontend/packages/telegram-bot/src/commands/photoRouter.ts
@@ -1,8 +1,8 @@
 import { Bot, type CommandContext, type HearsContext, type CallbackQueryContext } from "grammy";
 
-import { sendPhotoById, openPhotoInline } from "../photo.js";
-import { withRegistered } from '../registration.js';
-import type { MyContext } from '../i18n.js';
+import { sendPhotoById, openPhotoInline } from "../photo";
+import { withRegistered } from '../registration';
+import type { MyContext } from '../i18n';
 
 // Main command
 export function registerPhotoRoutes(bot: Bot<MyContext>) {

--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -2,10 +2,10 @@ import { InlineKeyboard } from 'grammy';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 import { firstNWords } from '@photobank/shared/index';
 
-import type { MyContext } from '../i18n.js';
-import { searchPhotos } from '../services/photo.js';
-import { handleCommandError } from '../errorHandler.js';
-import { captionCache, currentPagePhotos, deletePhotoMessage } from '../photo.js';
+import type { MyContext } from '../i18n';
+import { searchPhotos } from '../services/photo';
+import { handleCommandError } from '../errorHandler';
+import { captionCache, currentPagePhotos, deletePhotoMessage } from '../photo';
 
 export const PHOTOS_PAGE_SIZE = 10;
 

--- a/frontend/packages/telegram-bot/src/commands/profile.ts
+++ b/frontend/packages/telegram-bot/src/commands/profile.ts
@@ -1,6 +1,6 @@
-import type { MyContext } from "../i18n.js";
-import { getUser } from "../services/auth.js";
-import { handleCommandError } from "../errorHandler.js";
+import type { MyContext } from "../i18n";
+import { getUser } from "../services/auth";
+import { handleCommandError } from "../errorHandler";
 
 export async function profileCommand(ctx: MyContext) {
     const username = ctx.from?.username ?? String(ctx.from?.id ?? "");

--- a/frontend/packages/telegram-bot/src/commands/search.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.ts
@@ -9,9 +9,9 @@ import {
 } from 'date-fns';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 
-import type { MyContext } from '@/i18n.js';
+import type { MyContext } from '@/i18n';
 
-import { sendPhotosPage } from './photosPage.js';
+import { sendPhotosPage } from './photosPage';
 
 /* ===================== токенизация ===================== */
 

--- a/frontend/packages/telegram-bot/src/commands/storages.ts
+++ b/frontend/packages/telegram-bot/src/commands/storages.ts
@@ -1,6 +1,6 @@
-import type { MyContext } from '../i18n.js';
-import { getAllStoragesWithPaths } from '../dictionaries.js';
-import { parsePrefix, sendNamedItemsPage } from './helpers.js';
+import type { MyContext } from '../i18n';
+import { getAllStoragesWithPaths } from '../dictionaries';
+import { parsePrefix, sendNamedItemsPage } from './helpers';
 
 const MAX_PATHS_PER_STORAGE = 20;
 

--- a/frontend/packages/telegram-bot/src/commands/subscribe.ts
+++ b/frontend/packages/telegram-bot/src/commands/subscribe.ts
@@ -1,10 +1,10 @@
 import { Bot } from 'grammy';
 import type { UpdateUserDto } from '@photobank/shared/api/photobank';
 
-import { updateUser } from '../services/auth.js';
-import type { MyContext } from '../i18n.js';
-import { i18n } from '../i18n.js';
-import { sendThisDayPage } from './thisday.js';
+import { updateUser } from '../services/auth';
+import type { MyContext } from '../i18n';
+import { i18n } from '../i18n';
+import { sendThisDayPage } from './thisday';
 
 export const subscriptions = new Map<number, { time: string; locale: string }>();
 

--- a/frontend/packages/telegram-bot/src/commands/tags.ts
+++ b/frontend/packages/telegram-bot/src/commands/tags.ts
@@ -1,6 +1,6 @@
-import type { MyContext } from '../i18n.js';
-import { getAllTags } from '../dictionaries.js';
-import { parsePrefix, sendNamedItemsPage } from './helpers.js';
+import type { MyContext } from '../i18n';
+import { getAllTags } from '../dictionaries';
+import { parsePrefix, sendNamedItemsPage } from './helpers';
 
 export async function sendTagsPage(
   ctx: MyContext,

--- a/frontend/packages/telegram-bot/src/commands/thisday.ts
+++ b/frontend/packages/telegram-bot/src/commands/thisday.ts
@@ -1,5 +1,5 @@
-import type { MyContext } from '../i18n.js';
-import { sendPhotosPage } from './photosPage.js';
+import type { MyContext } from '../i18n';
+import { sendPhotosPage } from './photosPage';
 
 function parsePage(text?: string): number {
     if (!text) return 1;

--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
 import { uploadStorageName } from '@photobank/shared/constants';
 
-import { BOT_TOKEN } from '../config.js';
-import { getStorageId } from '../dictionaries.js';
-import { handleCommandError } from '../errorHandler.js';
-import type { MyContext } from '../i18n.js';
-import { uploadPhotos } from '../services/photo.js';
+import { BOT_TOKEN } from '../config';
+import { getStorageId } from '../dictionaries';
+import { handleCommandError } from '../errorHandler';
+import type { MyContext } from '../i18n';
+import { uploadPhotos } from '../services/photo';
 
 async function fetchFile(ctx: MyContext, fileId: string, fileName: string) {
   const file = await ctx.api.getFile(fileId);

--- a/frontend/packages/telegram-bot/src/dictionaries.ts
+++ b/frontend/packages/telegram-bot/src/dictionaries.ts
@@ -4,14 +4,14 @@ import type {
   TagDto,
 } from '@photobank/shared/api/photobank';
 
-import { i18n } from './i18n.js';
-import type { MyContext } from './i18n.js';
+import { i18n } from './i18n';
+import type { MyContext } from './i18n';
 import {
   fetchPaths,
   fetchPersons,
   fetchStorages,
   fetchTags,
-} from './services/dictionary.js';
+} from './services/dictionary';
 
 type DictData = {
   tagMap: Map<number, string>;

--- a/frontend/packages/telegram-bot/src/errorHandler.ts
+++ b/frontend/packages/telegram-bot/src/errorHandler.ts
@@ -2,8 +2,8 @@ import { BotError, Context } from 'grammy';
 import { apiErrorMsg } from '@photobank/shared/constants';
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
-import type { MyContext } from './i18n.js';
-import { logger } from './logger.js';
+import type { MyContext } from './i18n';
+import { logger } from './logger';
 
 export function handleBotError(err: BotError<Context>) {
   const ctx = err.ctx;

--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -1,7 +1,7 @@
 import type { PhotoDto } from "@photobank/shared/api/photobank";
 import { formatDate } from "@photobank/shared/index";
 
-import { getPersonName } from "./dictionaries.js";
+import { getPersonName } from "./dictionaries";
 
 export function formatPhotoMessage(photo: PhotoDto): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
     const lines: string[] = [];

--- a/frontend/packages/telegram-bot/src/handlers/deeplink.ts
+++ b/frontend/packages/telegram-bot/src/handlers/deeplink.ts
@@ -1,8 +1,8 @@
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
-import { bot } from '../bot.js';
-import type { MyContext } from '../i18n.js';
-import { ensureUserAccessToken } from '../auth.js';
+import { bot } from '../bot';
+import type { MyContext } from '../i18n';
+import { ensureUserAccessToken } from '../auth';
 
 bot.on('message', async (ctx: MyContext, next) => {
   const text = ctx.message?.text ?? '';

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -2,12 +2,12 @@ import type { InlineQueryResult, InlineQueryResultPhoto } from 'grammy/types';
 import { formatDate } from '@photobank/shared/format';
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
-import { bot } from '../bot.js';
-import { ensureUserAccessToken } from '../auth.js';
-import { searchPhotos } from '../services/photo.js';
-import { getTagName } from '../dictionaries.js';
-import { logger } from '../logger.js';
-import type { MyContext } from '../i18n.js';
+import { bot } from '../bot';
+import { ensureUserAccessToken } from '../auth';
+import { searchPhotos } from '../services/photo';
+import { getTagName } from '../dictionaries';
+import { logger } from '../logger';
+import type { MyContext } from '../i18n';
 
 const PAGE_SIZE = 20;
 

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -1,32 +1,32 @@
 import { configureAzureOpenAI } from "@photobank/shared/ai/openai";
 
-import { loadDictionaries, setDictionariesUser } from "./dictionaries.js";
+import { loadDictionaries, setDictionariesUser } from "./dictionaries";
 import {
   AZURE_OPENAI_ENDPOINT,
   AZURE_OPENAI_KEY,
   AZURE_OPENAI_DEPLOYMENT,
   AZURE_OPENAI_API_VERSION,
-} from "./config.js";
-import { bot } from './bot.js';
-import { sendThisDayPage, thisDayCommand } from "./commands/thisday.js";
-import { captionCache } from "./photo.js";
-import { sendSearchPage, searchCommand, decodeSearchCallback } from "./commands/search.js";
-import { aiCommand, sendAiPage } from "./commands/ai.js";
-import { helpCommand } from "./commands/help.js";
-import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe.js";
-import { tagsCommand, sendTagsPage } from "./commands/tags.js";
-import { personsCommand, sendPersonsPage } from "./commands/persons.js";
-import { storagesCommand, sendStoragesPage } from "./commands/storages.js";
-import { tagsCallbackPattern, personsCallbackPattern, storagesCallbackPattern } from "./patterns.js";
-import { registerPhotoRoutes } from "./commands/photoRouter.js";
-import { profileCommand } from "./commands/profile.js";
-import { uploadCommand } from "./commands/upload.js";
-import { withRegistered } from './registration.js';
-import { logger } from './logger.js';
-import { handleBotError } from './errorHandler.js';
-import './handlers/inline.js';
-import './handlers/deeplink.js';
-import { i18n } from './i18n.js';
+} from "./config";
+import { bot } from './bot';
+import { sendThisDayPage, thisDayCommand } from "./commands/thisday";
+import { captionCache } from "./photo";
+import { sendSearchPage, searchCommand, decodeSearchCallback } from "./commands/search";
+import { aiCommand, sendAiPage } from "./commands/ai";
+import { helpCommand } from "./commands/help";
+import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
+import { tagsCommand, sendTagsPage } from "./commands/tags";
+import { personsCommand, sendPersonsPage } from "./commands/persons";
+import { storagesCommand, sendStoragesPage } from "./commands/storages";
+import { tagsCallbackPattern, personsCallbackPattern, storagesCallbackPattern } from "./patterns";
+import { registerPhotoRoutes } from "./commands/photoRouter";
+import { profileCommand } from "./commands/profile";
+import { uploadCommand } from "./commands/upload";
+import { withRegistered } from './registration';
+import { logger } from './logger';
+import { handleBotError } from './errorHandler';
+import './handlers/inline';
+import './handlers/deeplink';
+import { i18n } from './i18n';
 
 const privateCommands = (lang: string) => [
   { command: 'start', description: i18n.t(lang, 'cmd-start') },

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -1,9 +1,9 @@
 import { InlineKeyboard } from 'grammy';
 import type { PhotoDto } from '@photobank/shared/api/photobank';
 
-import { formatPhotoMessage } from './formatPhotoMessage.js';
-import type { MyContext } from './i18n.js';
-import { getPhoto } from './services/photo.js';
+import { formatPhotoMessage } from './formatPhotoMessage';
+import type { MyContext } from './i18n';
+import { getPhoto } from './services/photo';
 
 export const photoMessages = new Map<number, number>();
 export const currentPagePhotos = new Map<number, { page: number; ids: number[] }>();

--- a/frontend/packages/telegram-bot/src/registration.ts
+++ b/frontend/packages/telegram-bot/src/registration.ts
@@ -1,8 +1,8 @@
 import type { MiddlewareFn } from 'grammy';
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
-import { ensureUserAccessToken } from './auth.js';
-import type { MyContext } from './i18n.js';
+import { ensureUserAccessToken } from './auth';
+import type { MyContext } from './i18n';
 
 export async function ensureRegistered(ctx: MyContext): Promise<boolean> {
   try {

--- a/frontend/packages/telegram-bot/src/services/auth.ts
+++ b/frontend/packages/telegram-bot/src/services/auth.ts
@@ -7,7 +7,7 @@ import {
   type UpdateUserDto,
 } from '@photobank/shared/api/photobank';
 
-import { ensureUserAccessToken } from '../auth.js';
+import { ensureUserAccessToken } from '../auth';
 
 async function authorized<T>(ctx: Context, fn: (options?: RequestInit) => Promise<T>): Promise<T> {
   const token = await ensureUserAccessToken(ctx);

--- a/frontend/packages/telegram-bot/src/services/dictionary.ts
+++ b/frontend/packages/telegram-bot/src/services/dictionary.ts
@@ -1,11 +1,11 @@
 import type { Context } from 'grammy';
 
-import { getPaths } from '../api/photobank/paths/paths.js';
-import { getPersons } from '../api/photobank/persons/persons.js';
-import { getStorages } from '../api/photobank/storages/storages.js';
-import { getTags } from '../api/photobank/tags/tags.js';
-import { setRequestContext } from '../api/axios-instance.js';
-import { handleServiceError } from '../errorHandler.js';
+import { getPaths } from '../api/photobank/paths/paths';
+import { getPersons } from '../api/photobank/persons/persons';
+import { getStorages } from '../api/photobank/storages/storages';
+import { getTags } from '../api/photobank/tags/tags';
+import { setRequestContext } from '../api/axios-instance';
+import { handleServiceError } from '../errorHandler';
 
 const { pathsGetAll } = getPaths();
 const { personsGetAll } = getPersons();

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -5,9 +5,9 @@ import {
   getPhotos,
   type PhotosGetPhotoResult,
   type PhotosSearchPhotosResult,
-} from '../api/photobank/photos/photos.js';
-import { setRequestContext } from '../api/axios-instance.js';
-import { handleServiceError } from '../errorHandler.js';
+} from '../api/photobank/photos/photos';
+import { setRequestContext } from '../api/axios-instance';
+import { handleServiceError } from '../errorHandler';
 
 const { photosSearchPhotos, photosGetPhoto, photosUpload } = getPhotos();
 

--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -2,11 +2,11 @@ import type { Context } from 'grammy';
 import type { InputMediaPhoto, Message } from 'grammy/types';
 import { formatDate } from '@photobank/shared/format';
 
-import { throttled } from '../utils/limiter.js';
-import { getFileId, setFileId, delFileId } from '../cache/fileIdCache.js';
-import { logger } from '../utils/logger.js';
-import type { PhotoItemDto } from '../types.js';
-import { withTelegramRetry } from '../utils/retry.js';
+import { throttled } from '../utils/limiter';
+import { getFileId, setFileId, delFileId } from '../cache/fileIdCache';
+import { logger } from '../utils/logger';
+import type { PhotoItemDto } from '../types';
+import { withTelegramRetry } from '../utils/retry';
 
 function buildCaption(p: PhotoItemDto): string {
   const parts = [p.name, p.takenDate ? formatDate(p.takenDate) : null];

--- a/frontend/packages/telegram-bot/src/utils/logger.ts
+++ b/frontend/packages/telegram-bot/src/utils/logger.ts
@@ -1,1 +1,1 @@
-export { logger } from '../logger.js';
+export { logger } from '../logger';


### PR DESCRIPTION
## Summary
- remove `.js` extensions from imports in telegram-bot
- drop `.js` suffixes from shared package imports/exports

## Testing
- `pnpm --filter @photobank/shared build`
- `pnpm --filter @photobank/shared test` *(fails: expected localized format values)*
- `pnpm --filter @photobank/telegram-bot exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c1d6345cc8832885b14cd6c562d372