### PR TITLE
fix: load bot handlers after i18n middleware

### DIFF
--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -25,8 +25,6 @@ import { uploadCommand } from "./commands/upload";
 import { withRegistered } from './registration';
 import { logger } from './logger';
 import { handleBotError } from './errorHandler';
-import './handlers/inline';
-import './handlers/deeplink';
 import { i18n } from './i18n';
 
 const privateCommands = (lang: string) => [
@@ -54,6 +52,11 @@ bot.use(async (ctx, next) => {
   if (lang) ctx.i18n.useLocale(lang);
   await next();
 });
+
+await Promise.all([
+  import('./handlers/deeplink'),
+  import('./handlers/inline'),
+]);
 
 bot.use(async (ctx, next) => {
   const username = ctx.from?.username ?? String(ctx.from?.id ?? '');


### PR DESCRIPTION
## Summary
- load the inline and deeplink handler modules only after i18n middleware is registered so ctx.t is available
- keep remaining bot setup after middleware to avoid ctx.t runtime errors

## Testing
- pnpm --filter @photobank/telegram-bot typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c9b512dc5083289ce3cd291083fbdd