### PR TITLE
fix: narrow ProblemDetailsError access

### DIFF
--- a/frontend/packages/telegram-bot/src/errorHandler.ts
+++ b/frontend/packages/telegram-bot/src/errorHandler.ts
@@ -12,9 +12,11 @@ export function handleBotError(err: BotError<Context>) {
 }
 
 export async function handleCommandError(ctx: MyContext, error: unknown) {
-  if (error instanceof ProblemDetailsError && error.problem.status === 403) {
-    await ctx.reply(ctx.t('not-registered', { userId: ctx.from?.id ?? 0 }));
-    return;
+  if (error instanceof ProblemDetailsError) {
+    if (error.problem.status === 403) {
+      await ctx.reply(ctx.t('not-registered', { userId: ctx.from?.id ?? 0 }));
+      return;
+    }
   }
 
   logger.error(apiErrorMsg, error);

--- a/frontend/packages/telegram-bot/src/handlers/deeplink.ts
+++ b/frontend/packages/telegram-bot/src/handlers/deeplink.ts
@@ -16,7 +16,9 @@ bot.on('message', async (ctx: MyContext, next) => {
         await ctx.reply(ctx.t('start-linked'));
       } catch (e: unknown) {
         let forbidden = false;
-        if (e instanceof ProblemDetailsError) forbidden = e.problem.status === 403;
+        if (e instanceof ProblemDetailsError) {
+          forbidden = e.problem.status === 403;
+        }
         await ctx.reply(
           forbidden
             ? ctx.t('not-registered', { userId: ctx.from?.id ?? 0 })

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -78,7 +78,9 @@ bot.on('inline_query', async (ctx: MyContext) => {
     );
   } catch (e: unknown) {
     let forbidden = false;
-    if (e instanceof ProblemDetailsError) forbidden = e.problem.status === 403;
+    if (e instanceof ProblemDetailsError) {
+      forbidden = e.problem.status === 403;
+    }
     if (forbidden) {
       await ctx.answerInlineQuery(
         [],

--- a/frontend/packages/telegram-bot/src/registration.ts
+++ b/frontend/packages/telegram-bot/src/registration.ts
@@ -10,7 +10,9 @@ export async function ensureRegistered(ctx: MyContext): Promise<boolean> {
     return true;
   } catch (e: unknown) {
     let forbidden = false;
-    if (e instanceof ProblemDetailsError) forbidden = e.problem.status === 403;
+    if (e instanceof ProblemDetailsError) {
+      forbidden = e.problem.status === 403;
+    }
     await ctx.reply(
       forbidden
         ? ctx.t('not-registered', { userId: ctx.from?.id ?? 0 })


### PR DESCRIPTION
## Summary
- ensure ProblemDetailsError properties are read only after instanceof narrowing
- adjust error handling in command, deeplink, inline, registration handlers

## Testing
- `pnpm --filter @photobank/telegram-bot run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c6b1155d148328aad55e02748511a0