### PR TITLE
fix: handle 403 errors in command error handler

### DIFF
--- a/frontend/packages/telegram-bot/src/errorHandler.ts
+++ b/frontend/packages/telegram-bot/src/errorHandler.ts
@@ -12,12 +12,11 @@ export function handleBotError(err: BotError<Context>) {
 }
 
 export async function handleCommandError(ctx: MyContext, error: unknown) {
-  let forbidden = false;
-  if (error instanceof ProblemDetailsError) forbidden = error.problem.status === 403;
-  if (forbidden) {
+  if (error instanceof ProblemDetailsError && error.problem.status === 403) {
     await ctx.reply(ctx.t('not-registered', { userId: ctx.from?.id ?? 0 }));
     return;
   }
+
   logger.error(apiErrorMsg, error);
   await ctx.reply(ctx.t('sorry-try-later'));
 }

--- a/frontend/packages/telegram-bot/test/errorHandler.test.ts
+++ b/frontend/packages/telegram-bot/test/errorHandler.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ProblemDetailsError } from '@photobank/shared/types/problem';
+import { apiErrorMsg } from '@photobank/shared/constants';
+
+import { handleCommandError } from '../src/errorHandler';
+import { i18n } from '../src/i18n';
+import { logger } from '../src/logger';
+
+describe('handleCommandError', () => {
+  it('handles forbidden error', async () => {
+    const ctx: any = {
+      reply: vi.fn(),
+      from: { id: 42 },
+      t: (k: string, params?: any) => i18n.t('en', k, params),
+    };
+    const error = new ProblemDetailsError({ title: 'forbidden', status: 403 });
+
+    await handleCommandError(ctx, error);
+
+    expect(ctx.reply).toHaveBeenCalledWith(
+      i18n.t('en', 'not-registered', { userId: 42 }),
+    );
+  });
+
+  it('logs generic errors', async () => {
+    const ctx: any = {
+      reply: vi.fn(),
+      from: { id: 42 },
+      t: (k: string, params?: any) => i18n.t('en', k, params),
+    };
+    const error = new Error('oops');
+    const spy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    await handleCommandError(ctx, error);
+
+    expect(spy).toHaveBeenCalledWith(apiErrorMsg, error);
+    expect(ctx.reply).toHaveBeenCalledWith(i18n.t('en', 'sorry-try-later'));
+
+    spy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- handle 403 ProblemDetails in command error handler
- add tests for command error handler

## Testing
- `pnpm --filter @photobank/telegram-bot exec vitest run` *(fails: Cannot find module '@photobank/shared/api/photobank/msw')*


------
https://chatgpt.com/codex/tasks/task_e_68c5929f68408328a194cb010a8df529