### PR TITLE
fix: improve frontend docker build cache

### DIFF
--- a/frontend/Dockerfile.frontend
+++ b/frontend/Dockerfile.frontend
@@ -3,30 +3,28 @@ WORKDIR /app
 
 # install dependencies
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/frontend/package.json packages/frontend/
+COPY packages/shared/package.json packages/shared/
+COPY packages/telegram-bot/package.json packages/telegram-bot/
 
-#
 RUN corepack enable
 RUN pnpm install --frozen-lockfile
 
-#
+# copy source
 COPY . .
 
-#  API URL  build stage
+# API URL build stage
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
-#
-RUN pnpm --filter frontend build
+RUN pnpm --filter @photobank/frontend build
 
 # Production
 FROM node:22-alpine AS production
 WORKDIR /app
 
-#
 RUN npx serve -s dist -l 5173
 
-#
 COPY --from=build /app/packages/frontend/dist ./dist
 
-#
 CMD ["serve", "-s", "dist", "-l", "5173"]


### PR DESCRIPTION
## Summary
- copy package manifests into the Docker build context before installing frontend dependencies
- ensure the scoped frontend build runs after dependencies are installed

## Testing
- pnpm install --frozen-lockfile
- pnpm --filter @photobank/frontend build

------
https://chatgpt.com/codex/tasks/task_e_68c9826f0ddc8328ad5a1bf763d673b9