### PR TITLE
chore: add vitest scripts to shared package

### DIFF
--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -54,7 +54,9 @@
   ],
   "scripts": {
     "build:types": "rimraf dist && tsc -b",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "axios": "^1.11.0",


### PR DESCRIPTION
## Summary
- add vitest run scripts to shared package

## Testing
- `pnpm --filter @photobank/shared run build:types`
- `pnpm --filter @photobank/shared test` *(fails: Cannot find module './src/api/photobank/msw')*


------
https://chatgpt.com/codex/tasks/task_e_68c5c7d883dc832892339bf419488604