### PR TITLE
refactor: build telegram options before sending

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/helpers.ts
+++ b/frontend/packages/telegram-bot/src/commands/helpers.ts
@@ -1,17 +1,19 @@
-import { InlineKeyboard } from "grammy";
+import { InlineKeyboard } from 'grammy';
 
-import type { MyContext } from "../i18n";
-import { logger } from "../logger";
+import type { MyContext } from '../i18n';
+import { logger } from '../logger';
 
 export const PAGE_SIZE = 10;
 
 export function parsePrefix(text?: string): string {
-  if (!text) return "";
-  const parts = text.split(" ");
-  return parts[1]?.trim() ?? "";
+  if (!text) return '';
+  const parts = text.split(' ');
+  return parts[1]?.trim() ?? '';
 }
 
-export interface NamedItem { name: string }
+export interface NamedItem {
+  name: string;
+}
 
 export interface SendPageOptions<T extends NamedItem> {
   ctx: MyContext;
@@ -53,41 +55,48 @@ export async function sendNamedItemsPage<T extends NamedItem>({
   const pageIndex = Math.min(Math.max(page, 1), totalPages);
   const slice = filtered.slice(
     (pageIndex - 1) * PAGE_SIZE,
-    pageIndex * PAGE_SIZE,
+    pageIndex * PAGE_SIZE
   );
 
   const lines = slice.map((i) => `- ${i.name}`);
-  lines.push("", ctx.t('page-info', { page: pageIndex, total: totalPages }));
+  lines.push('', ctx.t('page-info', { page: pageIndex, total: totalPages }));
 
   const keyboard = new InlineKeyboard();
   if (pageIndex > 1) {
     keyboard.text(
       ctx.t('first-page'),
-      `${command}:1:${encodeURIComponent(prefix)}`,
+      `${command}:1:${encodeURIComponent(prefix)}`
     );
     keyboard.text(
       ctx.t('prev-page'),
-      `${command}:${pageIndex - 1}:${encodeURIComponent(prefix)}`,
+      `${command}:${pageIndex - 1}:${encodeURIComponent(prefix)}`
     );
   }
   if (pageIndex < totalPages) {
     keyboard.text(
       ctx.t('next-page'),
-      `${command}:${pageIndex + 1}:${encodeURIComponent(prefix)}`,
+      `${command}:${pageIndex + 1}:${encodeURIComponent(prefix)}`
     );
     keyboard.text(
       ctx.t('last-page'),
-      `${command}:${totalPages}:${encodeURIComponent(prefix)}`,
+      `${command}:${totalPages}:${encodeURIComponent(prefix)}`
     );
   }
 
-  const text = lines.join("\n");
+  const text = lines.join('\n');
+
+  const replyOptions: Parameters<typeof ctx.reply>[1] = {};
+  const editOptions: Parameters<typeof ctx.editMessageText>[1] = {};
+  if (keyboard.inline_keyboard.length) {
+    replyOptions.reply_markup = keyboard;
+    editOptions.reply_markup = keyboard;
+  }
 
   if (edit) {
     await ctx
-      .editMessageText(text, { reply_markup: keyboard })
-      .catch(() => ctx.reply(text, { reply_markup: keyboard }));
+      .editMessageText(text, editOptions)
+      .catch(() => ctx.reply(text, replyOptions));
   } else {
-    await ctx.reply(text, { reply_markup: keyboard });
+    await ctx.reply(text, replyOptions);
   }
 }

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -6,114 +6,143 @@ import type { MyContext } from './i18n';
 import { getPhoto } from './services/photo';
 
 export const photoMessages = new Map<number, number>();
-export const currentPagePhotos = new Map<number, { page: number; ids: number[] }>();
+export const currentPagePhotos = new Map<
+  number,
+  { page: number; ids: number[] }
+>();
 export const captionCache = new Map<number, string>();
 
 export async function deletePhotoMessage(ctx: MyContext) {
-    const chatId = ctx.chat?.id;
-    const messageId = chatId ? photoMessages.get(chatId) : undefined;
-    if (chatId && messageId) {
-        try {
-            await ctx.api.deleteMessage(chatId, messageId);
-        } catch {
-            // ignore
-        }
-        photoMessages.delete(chatId);
+  const chatId = ctx.chat?.id;
+  const messageId = chatId ? photoMessages.get(chatId) : undefined;
+  if (chatId && messageId) {
+    try {
+      await ctx.api.deleteMessage(chatId, messageId);
+    } catch {
+      // ignore
     }
+    photoMessages.delete(chatId);
+  }
 }
 
-async function fetchPhoto(ctx: MyContext, id: number): Promise<PhotoDto | null> {
-    try {
-        const photo = await getPhoto(ctx, id);
-        return photo;
-    } catch {
-        return null;
-    }
+async function fetchPhoto(
+  ctx: MyContext,
+  id: number
+): Promise<PhotoDto | null> {
+  try {
+    const photo = await getPhoto(ctx, id);
+    return photo;
+  } catch {
+    return null;
+  }
 }
 
 export async function sendPhotoById(ctx: MyContext, id: number) {
-    let photo: PhotoDto;
+  let photo: PhotoDto;
 
-    try {
-        photo = await getPhoto(ctx, id);
-    } catch {
-        await ctx.reply(ctx.t('photo-not-found'));
-        return;
-    }
+  try {
+    photo = await getPhoto(ctx, id);
+  } catch {
+    await ctx.reply(ctx.t('photo-not-found'));
+    return;
+  }
 
-    const { caption, hasSpoiler, imageUrl } = formatPhotoMessage(photo);
+  const { caption, hasSpoiler, imageUrl } = formatPhotoMessage(photo);
 
-    if (imageUrl) {
-        await ctx.replyWithPhoto(imageUrl, {
-            caption,
-            parse_mode: "HTML",
-            has_spoiler: hasSpoiler,
-        });
-    } else {
-        await ctx.reply(caption, { parse_mode: "HTML" });
-    }
+  if (imageUrl) {
+    await ctx.replyWithPhoto(imageUrl, {
+      caption,
+      parse_mode: 'HTML',
+      has_spoiler: hasSpoiler,
+    });
+  } else {
+    await ctx.reply(caption, { parse_mode: 'HTML' });
+  }
 }
 
 export async function openPhotoInline(ctx: MyContext, id: number) {
-    const chatId = ctx.chat?.id;
-    const photo = await fetchPhoto(ctx, id);
-    if (!photo) {
-        await ctx.reply(ctx.t('photo-not-found'));
-        return;
+  const chatId = ctx.chat?.id;
+  const photo = await fetchPhoto(ctx, id);
+  if (!photo) {
+    await ctx.reply(ctx.t('photo-not-found'));
+    return;
+  }
+
+  const { caption, hasSpoiler, imageUrl } = formatPhotoMessage(photo);
+
+  let keyboard: InlineKeyboard | undefined;
+  if (chatId) {
+    const list = currentPagePhotos.get(chatId);
+    if (list) {
+      const index = list.ids.indexOf(id);
+      keyboard = new InlineKeyboard();
+      if (index > 0)
+        keyboard.text(ctx.t('prev-page'), `photo_nav:${list.ids[index - 1]}`);
+      if (index < list.ids.length - 1)
+        keyboard.text(ctx.t('next-page'), `photo_nav:${list.ids[index + 1]}`);
+      if (!keyboard.inline_keyboard.length) keyboard = undefined;
     }
+  }
 
-    const { caption, hasSpoiler, imageUrl } = formatPhotoMessage(photo);
-
-    let keyboard: InlineKeyboard | undefined;
-    if (chatId) {
-        const list = currentPagePhotos.get(chatId);
-        if (list) {
-            const index = list.ids.indexOf(id);
-            keyboard = new InlineKeyboard();
-            if (index > 0) keyboard.text(ctx.t('prev-page'), `photo_nav:${list.ids[index - 1]}`);
-            if (index < list.ids.length - 1) keyboard.text(ctx.t('next-page'), `photo_nav:${list.ids[index + 1]}`);
-            if (!keyboard.inline_keyboard.length) keyboard = undefined;
-        }
-    }
-
-    if (!chatId) {
-        if (imageUrl) {
-            await ctx.replyWithPhoto(imageUrl, { caption, parse_mode: "HTML", reply_markup: keyboard, has_spoiler: hasSpoiler });
-        } else {
-            await ctx.reply(caption, { parse_mode: "HTML", reply_markup: keyboard });
-        }
-        return;
-    }
-
-    const existing = photoMessages.get(chatId);
-    if (existing) {
-        try {
-            if (imageUrl) {
-                await ctx.api.editMessageMedia(
-                    chatId,
-                    existing,
-                    {
-                        type: "photo",
-                        media: imageUrl,
-                        caption,
-                        parse_mode: "HTML",
-                    },
-                    { reply_markup: keyboard }
-                );
-            } else {
-                await ctx.api.editMessageCaption(chatId, existing, { caption, parse_mode: "HTML" });
-            }
-            return;
-        } catch {
-            photoMessages.delete(chatId);
-        }
-    }
-
+  if (!chatId) {
     if (imageUrl) {
-        const msg = await ctx.replyWithPhoto(imageUrl, { caption, parse_mode: "HTML", reply_markup: keyboard, has_spoiler: hasSpoiler });
-        photoMessages.set(chatId, msg.message_id);
+      const options: Parameters<typeof ctx.replyWithPhoto>[1] = {
+        caption,
+        parse_mode: 'HTML',
+        has_spoiler: hasSpoiler,
+      };
+      if (keyboard) options.reply_markup = keyboard;
+      await ctx.replyWithPhoto(imageUrl, options);
     } else {
-        const msg = await ctx.reply(caption, { parse_mode: "HTML", reply_markup: keyboard });
-        photoMessages.set(chatId, msg.message_id);
+      const options: Parameters<typeof ctx.reply>[1] = { parse_mode: 'HTML' };
+      if (keyboard) options.reply_markup = keyboard;
+      await ctx.reply(caption, options);
     }
+    return;
+  }
+
+  const existing = photoMessages.get(chatId);
+  if (existing) {
+    try {
+      if (imageUrl) {
+        const options: Parameters<typeof ctx.api.editMessageMedia>[3] = {};
+        if (keyboard) options.reply_markup = keyboard;
+        await ctx.api.editMessageMedia(
+          chatId,
+          existing,
+          {
+            type: 'photo',
+            media: imageUrl,
+            caption,
+            parse_mode: 'HTML',
+          },
+          options
+        );
+      } else {
+        await ctx.api.editMessageCaption(chatId, existing, {
+          caption,
+          parse_mode: 'HTML',
+        });
+      }
+      return;
+    } catch {
+      photoMessages.delete(chatId);
+    }
+  }
+
+  if (imageUrl) {
+    const options: Parameters<typeof ctx.replyWithPhoto>[1] = {
+      caption,
+      parse_mode: 'HTML',
+      has_spoiler: hasSpoiler,
+    };
+    if (keyboard) options.reply_markup = keyboard;
+    const msg = await ctx.replyWithPhoto(imageUrl, options);
+    photoMessages.set(chatId, msg.message_id);
+  } else {
+    const options: Parameters<typeof ctx.reply>[1] = { parse_mode: 'HTML' };
+    if (keyboard) options.reply_markup = keyboard;
+    const msg = await ctx.reply(caption, options);
+    photoMessages.set(chatId, msg.message_id);
+  }
 }


### PR DESCRIPTION
## Summary
- build telegram bot message options without reply_markup
- attach keyboards only when available

## Testing
- `pnpm lint` *(fails: Error while loading rule '@typescript-eslint/await-thenable')*
- `pnpm --filter @photobank/telegram-bot exec vitest run` *(fails: Cannot find module '@photobank/shared/api/photobank/msw')*

------
https://chatgpt.com/codex/tasks/task_e_68c58b7ad1548328b9be772772640501