### PR TITLE
fix: rely on shared package exports for telegram-bot type resolution

### DIFF
--- a/frontend/packages/telegram-bot/tsconfig.json
+++ b/frontend/packages/telegram-bot/tsconfig.json
@@ -12,9 +12,7 @@
     "types": ["node"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@photobank/shared": ["../shared/src/index.ts"],
-      "@photobank/shared/*": ["../shared/src/*"]
+      "@/*": ["src/*"]
     }
   },
   "references": [


### PR DESCRIPTION
## Summary
- remove @photobank/shared path aliases from telegram-bot tsconfig to use package exports

## Testing
- `pnpm --filter @photobank/telegram-bot run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c6b5aa1c3883288231fa40c3989f93