### PR TITLE
fix: emit problem details for telegram exchange errors

### DIFF
--- a/backend/PhotoBank.Api/Controllers/AuthController.cs
+++ b/backend/PhotoBank.Api/Controllers/AuthController.cs
@@ -112,12 +112,17 @@ public class AuthController(
         var configuredKey = configuration["Auth:Telegram:ServiceKey"];
         var presentedKey = Request.Headers["X-Service-Key"].ToString();
         if (string.IsNullOrWhiteSpace(configuredKey) || presentedKey != configuredKey)
-            return Unauthorized(Problem(title: "Unauthorized", statusCode: 401, detail: "Invalid service key"));
+            return Problem(
+                title: "Unauthorized",
+                statusCode: StatusCodes.Status401Unauthorized,
+                detail: "Invalid service key");
 
         var user = await userManager.Users.FirstOrDefaultAsync(u => u.TelegramUserId == req.TelegramUserId);
         if (user is null)
-            return StatusCode(StatusCodes.Status403Forbidden,
-                Problem(title: "Telegram not linked", statusCode: 403, detail: "Ask admin to link your Telegram"));
+            return Problem(
+                title: "Telegram not linked",
+                statusCode: StatusCodes.Status403Forbidden,
+                detail: "Ask admin to link your Telegram");
 
         var token = tokenService.CreateToken(user, rememberMe: false);
         var expiresIn = 3600;

--- a/backend/PhotoBank.UnitTests/AuthControllerTests.cs
+++ b/backend/PhotoBank.UnitTests/AuthControllerTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.Api.Controllers;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Api;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class AuthControllerTests
+{
+    [Test]
+    public async Task TelegramExchange_InvalidServiceKey_ReturnsProblemDetails()
+    {
+        await using var db = TestDbFactory.CreateInMemory();
+        var controller = CreateController(db, serviceKey: "expected-key", presentedKey: "wrong-key");
+
+        var result = await controller.TelegramExchange(new AuthController.TelegramExchangeRequest(123, "user"));
+
+        var problemResult = result.Should().BeOfType<ObjectResult>().Which;
+        problemResult.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        problemResult.ContentTypes.Should().Contain("application/problem+json");
+
+        var problem = problemResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Status.Should().Be(StatusCodes.Status401Unauthorized);
+        problem.Title.Should().Be("Unauthorized");
+        problem.Detail.Should().Be("Invalid service key");
+    }
+
+    [Test]
+    public async Task TelegramExchange_UnknownTelegramUser_ReturnsProblemDetails()
+    {
+        await using var db = TestDbFactory.CreateInMemory();
+        var controller = CreateController(db, serviceKey: "expected-key", presentedKey: "expected-key");
+
+        var result = await controller.TelegramExchange(new AuthController.TelegramExchangeRequest(456, "user"));
+
+        var problemResult = result.Should().BeOfType<ObjectResult>().Which;
+        problemResult.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        problemResult.ContentTypes.Should().Contain("application/problem+json");
+
+        var problem = problemResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Status.Should().Be(StatusCodes.Status403Forbidden);
+        problem.Title.Should().Be("Telegram not linked");
+        problem.Detail.Should().Be("Ask admin to link your Telegram");
+    }
+
+    private static AuthController CreateController(PhotoBankDbContext db, string serviceKey, string presentedKey)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Auth:Telegram:ServiceKey"] = serviceKey
+            })
+            .Build();
+
+        var userManager = CreateUserManager(db);
+        var signInManager = CreateSignInManager(userManager);
+        var tokenService = Mock.Of<ITokenService>();
+
+        var controller = new AuthController(userManager, signInManager, tokenService, configuration)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+        controller.ControllerContext.HttpContext!.Request.Headers["X-Service-Key"] = presentedKey;
+        return controller;
+    }
+
+    private static UserManager<ApplicationUser> CreateUserManager(PhotoBankDbContext db)
+    {
+        var store = new UserStore<ApplicationUser>(db);
+        var options = Options.Create(new IdentityOptions());
+        var passwordHasher = new PasswordHasher<ApplicationUser>();
+        var userValidators = new List<IUserValidator<ApplicationUser>> { new UserValidator<ApplicationUser>() };
+        var passwordValidators = new List<IPasswordValidator<ApplicationUser>> { new PasswordValidator<ApplicationUser>() };
+        var keyNormalizer = new UpperInvariantLookupNormalizer();
+        var errors = new IdentityErrorDescriber();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var serviceProvider = services.BuildServiceProvider();
+        var logger = serviceProvider.GetRequiredService<ILogger<UserManager<ApplicationUser>>>();
+
+        return new UserManager<ApplicationUser>(
+            store,
+            options,
+            passwordHasher,
+            userValidators,
+            passwordValidators,
+            keyNormalizer,
+            errors,
+            serviceProvider,
+            logger);
+    }
+
+    private static SignInManager<ApplicationUser> CreateSignInManager(UserManager<ApplicationUser> userManager)
+    {
+        var contextAccessor = new HttpContextAccessor();
+        var options = Options.Create(new IdentityOptions());
+        var claimsFactory = new UserClaimsPrincipalFactory<ApplicationUser>(userManager, options);
+
+        return new SignInManager<ApplicationUser>(
+            userManager,
+            contextAccessor,
+            claimsFactory,
+            options,
+            NullLogger<SignInManager<ApplicationUser>>.Instance,
+            new Mock<Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider>().Object,
+            new Mock<IUserConfirmation<ApplicationUser>>().Object);
+    }
+}

--- a/frontend/packages/telegram-bot/test/registration.test.ts
+++ b/frontend/packages/telegram-bot/test/registration.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProblemDetailsError } from '@photobank/shared/types/problem';
+
+import type { MyContext } from '../src/i18n';
+import { ensureRegistered } from '../src/registration';
+
+const ensureUserAccessToken = vi.hoisted(() =>
+  vi.fn<[unknown, boolean | undefined], Promise<string>>()
+);
+
+vi.mock('../src/auth', () => ({
+  ensureUserAccessToken,
+}));
+
+describe('ensureRegistered', () => {
+  beforeEach(() => {
+    ensureUserAccessToken.mockReset();
+  });
+
+  it('replies with not registered message when backend returns ProblemDetails 403', async () => {
+    const reply = vi.fn<[string], Promise<void>>(() => Promise.resolve());
+    const t = vi.fn<[string, Record<string, unknown> | undefined], string>((key, params) => {
+      if (key === 'not-registered') {
+        return `not-registered:${params?.userId ?? 'missing'}`;
+      }
+      return key;
+    });
+
+    const ctx = {
+      from: { id: 123 },
+      reply,
+      t,
+    } as unknown as MyContext;
+
+    ensureUserAccessToken.mockRejectedValue(
+      new ProblemDetailsError({ title: 'Forbidden', status: 403, detail: 'no access' })
+    );
+
+    const result = await ensureRegistered(ctx);
+
+    expect(result).toBe(false);
+    expect(ensureUserAccessToken).toHaveBeenCalledWith(ctx);
+    expect(t).toHaveBeenCalledWith('not-registered', { userId: 123 });
+    expect(reply).toHaveBeenCalledWith('not-registered:123');
+  });
+});


### PR DESCRIPTION
## Summary
- return RFC 7807 problem details for unauthorized and forbidden telegram exchange requests
- cover telegram exchange error flows with backend tests
- ensure the telegram bot surfaces 403 problem details as the not registered reply

## Testing
- pnpm --filter @photobank/telegram-bot test
- dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4570570c83288ced5dab40623f83