### PR TITLE
chore: optimize backend Docker layering

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,17 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /app
 
-# Копируем весь backend код
+#   PhotoBank.Api   
+COPY PhotoBank.Api/PhotoBank.Api.csproj PhotoBank.Api/
+RUN dotnet restore PhotoBank.Api/PhotoBank.Api.csproj
+
+#   backend 
 COPY . .
 
-# Восстановление и сборка
-RUN dotnet restore PhotoBank.Api/PhotoBank.Api.csproj
-RUN dotnet publish PhotoBank.Api/PhotoBank.Api.csproj -c Release -o /out
+#    
+RUN dotnet publish PhotoBank.Api/PhotoBank.Api.csproj -c Release -o /out --no-restore
 
-# Runtime слой
+# Runtime Е„Г«Г®Г©
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
 WORKDIR /app
 COPY --from=build /out .


### PR DESCRIPTION
## Summary
- restore PhotoBank.Api dependencies before copying the full source to improve layer caching
- publish the API without rerunning restore by using the --no-restore flag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c95728a38c8328a5cea6894a4714dc