### PR TITLE
fix: retry telegram axios on HttpError

### DIFF
--- a/frontend/packages/telegram-bot/src/api/axios-instance.ts
+++ b/frontend/packages/telegram-bot/src/api/axios-instance.ts
@@ -1,6 +1,8 @@
 import axios, { type AxiosRequestConfig, type AxiosInstance } from 'axios';
 import type { Context } from 'grammy';
 
+import { HttpError } from '@photobank/shared/types/problem';
+
 import { ensureUserAccessToken, invalidateUserToken } from '@/auth';
 
 const API_BASE_URL = process.env.API_BASE_URL ?? '/api';
@@ -28,7 +30,11 @@ export async function photobankAxios<T>(config: AxiosRequestConfig, ctx?: Contex
   try {
     return await doRequest(false);
   } catch (error: unknown) {
-    const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+    const status = axios.isAxiosError(error)
+      ? error.response?.status
+      : error instanceof HttpError
+        ? error.status
+        : undefined;
     if (status === 401 || status === 403) {
       invalidateUserToken(context);
       return await doRequest(true);

--- a/frontend/packages/telegram-bot/test/axios-instance.test.ts
+++ b/frontend/packages/telegram-bot/test/axios-instance.test.ts
@@ -1,0 +1,73 @@
+import type { Context } from 'grammy';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HttpError } from '@photobank/shared/types/problem';
+
+const mocks = vi.hoisted(() => {
+  const request = vi.fn();
+  return {
+    ensureUserAccessToken: vi.fn<
+      [Context, boolean | undefined],
+      Promise<string>
+    >(),
+    invalidateUserToken: vi.fn<
+      [Context | { from?: { id?: number } }],
+      void
+    >(),
+    request,
+    create: vi.fn(() => ({ request })),
+    isAxiosError: vi.fn(() => false),
+  };
+});
+
+vi.mock('@/auth', () => ({
+  ensureUserAccessToken: mocks.ensureUserAccessToken,
+  invalidateUserToken: mocks.invalidateUserToken,
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    create: mocks.create,
+    isAxiosError: mocks.isAxiosError,
+  },
+  create: mocks.create,
+  isAxiosError: mocks.isAxiosError,
+}));
+
+const { ensureUserAccessToken, invalidateUserToken, request } = mocks;
+
+import { photobankAxios } from '../src/api/axios-instance';
+
+describe('photobankAxios', () => {
+  beforeEach(() => {
+    ensureUserAccessToken.mockReset();
+    invalidateUserToken.mockReset();
+    request.mockReset();
+  });
+
+  it('retries when ensureUserAccessToken throws HttpError 403', async () => {
+    const ctx = { from: { id: 123 } } as unknown as Context;
+    const responseData = { ok: true };
+
+    request.mockResolvedValue({ data: responseData });
+    ensureUserAccessToken.mockImplementation(async (_ctx, force) => {
+      if (!force) {
+        throw new HttpError(403);
+      }
+      return 'fresh-token';
+    });
+
+    const result = await photobankAxios<typeof responseData>({ url: '/photos' }, ctx);
+
+    expect(result).toEqual(responseData);
+    expect(ensureUserAccessToken).toHaveBeenCalledTimes(2);
+    expect(ensureUserAccessToken).toHaveBeenNthCalledWith(1, ctx, false);
+    expect(ensureUserAccessToken).toHaveBeenNthCalledWith(2, ctx, true);
+    expect(invalidateUserToken).toHaveBeenCalledWith(ctx);
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith({
+      url: '/photos',
+      headers: { Authorization: 'Bearer fresh-token' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- treat HttpError 401/403 responses like axios auth failures by invalidating the Telegram token and retrying
- add a vitest that covers HttpError thrown by ensureUserAccessToken and ensures a forced retry is attempted

## Testing
- pnpm --filter @photobank/telegram-bot test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c9c3c4b8588328ab790d03ba0335d0