### PR TITLE
chore: enable TypeScript build mode

### DIFF
--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -53,7 +53,7 @@
     "dist"
   ],
   "scripts": {
-    "build:types": "rimraf dist && tsc -p tsconfig.json --emitDeclarationOnly",
+    "build:types": "rimraf dist && tsc -b",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": ["dist"],
   "scripts": {
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -b",
     "build": "pnpm run typecheck && tsup",
     "dev": "tsup --watch --onSuccess \"node dist/index.js\"",
     "start": "node dist/index.js"

--- a/frontend/packages/telegram-bot/tsconfig.json
+++ b/frontend/packages/telegram-bot/tsconfig.json
@@ -7,15 +7,12 @@
     "rootDir": "src",
     "outDir": "dist",
     "composite": true,
-    "declaration": true,
-    "noEmit": false,
+    "noEmit": true,
     "moduleDetection": "force",
     "types": ["node"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@photobank/shared": ["../shared/src/index.ts"],
-      "@photobank/shared/*": ["../shared/src/*"]
+      "@/*": ["src/*"]
     }
   },
   "references": [{ "path": "../shared" }],


### PR DESCRIPTION
## Summary
- build shared types via `tsc -b`
- type-check telegram bot with project build mode
- stop telegram bot from emitting JS and remove direct shared path mappings

## Testing
- `pnpm build:types` (packages/shared)
- `pnpm test` (packages/shared) *(fails: Missing script)*
- `pnpm typecheck` (packages/telegram-bot) *(fails: TypeScript errors)*
- `pnpm test` (packages/telegram-bot) *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c0f2abd88328bd0f20cbda25aa32