### PR TITLE
fix: ensure year map initialized

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -63,8 +63,11 @@ export async function sendPhotosPage({
 
   for (const photo of queryResult.items) {
     const year = photo.takenDate ? new Date(photo.takenDate).getFullYear() : 0;
-    if (!byYear.has(year)) byYear.set(year, new Map());
-    const yearMap = byYear.get(year);
+    let yearMap = byYear.get(year);
+    if (!yearMap) {
+      yearMap = new Map();
+      byYear.set(year, yearMap);
+    }
     const key = `${photo.storageName} / ${photo.relativePath}`;
     if (!yearMap.has(key)) yearMap.set(key, []);
     yearMap.get(key)!.push(photo);


### PR DESCRIPTION
## Summary
- safely initialize year map when grouping photos by year

## Testing
- `pnpm --filter @photobank/telegram-bot typecheck` (fails: TS errors)
- `pnpm --filter @photobank/telegram-bot test`

------
https://chatgpt.com/codex/tasks/task_e_68c589b2eb248328bdff0d8cdf86baec