### PR TITLE
refactor: type unknown in catch blocks

### DIFF
--- a/frontend/packages/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/packages/frontend/src/pages/auth/RegisterPage.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { useAuthRegister } from '@photobank/shared/api/photobank';
 import { logger } from '@photobank/shared/utils/logger';
 import { useTranslation } from 'react-i18next';
+import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
 import { Button } from '@/shared/ui/button';
 import {
@@ -39,8 +40,9 @@ export default function RegisterPage() {
     try {
       await register({ data });
       navigate('/login');
-    } catch (e) {
-      logger.error(e);
+    } catch (e: unknown) {
+      if (e instanceof ProblemDetailsError) logger.error(e.problem);
+      else logger.error(e);
       setErrorMessage('Failed to register');
     }
   };

--- a/frontend/packages/frontend/src/pages/openai/OpenAIPage.tsx
+++ b/frontend/packages/frontend/src/pages/openai/OpenAIPage.tsx
@@ -45,7 +45,7 @@ export default function OpenAIPage() {
       const reply = await parseQueryWithOpenAI(input);
       const aiMsg: ChatMessage = { role: 'assistant', content: JSON.stringify(reply, null, 2) };
       setMessages(() => [...newMessages, aiMsg]);
-    } catch (err) {
+    } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       setError(message);
     } finally {

--- a/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
+++ b/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
@@ -7,6 +7,7 @@ import { setAuthToken } from '@photobank/shared/auth';
 import { logger } from '@photobank/shared/utils/logger';
 import { useTranslation } from 'react-i18next';
 import { useAuthGetUser, useAuthUpdateUser } from '@photobank/shared/api/photobank';
+import { ProblemDetailsError } from '@photobank/shared/types/problem';
 
 import {Button} from '@/shared/ui/button';
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/shared/ui/form';
@@ -51,8 +52,9 @@ export default function MyProfilePage() {
         },
       });
       navigate('/filter');
-    } catch (e) {
-      logger.error(e);
+    } catch (e: unknown) {
+      if (e instanceof ProblemDetailsError) logger.error(e.problem);
+      else logger.error(e);
     }
   };
 

--- a/frontend/packages/shared/src/api/photobank/fetcher.ts
+++ b/frontend/packages/shared/src/api/photobank/fetcher.ts
@@ -106,11 +106,12 @@ export async function customFetcher<T>(url: string, init?: RequestInit): Promise
           continue;
         }
         throw err;
-      } catch (e: any) {
+      } catch (e: unknown) {
+        const err = e as { name?: string; code?: string; message?: string };
         const isAbort =
-          e?.name === 'AbortError' ||
-          e?.code === 'ABORT_ERR' ||
-          (typeof e?.message === 'string' && /aborted/i.test(e.message));
+          err?.name === 'AbortError' ||
+          err?.code === 'ABORT_ERR' ||
+          (typeof err?.message === 'string' && /aborted/i.test(err.message));
         if (isAbort) throw e;
 
         const isNetwork = e instanceof TypeError;

--- a/frontend/packages/telegram-bot/src/api/axios-instance.ts
+++ b/frontend/packages/telegram-bot/src/api/axios-instance.ts
@@ -27,7 +27,7 @@ export async function photobankAxios<T>(config: AxiosRequestConfig, ctx?: Contex
 
   try {
     return await doRequest(false);
-  } catch (error) {
+  } catch (error: unknown) {
     const status = axios.isAxiosError(error) ? error.response?.status : undefined;
     if (status === 401 || status === 403) {
       invalidateUserToken(context);

--- a/frontend/packages/telegram-bot/src/commands/ai.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.ts
@@ -64,7 +64,7 @@ export async function aiCommand(ctx: MyContext, promptOverride?: string) {
     aiFilters.set(hash, dto);
 
     await sendAiPage(ctx, hash, 1);
-  } catch (err) {
+  } catch (err: unknown) {
     logger.error(err);
     await ctx.reply(ctx.t('sorry-try-later'));
   }

--- a/frontend/packages/telegram-bot/src/commands/helpers.ts
+++ b/frontend/packages/telegram-bot/src/commands/helpers.ts
@@ -39,7 +39,7 @@ export async function sendNamedItemsPage<T extends NamedItem>({
   let items: T[];
   try {
     items = await fetchAll();
-  } catch (err) {
+  } catch (err: unknown) {
     logger.error(err);
     await ctx.reply(errorMsg);
     return;

--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -41,7 +41,7 @@ export async function sendPhotosPage({
       top: PHOTOS_PAGE_SIZE,
       skip,
     });
-  } catch (err) {
+  } catch (err: unknown) {
     await handleCommandError(ctx, err);
     return;
   }

--- a/frontend/packages/telegram-bot/src/commands/upload.ts
+++ b/frontend/packages/telegram-bot/src/commands/upload.ts
@@ -53,7 +53,7 @@ export async function uploadCommand(ctx: MyContext) {
     });
 
     await ctx.reply(ctx.t('upload-success'));
-  } catch (err) {
+  } catch (err: unknown) {
     await ctx.reply(ctx.t('upload-failed'));
     await handleCommandError(ctx, err);
   }

--- a/frontend/packages/telegram-bot/src/services/dictionary.ts
+++ b/frontend/packages/telegram-bot/src/services/dictionary.ts
@@ -16,7 +16,7 @@ export async function fetchTags(ctx: Context) {
   try {
     setRequestContext(ctx);
     return await tagsGetAll();
-  } catch (err) {
+  } catch (err: unknown) {
     handleServiceError(err);
     throw err;
   }
@@ -26,7 +26,7 @@ export async function fetchPersons(ctx: Context) {
   try {
     setRequestContext(ctx);
     return await personsGetAll();
-  } catch (err) {
+  } catch (err: unknown) {
     handleServiceError(err);
     throw err;
   }
@@ -36,7 +36,7 @@ export async function fetchStorages(ctx: Context) {
   try {
     setRequestContext(ctx);
     return await storagesGetAll();
-  } catch (err) {
+  } catch (err: unknown) {
     handleServiceError(err);
     throw err;
   }
@@ -46,7 +46,7 @@ export async function fetchPaths(ctx: Context) {
   try {
     setRequestContext(ctx);
     return await pathsGetAll();
-  } catch (err) {
+  } catch (err: unknown) {
     handleServiceError(err);
     throw err;
   }

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -18,7 +18,7 @@ export async function searchPhotos(
   try {
     setRequestContext(ctx);
     return await photosSearchPhotos(filter as FilterDto);
-  } catch (err) {
+  } catch (err: unknown) {
     handleServiceError(err);
     throw err;
   }
@@ -31,7 +31,7 @@ export async function getPhoto(
   try {
     setRequestContext(ctx);
     return await photosGetPhoto(id);
-  } catch (err) {
+  } catch (err: unknown) {
     handleServiceError(err);
     throw err;
   }
@@ -48,7 +48,7 @@ export async function uploadPhotos(
   try {
     setRequestContext(ctx);
     return await photosUpload({ files: blobs, storageId, path });
-  } catch (err) {
+  } catch (err: unknown) {
     handleServiceError(err);
     throw err;
   }

--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -106,7 +106,7 @@ export async function sendAlbumSmart(ctx: Context, photos: PhotoItemDto[]) {
         try {
           const msg = await sendPhotoSmart(ctx, p);
           results.push(msg);
-        } catch (inner) {
+        } catch (inner: unknown) {
           // if even single send fails—log and continue
           logger.error('single send failed', inner);
         }

--- a/frontend/packages/tv/hooks/useAutoLogin.ts
+++ b/frontend/packages/tv/hooks/useAutoLogin.ts
@@ -16,7 +16,7 @@ export function useAutoLogin() {
         });
         setAuthToken(res.data.token!, true);
         logger.debug('Login success');
-      } catch (e) {
+      } catch (e: unknown) {
         logger.error('Login failed', e);
       }
     }


### PR DESCRIPTION
## Summary
- annotate catch clauses with `unknown`
- guard ProblemDetailsError before accessing `.problem`
- handle unknown errors in shared fetcher and UI pages

## Testing
- `pnpm --filter @photobank/shared build` *(fails: None of the selected packages has a "build" script)*
- `pnpm run test --filter @photobank/shared` *(fails: Missing script: test)*
- `pnpm --filter @photobank/frontend test` *(fails: vi configuration error)*
- `pnpm run test --filter @photobank/telegram-bot` *(fails: Missing script: test)*
- `pnpm run test --filter photobanktv` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68c58ede38448328b72dc04a793fc00c