### PR TITLE
chore: add shared path mapping for telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/tsconfig.json
+++ b/frontend/packages/telegram-bot/tsconfig.json
@@ -6,14 +6,16 @@
     "resolveJsonModule": true,
     "rootDir": "src",
     "outDir": "dist",
-    "composite": false,
+    "composite": true,
     "declaration": true,
     "noEmit": false,
     "moduleDetection": "force",
     "types": ["node"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@photobank/shared": ["../shared/src/index.ts"],
+      "@photobank/shared/*": ["../shared/src/*"]
     }
   },
   "references": [{ "path": "../shared" }],


### PR DESCRIPTION
## Summary
- enable composite project refs and @photobank/shared path mapping in telegram-bot tsconfig

## Testing
- `pnpm run build:types`
- `pnpm --filter @photobank/telegram-bot run typecheck` *(fails: 'yearMap' is possibly 'undefined', etc.)*
- `pnpm test` *(no script found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5891582c4832895b4a789649da85f