### PR TITLE
chore: improve frontend docker caching

### DIFF
--- a/frontend/Dockerfile.frontend
+++ b/frontend/Dockerfile.frontend
@@ -1,29 +1,28 @@
 FROM node:22-alpine AS build
 WORKDIR /app
 
-# Установить pnpm глобально
-RUN npm install -g pnpm
+# pnpm
+RUN corepack enable
 
-# Скопировать всё
+# Install dependencies
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile --prod=false
+
+# Build workspace
 COPY . .
 
-# Пробросить API URL в build stage
+# API URL build stage
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
-# Установить зависимости и собрать фронт
-RUN pnpm install --frozen-lockfile --prod=false
 RUN pnpm --filter frontend build
 
-# Production слой
+# Production
 FROM node:22-alpine AS production
 WORKDIR /app
 
-# Установить минимальный сервер
 RUN npm install -g serve
 
-# Скопировать только билд
 COPY --from=build /app/packages/frontend/dist ./dist
 
-# Старт сервера
 CMD ["serve", "-s", "dist", "-l", "5173"]


### PR DESCRIPTION
## Summary
- copy the workspace manifests before the rest of the sources to leverage docker layer caching
- switch to using `corepack enable` before pnpm install in the build stage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c95cf13c7c8328b084d47f9701943d