### PR TITLE
fix: install serve in frontend production image

### DIFF
--- a/frontend/Dockerfile.frontend
+++ b/frontend/Dockerfile.frontend
@@ -23,7 +23,7 @@ RUN pnpm --filter @photobank/frontend build
 FROM node:22-alpine AS production
 WORKDIR /app
 
-# RUN npx serve -s dist -l 5173
+RUN npm install -g serve
 
 COPY --from=build /app/packages/frontend/dist ./dist
 


### PR DESCRIPTION
## Summary
- install the serve CLI in the frontend production Docker stage so the SPA can be hosted

## Testing
- docker build -f frontend/Dockerfile.frontend -t photobank-frontend:test . *(fails: docker not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c0905030832895fc6ea727a6986e