### PR TITLE
fix: rely on compiled shared package in telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/tsconfig.json
+++ b/frontend/packages/telegram-bot/tsconfig.json
@@ -12,9 +12,7 @@
     "types": ["node"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@photobank/shared": ["../shared/src/index.ts"],
-      "@photobank/shared/*": ["../shared/src/*"]
+      "@/*": ["src/*"]
     }
   },
   "references": [


### PR DESCRIPTION
## Summary
- remove the telegram bot TypeScript path alias that pointed at @photobank/shared sources so it now resolves the built workspace package

## Testing
- pnpm --filter @photobank/telegram-bot run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c98eab5a0c8328a0edcce731da277b