### PR TITLE
chore: add object-hash dependency to telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -28,6 +28,7 @@
     "fetch-blob": "^4.0.0",
     "grammy": "^1.38.2",
     "lru-cache": "^11.2.1",
+    "object-hash": "^3.0.0",
     "openai": "^5.20.1",
     "p-retry": "^7.0.0",
     "zod": "^4.1.7"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -674,6 +674,9 @@ importers:
       lru-cache:
         specifier: ^11.2.1
         version: 11.2.1
+      object-hash:
+        specifier: ^3.0.0
+        version: 3.0.0
       openai:
         specifier: ^5.20.1
         version: 5.20.2(ws@8.18.3)(zod@4.1.8)


### PR DESCRIPTION
## Summary
- add object-hash dependency to telegram bot
- update pnpm lockfile

## Testing
- `pnpm install`
- `pnpm --filter @photobank/telegram-bot run build`
- `pnpm --filter @photobank/telegram-bot test`
- `pnpm --filter @photobank/telegram-bot start` *(fails: Cannot find package 'dexie')*


------
https://chatgpt.com/codex/tasks/task_e_68c7272562b08328aef042c117bb665d