### PR TITLE
fix: handle ProblemDetailsError safely

### DIFF
--- a/frontend/packages/telegram-bot/src/errorHandler.ts
+++ b/frontend/packages/telegram-bot/src/errorHandler.ts
@@ -12,9 +12,11 @@ export function handleBotError(err: BotError<Context>) {
 }
 
 export async function handleCommandError(ctx: MyContext, error: unknown) {
-    if (error instanceof ProblemDetailsError && (error).problem.status === 403) {
-      await ctx.reply(ctx.t('not-registered', { userId: ctx.from?.id ?? 0 }));
-      return;
+  let forbidden = false;
+  if (error instanceof ProblemDetailsError) forbidden = error.problem.status === 403;
+  if (forbidden) {
+    await ctx.reply(ctx.t('not-registered', { userId: ctx.from?.id ?? 0 }));
+    return;
   }
   logger.error(apiErrorMsg, error);
   await ctx.reply(ctx.t('sorry-try-later'));

--- a/frontend/packages/telegram-bot/src/handlers/deeplink.ts
+++ b/frontend/packages/telegram-bot/src/handlers/deeplink.ts
@@ -14,11 +14,12 @@ bot.on('message', async (ctx: MyContext, next) => {
       try {
         await ensureUserAccessToken(ctx);
         await ctx.reply(ctx.t('start-linked'));
-      } catch (e) {
-        const forbidden = e instanceof ProblemDetailsError && e.problem.status === 403;
+      } catch (e: unknown) {
+        let forbidden = false;
+        if (e instanceof ProblemDetailsError) forbidden = e.problem.status === 403;
         await ctx.reply(
           forbidden
-            ? ctx.t('not-registered', { userId: ctx.from?.id })
+            ? ctx.t('not-registered', { userId: ctx.from?.id ?? 0 })
             : ctx.t('sorry-try-later')
         );
       }

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -18,7 +18,7 @@ bot.on('inline_query', async (ctx: MyContext) => {
   // Авторизация для inline: если нет — мягко предлагаем /start link
   try {
     await ensureUserAccessToken(ctx);
-  } catch {
+  } catch (e: unknown) {
     await ctx.answerInlineQuery(
       [],
       {
@@ -76,8 +76,10 @@ bot.on('inline_query', async (ctx: MyContext) => {
         next_offset: nextOffset,
       } satisfies Parameters<typeof ctx.answerInlineQuery>[1],
     );
-  } catch (e) {
-    if (e instanceof ProblemDetailsError && e.problem.status === 403) {
+  } catch (e: unknown) {
+    let forbidden = false;
+    if (e instanceof ProblemDetailsError) forbidden = e.problem.status === 403;
+    if (forbidden) {
       await ctx.answerInlineQuery(
         [],
         {

--- a/frontend/packages/telegram-bot/src/registration.ts
+++ b/frontend/packages/telegram-bot/src/registration.ts
@@ -8,12 +8,14 @@ export async function ensureRegistered(ctx: MyContext): Promise<boolean> {
   try {
     await ensureUserAccessToken(ctx);
     return true;
-  } catch (err) {
-    if (err instanceof ProblemDetailsError && err.problem.status === 403) {
-      await ctx.reply(ctx.t('not-registered', { userId: ctx.from?.id ?? 0 }));
-    } else {
-      await ctx.reply(ctx.t('not-registered', { userId: ctx.from?.id ?? 0 }));
-    }
+  } catch (e: unknown) {
+    let forbidden = false;
+    if (e instanceof ProblemDetailsError) forbidden = e.problem.status === 403;
+    await ctx.reply(
+      forbidden
+        ? ctx.t('not-registered', { userId: ctx.from?.id ?? 0 })
+        : ctx.t('sorry-try-later')
+    );
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- improve error handling across telegram-bot to safely narrow ProblemDetailsError before accessing `.problem`
- default to `ctx.from?.id ?? 0` in translation variables

## Testing
- `pnpm vitest run` *(fails: Cannot find module '@photobank/shared/api/photobank/msw')*


------
https://chatgpt.com/codex/tasks/task_e_68c58b5e35fc8328ac0c167978969955