### PR TITLE
test: add vitest scripts to telegram bot package

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -11,6 +11,8 @@
     "typecheck": "tsc -b",
     "build": "pnpm run typecheck && tsup",
     "dev": "tsup --watch --onSuccess \"node dist/index.js\"",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "start": "node dist/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add vitest test and watch scripts to telegram bot package
- verify vitest is available in devDependencies

## Testing
- `pnpm --filter @photobank/telegram-bot test` *(fails: Cannot find module '@photobank/shared/api/photobank/msw')*

------
https://chatgpt.com/codex/tasks/task_e_68c5c7ebb3c08328bf4686b7a34c1d44