### PR TITLE
fix: copy locales in telegram bot build

### DIFF
--- a/frontend/packages/telegram-bot/package.json
+++ b/frontend/packages/telegram-bot/package.json
@@ -10,8 +10,9 @@
   "scripts": {
     "pretypecheck": "pnpm --filter @photobank/shared run build:types",
     "typecheck": "tsc -b",
-    "build": "pnpm run typecheck && tsup",
-    "dev": "tsup --watch --onSuccess \"node dist/index.js\"",
+    "build": "pnpm run typecheck && tsup && pnpm run copy:locales",
+    "copy:locales": "cpy src/locales/**/*.ftl dist/locales",
+    "dev": "tsup --watch --onSuccess \"pnpm run copy:locales && node dist/index.js\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "start": "node dist/index.js"


### PR DESCRIPTION
## Summary
- add a copy:locales script to stage .ftl bundles in the telegram bot distribution
- run the locale copy step after tsup builds during both build and watch modes to prevent missing files at runtime

## Testing
- pnpm run build (packages/telegram-bot)


------
https://chatgpt.com/codex/tasks/task_e_68c9a627007c8328824478a69a90f61a