### PR TITLE
build: emit js artifacts for shared package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,10 +10,10 @@
   "private": true,
   "scripts": {
     "orval": "orval --config orval.config.ts",
-    "build:types": "pnpm --filter @photobank/shared run build:types",
+    "build:types": "pnpm --filter @photobank/shared run build",
     "build:frontend": "pnpm --filter @photobank/frontend run build",
     "build:bot": "pnpm --filter @photobank/telegram-bot run build",
-    "build": "pnpm run orval && pnpm run build:types && pnpm run build:frontend && pnpm run build:bot",
+    "build": "pnpm run orval && pnpm -r --filter \"@photobank/*\" run build",
     "dev:frontend": "pnpm --filter @photobank/frontend run dev",
     "dev:bot": "pnpm --filter @photobank/telegram-bot run dev",
     "generate:api": "orval --config orval.config.ts",

--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -51,7 +51,8 @@
     "dist"
   ],
   "scripts": {
-    "build:types": "rimraf dist && tsc -b",
+    "build": "rimraf dist && tsc -b --force",
+    "build:types": "pnpm run build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/frontend/packages/shared/tsconfig.json
+++ b/frontend/packages/shared/tsconfig.json
@@ -5,7 +5,6 @@
     "rootDir": "src",
     "composite": true,
     "declaration": true,
-    "emitDeclarationOnly": true,
     "declarationMap": true,
     "stripInternal": true,
     "noEmit": false,


### PR DESCRIPTION
## Summary
- allow the shared TypeScript project to emit JavaScript alongside declaration files
- add a dedicated build script for @photobank/shared and ensure pnpm -r build compiles it ahead of dependents

## Testing
- pnpm -C frontend build

------
https://chatgpt.com/codex/tasks/task_e_68c98a41482c8328a2d06b857158fb13