### PR TITLE
fix: add dexie dependency to telegram-bot

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -24,6 +24,7 @@
     "axios": "^1.11.0",
     "bottleneck": "^2.19.5",
     "date-fns": "^4.1.0",
+    "dexie": "^4.2.0",
     "dotenv": "^17.2.2",
     "fetch-blob": "^4.0.0",
     "grammy": "^1.38.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -662,6 +662,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dexie:
+        specifier: ^4.2.0
+        version: 4.2.0
       dotenv:
         specifier: ^17.2.2
         version: 17.2.2


### PR DESCRIPTION
## Summary
- add `dexie` dependency to telegram bot

## Testing
- `pnpm --filter @photobank/telegram-bot add dexie`
- `pnpm --filter @photobank/telegram-bot test`
- `pnpm --filter @photobank/telegram-bot run build`
- `pnpm --filter @photobank/telegram-bot start` *(fails: Cannot find package '@tanstack/react-query')*

------
https://chatgpt.com/codex/tasks/task_e_68c72a29ee78832885b6e0ab85919246