### PR TITLE
fix(telegram-bot): guard invalid subscribe time input

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/subscribe.ts
+++ b/frontend/packages/telegram-bot/src/commands/subscribe.ts
@@ -11,8 +11,10 @@ export const subscriptions = new Map<number, { time: string; locale: string }>()
 export function parseSubscribeTime(text?: string): string | null {
   if (!text) return null;
   const match = text.match(/\/subscribe\s+(\d{1,2}:\d{2})/);
-  if (!match) return null;
-  const [hours, minutes] = match[1].split(":").map(Number);
+  if (!match?.[1]) return null;
+  const [hStr, mStr] = match[1]!.split(":");
+  const hours = Number(hStr);
+  const minutes = Number(mStr);
   if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
   return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
 }


### PR DESCRIPTION
## Summary
- safely parse subscription time

## Testing
- `pnpm lint` *(fails: Error while loading rule '@typescript-eslint/await-thenable')*
- `pnpm --recursive run test` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @photobank/frontend@1.0.0 test: `vitest`)*

------
https://chatgpt.com/codex/tasks/task_e_68c589b554308328bbed662ee2f615d8