### PR TITLE
fix: use shared package imports

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -1,6 +1,5 @@
 import { InlineKeyboard } from 'grammy';
-import type { FilterDto } from '@photobank/shared/api/photobank';
-import { firstNWords } from '@photobank/shared/';
+import { firstNWords, type FilterDto } from '@photobank/shared';
 
 import type { MyContext } from '../i18n';
 import { searchPhotos } from '../services/photo';

--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -1,5 +1,4 @@
-import type { PhotoDto } from "@photobank/shared/api/photobank";
-import { formatDate } from "@photobank/shared/";
+import { formatDate, type PhotoDto } from "@photobank/shared";
 
 import { getPersonName } from "./dictionaries";
 


### PR DESCRIPTION
## Summary
- import types and helpers from `@photobank/shared`

## Testing
- `pnpm --filter @photobank/telegram-bot typecheck` *(fails: Type '{ caption: string | undefined; ... }' is not assignable to type 'FilterDto')*
- `pnpm test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c58dcc5fe48328a1536ae52eab3d9f