### PR TITLE
Allow non-admin access to person dictionary

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PersonsController.cs
+++ b/backend/PhotoBank.Api/Controllers/PersonsController.cs
@@ -7,7 +7,7 @@ namespace PhotoBank.Api.Controllers;
 
 [Route("[controller]")]
 [ApiController]
-[Authorize(Roles = "Admin")]
+[Authorize]
 public class PersonsController(IPhotoService photoService) : ControllerBase
 {
     [HttpGet]
@@ -18,6 +18,7 @@ public class PersonsController(IPhotoService photoService) : ControllerBase
         return Ok(persons);
     }
 
+    [Authorize(Roles = "Admin")]
     [HttpPost]
     [ProducesResponseType(typeof(PersonDto), StatusCodes.Status201Created)]
     public async Task<ActionResult<PersonDto>> CreateAsync(PersonDto dto)
@@ -26,6 +27,7 @@ public class PersonsController(IPhotoService photoService) : ControllerBase
         return CreatedAtAction(nameof(GetAllAsync), new { }, person);
     }
 
+    [Authorize(Roles = "Admin")]
     [HttpPut("{personId}")]
     [ProducesResponseType(typeof(PersonDto), StatusCodes.Status200OK)]
     public async Task<ActionResult<PersonDto>> UpdateAsync(int personId, PersonDto dto)
@@ -36,6 +38,7 @@ public class PersonsController(IPhotoService photoService) : ControllerBase
         return Ok(person);
     }
 
+    [Authorize(Roles = "Admin")]
     [HttpDelete("{personId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> DeleteAsync(int personId)

--- a/backend/PhotoBank.IntegrationTests/GetPersonsIntegrationTests.cs
+++ b/backend/PhotoBank.IntegrationTests/GetPersonsIntegrationTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Minio;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.AccessControl;
+using PhotoBank.Api.Controllers;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.DependencyInjection;
+using PhotoBank.Services.Api;
+using PhotoBank.ViewModel.Dto;
+using Respawn;
+using Testcontainers.MsSql;
+
+namespace PhotoBank.IntegrationTests;
+
+[TestFixture]
+public class GetPersonsIntegrationTests
+{
+    private MsSqlContainer _dbContainer = null!;
+    private Respawner _respawner = null!;
+    private IConfiguration _config = null!;
+    private string _connectionString = string.Empty;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetup()
+    {
+        try
+        {
+            _dbContainer = new MsSqlBuilder().WithPassword("yourStrong(!)Password").Build();
+            await _dbContainer.StartAsync();
+        }
+        catch (ArgumentException ex) when (ex.Message.Contains("Docker endpoint"))
+        {
+            Assert.Ignore("Docker not available: " + ex.Message);
+        }
+
+        _connectionString = _dbContainer.GetConnectionString();
+
+        _config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Issuer"] = "issuer",
+                ["Jwt:Audience"] = "audience",
+                ["Jwt:Key"] = "secret",
+                ["ConnectionStrings:DefaultConnection"] = _connectionString
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddDbContext<PhotoBankDbContext>(options =>
+            options.UseSqlServer(_connectionString, builder =>
+            {
+                builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
+                builder.UseNetTopologySuite();
+            }));
+        services
+            .AddPhotobankCore(_config)
+            .AddScoped<ICurrentUser, DummyCurrentUser>()
+            .AddPhotobankApi(_config)
+            .AddPhotobankCors();
+        services.AddLogging();
+        services.AddSingleton<IMinioClient>(Mock.Of<IMinioClient>());
+
+        await using (var provider = services.BuildServiceProvider())
+        {
+            var db = provider.GetRequiredService<PhotoBankDbContext>();
+            await db.Database.MigrateAsync();
+        }
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync();
+        _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
+        {
+            DbAdapter = DbAdapter.SqlServer
+        });
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dbContainer != null)
+        {
+            await _dbContainer.DisposeAsync();
+        }
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await _respawner.ResetAsync(conn);
+    }
+
+    [Test]
+    public async Task GetAllAsync_NonAdminUser_ReturnsOnlyAllowedPersons()
+    {
+        var seed = await SeedPersonsAsync();
+
+        await using var provider = BuildProvider(seed.AllowedGroupId);
+        using var scope = provider.CreateScope();
+        var service = scope.ServiceProvider.GetRequiredService<IPhotoService>();
+        var controller = new PersonsController(service);
+
+        var actionResult = await controller.GetAllAsync();
+
+        var okResult = actionResult.Result as Microsoft.AspNetCore.Mvc.OkObjectResult;
+        okResult.Should().NotBeNull();
+
+        var persons = okResult!.Value.Should().BeAssignableTo<IEnumerable<PersonDto>>().Subject.ToList();
+        persons.Should().HaveCount(1);
+        persons[0].Id.Should().Be(seed.AllowedPersonId);
+    }
+
+    private async Task<PersonSeedResult> SeedPersonsAsync()
+    {
+        await using var db = CreateDbContext();
+
+        var allowedGroup = new PersonGroup { Name = "Allowed" };
+        var blockedGroup = new PersonGroup { Name = "Blocked" };
+
+        var allowedPerson = new Person { Name = "Alice", PersonGroups = new List<PersonGroup> { allowedGroup } };
+        var blockedPerson = new Person { Name = "Bob", PersonGroups = new List<PersonGroup> { blockedGroup } };
+        var ungroupedPerson = new Person { Name = "Charlie", PersonGroups = new List<PersonGroup>() };
+
+        db.PersonGroups.AddRange(allowedGroup, blockedGroup);
+        db.Persons.AddRange(allowedPerson, blockedPerson, ungroupedPerson);
+
+        await db.SaveChangesAsync();
+
+        return new PersonSeedResult(allowedGroup.Id, allowedPerson.Id, blockedPerson.Id, ungroupedPerson.Id);
+    }
+
+    private PhotoBankDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<PhotoBankDbContext>()
+            .UseSqlServer(_connectionString, builder =>
+            {
+                builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
+                builder.UseNetTopologySuite();
+            })
+            .Options;
+        return new PhotoBankDbContext(options);
+    }
+
+    private ServiceProvider BuildProvider(params int[] allowedPersonGroupIds)
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<PhotoBankDbContext>(options =>
+            options.UseSqlServer(_connectionString, builder =>
+            {
+                builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
+                builder.UseNetTopologySuite();
+            }));
+
+        services
+            .AddPhotobankCore(_config)
+            .AddScoped<ICurrentUser>(_ => new NonAdminTestUser("user", allowedPersonGroupIds))
+            .AddPhotobankApi(_config)
+            .AddPhotobankCors();
+
+        services.AddLogging();
+        services.AddSingleton<IMinioClient>(Mock.Of<IMinioClient>());
+
+        return services.BuildServiceProvider();
+    }
+
+    private sealed record PersonSeedResult(int AllowedGroupId, int AllowedPersonId, int BlockedPersonId, int UngroupedPersonId);
+
+    private sealed class NonAdminTestUser : ICurrentUser
+    {
+        public NonAdminTestUser(string userId, IEnumerable<int> allowedPersonGroupIds)
+        {
+            UserId = userId;
+            AllowedPersonGroupIds = new HashSet<int>(allowedPersonGroupIds);
+        }
+
+        public string UserId { get; }
+        public bool IsAdmin => false;
+        public IReadOnlySet<int> AllowedStorageIds { get; } = new HashSet<int>();
+        public IReadOnlySet<int> AllowedPersonGroupIds { get; }
+        public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; } = Array.Empty<(DateOnly, DateOnly)>();
+        public bool CanSeeNsfw => false;
+    }
+}

--- a/frontend/packages/telegram-bot/test/axios-instance.test.ts
+++ b/frontend/packages/telegram-bot/test/axios-instance.test.ts
@@ -70,4 +70,24 @@ describe('photobankAxios', () => {
       headers: { Authorization: 'Bearer fresh-token' },
     });
   });
+
+  it('returns dictionary data for non-admin users without forcing reauth', async () => {
+    const ctx = { from: { id: 456 } } as unknown as Context;
+    const dictionary = [{ id: 1, name: 'Alice' }];
+
+    ensureUserAccessToken.mockResolvedValue('token');
+    request.mockResolvedValue({ data: dictionary });
+
+    const result = await photobankAxios<typeof dictionary>({ url: '/persons' }, ctx);
+
+    expect(result).toEqual(dictionary);
+    expect(ensureUserAccessToken).toHaveBeenCalledTimes(1);
+    expect(ensureUserAccessToken).toHaveBeenCalledWith(ctx, false);
+    expect(invalidateUserToken).not.toHaveBeenCalled();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith({
+      url: '/persons',
+      headers: { Authorization: 'Bearer token' },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- allow authenticated access to GET /persons while keeping mutations admin-only
- add an integration test exercising non-admin ACL filtering for /persons
- extend the telegram bot axios test to ensure dictionary fetching succeeds for non-admin users

## Testing
- dotnet test backend/PhotoBank.Backend.sln *(fails at teardown due to the .NET terminal logger crash after tests complete)*
- pnpm -C frontend/packages/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68cab45215d08328b809136b839351cf