### PR TITLE
chore: optimize telegram bot docker build

### DIFF
--- a/frontend/Dockerfile.bot
+++ b/frontend/Dockerfile.bot
@@ -1,7 +1,20 @@
-FROM node:22-alpine
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY . .
 
-RUN corepack enable && pnpm install --frozen-lockfile --prod=false
-CMD ["pnpm", "--filter", "telegram-bot", "start"]
+RUN corepack enable
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @photobank/telegram-bot build
+
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+COPY . .
+
+RUN corepack enable
+RUN pnpm install --prod
+
+COPY --from=builder /app/packages/telegram-bot/dist ./packages/telegram-bot/dist
+
+CMD ["node", "packages/telegram-bot/dist/index.js"]


### PR DESCRIPTION
## Summary
- add a builder stage that compiles @photobank/telegram-bot with pnpm
- install only production dependencies in the runtime stage and copy the built dist output
- run the container with node on the compiled telegram bot entry point

## Testing
- not run (dockerfile-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c95f5eaf588328a0ba3200800106a5