### PR TITLE
fix: use built shared outputs

### DIFF
--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -10,41 +10,39 @@
     "./safeStorage": "./src/safeStorage.ts",
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./src/index.ts"
+      "default": "./dist/index.js"
     },
     "./index": {
       "types": "./dist/index.d.ts",
-      "default": "./src/index.ts"
+      "default": "./dist/index.js"
     },
-
     "./format": {
       "types": "./dist/format/index.d.ts",
-      "default": "./src/format/index.ts"
+      "default": "./dist/format/index.js"
     },
     "./ai/openai": {
       "types": "./dist/ai/openai.d.ts",
-      "default": "./src/ai/openai.ts"
+      "default": "./dist/ai/openai.js"
     },
     "./types/problem": {
       "types": "./dist/types/problem.d.ts",
-      "default": "./src/types/problem.ts"
+      "default": "./dist/types/problem.js"
     },
     "./constants": {
       "types": "./dist/constants.d.ts",
-      "default": "./src/constants.ts"
+      "default": "./dist/constants.js"
     },
     "./utils/logger": {
       "types": "./dist/utils/logger.d.ts",
-      "default": "./src/utils/logger.ts"
+      "default": "./dist/utils/logger.js"
     },
-
     "./api/photobank": {
       "types": "./dist/api/photobank/index.d.ts",
-      "default": "./src/api/photobank/index.ts"
+      "default": "./dist/api/photobank/index.js"
     },
     "./api/photobank/*": {
       "types": "./dist/api/photobank/*.d.ts",
-      "default": "./src/api/photobank/*.ts"
+      "default": "./dist/api/photobank/*.js"
     }
   },
   "main": "dist/index.js",

--- a/frontend/packages/telegram-bot/tsconfig.json
+++ b/frontend/packages/telegram-bot/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
-    "rootDir": "src",
+    "rootDir": ".",
     "outDir": "dist",
     "composite": true,
     "noEmit": true,
@@ -15,6 +15,10 @@
       "@/*": ["src/*"]
     }
   },
-  "references": [{ "path": "../shared" }],
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- point shared package exports to built `dist` files
- widen Telegram bot `tsconfig` `rootDir` so shared types resolve

## Testing
- `pnpm --filter @photobank/shared run build:types`
- `pnpm --filter @photobank/shared run test` *(fails: Failed to resolve import "./src/api/photobank/msw" from "test-setup.ts".)*
- `pnpm --filter @photobank/telegram-bot run build` *(fails: Could not resolve modules from @photobank/shared)*
- `pnpm --filter @photobank/telegram-bot run test`


------
https://chatgpt.com/codex/tasks/task_e_68c6a7ca965483288315deb7c8036091