### PR TITLE
fix: handle OpenAI request errors

### DIFF
--- a/frontend/packages/shared/src/ai/__tests__/openai.spec.ts
+++ b/frontend/packages/shared/src/ai/__tests__/openai.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '../../utils/logger';
+
+const mockCreate = vi.fn();
+
+vi.mock('openai', () => ({
+  AzureOpenAI: vi.fn().mockImplementation(() => ({
+    chat: { completions: { create: mockCreate } },
+  })),
+}));
+
+import { configureAzureOpenAI, createChatCompletion, parseQueryWithOpenAI } from '../openai';
+
+describe('openai error handling', () => {
+  const loggerSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+  beforeEach(() => {
+    mockCreate.mockReset();
+    loggerSpy.mockClear();
+    configureAzureOpenAI({
+      endpoint: 'test',
+      apiKey: 'key',
+      deployment: 'deploy',
+      apiVersion: 'v1',
+    });
+  });
+
+  it('createChatCompletion throws friendly error when request fails', async () => {
+    const err = new Error('network');
+    mockCreate.mockRejectedValueOnce(err);
+
+    await expect(createChatCompletion('hi')).rejects.toThrow('OpenAI request failed');
+    expect(loggerSpy).toHaveBeenCalledWith(err);
+  });
+
+  it('parseQueryWithOpenAI throws friendly error when request fails', async () => {
+    const err = new Error('oops');
+    mockCreate.mockRejectedValueOnce(err);
+
+    await expect(parseQueryWithOpenAI('query')).rejects.toThrow('OpenAI request failed');
+    expect(loggerSpy).toHaveBeenCalledWith(err);
+  });
+});


### PR DESCRIPTION
## Summary
- log and rethrow friendly errors when Azure OpenAI chat completions fail
- add tests for createChatCompletion and parseQueryWithOpenAI error handling

## Testing
- `pnpm build:types`
- `pnpm test src/ai/__tests__/openai.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c679c854648328afb36773b119c9c8