### PR TITLE
chore: improve backend docker restore

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,18 +1,24 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /app
 
-#   PhotoBank.Api   
+# Restore dependencies using solution and project files
+COPY PhotoBank.sln ./
+COPY Directory.Build.props ./
 COPY PhotoBank.Api/PhotoBank.Api.csproj PhotoBank.Api/
-RUN dotnet restore PhotoBank.Api/PhotoBank.Api.csproj
+COPY PhotoBank.DependencyInjection/PhotoBank.DependencyInjection.csproj PhotoBank.DependencyInjection/
+COPY PhotoBank.Services/PhotoBank.Services.csproj PhotoBank.Services/
+COPY PhotoBank.DbContext/PhotoBank.DbContext.csproj PhotoBank.DbContext/
+COPY PhotoBank.InsightFace.Client/PhotoBank.InsightFaceApiClient.csproj PhotoBank.InsightFace.Client/
+COPY PhotoBank.Repositories/PhotoBank.Repositories.csproj PhotoBank.Repositories/
+COPY PhotoBank.ViewModel.Dto/PhotoBank.ViewModel.Dto.csproj PhotoBank.ViewModel.Dto/
+RUN dotnet restore PhotoBank.sln
 
-#   backend 
+# Copy the remaining source files and publish
 COPY . .
 
-#
 RUN dotnet publish PhotoBank.Api/PhotoBank.Api.csproj \
     -c Release \
-    -o /out \
-    --no-restore
+    -o /out
 
 # Runtime ńëîé
 FROM mcr.microsoft.com/dotnet/aspnet:9.0


### PR DESCRIPTION
## Summary
- copy the solution and all referenced project files before restoring in the backend Docker image
- run a solution-wide restore prior to copying sources so publish has required assets
- publish without --no-restore after copying the full source tree

## Testing
- docker build -t photobank-backend-test backend *(fails locally: docker CLI unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c97b8f39248328a9505307527426a3