### PR TITLE
fix: avoid running serve during frontend image build

### DIFF
--- a/frontend/Dockerfile.frontend
+++ b/frontend/Dockerfile.frontend
@@ -23,7 +23,7 @@ RUN pnpm --filter @photobank/frontend build
 FROM node:22-alpine AS production
 WORKDIR /app
 
-RUN npx serve -s dist -l 5173
+# RUN npx serve -s dist -l 5173
 
 COPY --from=build /app/packages/frontend/dist ./dist
 


### PR DESCRIPTION
## Summary
- comment out the serve run step in the frontend Dockerfile so the command only executes at container runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9881a96cc83289f3061967ac564b2