### PR TITLE
chore: run shared type build before bot typecheck

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": ["dist"],
   "scripts": {
+    "pretypecheck": "pnpm --filter @photobank/shared run build:types",
     "typecheck": "tsc -b",
     "build": "pnpm run typecheck && tsup",
     "dev": "tsup --watch --onSuccess \"node dist/index.js\"",


### PR DESCRIPTION
## Summary
- ensure telegram-bot builds shared types before type checking

## Testing
- `pnpm --filter @photobank/telegram-bot test`
- `pnpm run build:bot` *(fails: Could not resolve "@photobank/shared/..." during tsup build)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ad32cbe08328a98932c6b457ad43