### PR TITLE
fix: add missing breaks in search parser

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/search.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.ts
@@ -165,6 +165,7 @@ function parseArgsToFilter(raw: string): FilterDto {
             .forEach((x) => {
               if (x && !tagNames.includes(x)) tagNames.push(x);
             });
+          break;
         }
         case 'person':
         case 'people': {
@@ -174,19 +175,23 @@ function parseArgsToFilter(raw: string): FilterDto {
             .forEach((x) => {
               if (x && !personNames.includes(x)) personNames.push(x);
             });
+          break;
         }
         case 'date': {
           const { from, to } = parseDateExpr(val ?? '');
           if (from) takenDateFrom = from;
           if (to) takenDateTo = to;
+          break;
         }
         case 'before': {
           const { to } = parseBefore(val);
           if (to) takenDateTo = to;
+          break;
         }
         case 'after': {
           const { from } = parseAfter(val);
           if (from) takenDateFrom = from;
+          break;
         }
         default:
           rest.push(t);
@@ -216,7 +221,7 @@ function parseArgsToFilter(raw: string): FilterDto {
       : undefined,
     takenDateFrom,
     takenDateTo,
-  };
+  } as FilterDto;
 }
 
 /* ===================== callback_data кодек ===================== */

--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -3,36 +3,36 @@ import { formatDate, type PhotoDto } from "@photobank/shared";
 import { getPersonName } from "./dictionaries";
 
 export function formatPhotoMessage(photo: PhotoDto): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
-    const lines: string[] = [];
+  const lines: string[] = [];
 
-    lines.push(`📸 <b>${photo.name}</b>`);
-    if (photo.takenDate) {
-        lines.push(`📅 ${formatDate(photo.takenDate)}`);
+  lines.push(`📸 <b>${photo.name}</b>`);
+  if (photo.takenDate) {
+    lines.push(`📅 ${formatDate(photo.takenDate)}`);
+  }
+
+  // lines.push(`📏 ${photo.width}×${photo.height}`);
+
+  if (photo.captions?.[0]) lines.push(`📝 ${photo.captions[0]}`);
+  if (photo.tags?.length) lines.push(`🏷️ ${photo.tags.join(", ")}`);
+
+  if (photo.location) {
+    const { latitude, longitude } = photo.location;
+    const coords = `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
+    lines.push(`📍 <a href="https://www.google.com/maps?q=${latitude},${longitude}">${coords}</a>`);
+  }
+
+  if (photo.faces?.length) {
+    const people = photo.faces.map((f: { personId?: number | null }) => getPersonName(f.personId ?? null));
+    if (people.some(Boolean)) {
+      lines.push(`👤 ${people.join(", ")}`);
     }
+  }
 
-    // lines.push(`📏 ${photo.width}×${photo.height}`);
+  const imageUrl = photo.previewUrl ?? undefined;
 
-    if (photo.captions?.[0]) lines.push(`📝 ${photo.captions[0]}`);
-    if (photo.tags?.length) lines.push(`🏷️ ${photo.tags.join(", ")}`);
-
-    if (photo.location) {
-        const { latitude, longitude } = photo.location;
-        const coords = `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
-        lines.push(`📍 <a href="https://www.google.com/maps?q=${latitude},${longitude}">${coords}</a>`);
-    }
-
-    if (photo.faces?.length) {
-        const people = photo.faces.map((f: { personId?: number | null }) => getPersonName(f.personId ?? null));
-        if (people.some(Boolean)) {
-            lines.push(`👤 ${people.join(", ")}`);
-        }
-    }
-
-    const imageUrl = photo.previewUrl ?? undefined;
-
-    return {
-        caption: lines.join("\n"),
-        hasSpoiler: photo.adultScore > 0.5 || photo.racyScore > 0.5,
-        imageUrl,
-    };
+  return {
+    caption: lines.join("\n"),
+    hasSpoiler: (photo.adultScore ?? 0) > 0.5 || (photo.racyScore ?? 0) > 0.5,
+    ...(imageUrl ? { imageUrl } : {}),
+  };
 }

--- a/frontend/packages/telegram-bot/src/telegram/send.ts
+++ b/frontend/packages/telegram-bot/src/telegram/send.ts
@@ -90,7 +90,7 @@ export async function sendAlbumSmart(ctx: Context, photos: PhotoItemDto[]) {
       msgs.forEach((m, i) => {
         const p = group[i];
         const id = m.photo?.at(-1)?.file_id;
-        if (id) setFileId(p.id, id);
+        if (p && id) setFileId(p.id, id);
       });
       results.push(...msgs);
     } catch (e: unknown) {


### PR DESCRIPTION
## Summary
- add break statements to `parseArgsToFilter` switch
- fix strict optional checks in photo formatting and sending helpers

## Testing
- `pnpm --filter @photobank/telegram-bot run typecheck`
- `pnpm --filter @photobank/telegram-bot test` *(fails: missing script? no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c577b848832894690f2fc200d252