### PR TITLE
fix: align telegram bot photo pagination

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -33,13 +33,12 @@ export async function sendPhotosPage({
     }
   }
 
-  const skip = (page - 1) * PHOTOS_PAGE_SIZE;
   let queryResult;
   try {
     queryResult = await searchPhotos(ctx, {
       ...filter,
-      top: PHOTOS_PAGE_SIZE,
-      skip,
+      page,
+      pageSize: PHOTOS_PAGE_SIZE,
     });
   } catch (err: unknown) {
     await handleCommandError(ctx, err);

--- a/frontend/packages/telegram-bot/src/handlers/inline.ts
+++ b/frontend/packages/telegram-bot/src/handlers/inline.ts
@@ -14,6 +14,7 @@ const PAGE_SIZE = 20;
 bot.on('inline_query', async (ctx: MyContext) => {
   const q = (ctx.inlineQuery?.query ?? '').trim();
   const offset = Number(ctx.inlineQuery?.offset ?? '0') || 0;
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
 
   // Авторизация для inline: если нет — мягко предлагаем /start link
   try {
@@ -35,8 +36,8 @@ bot.on('inline_query', async (ctx: MyContext) => {
   try {
     const resp = await searchPhotos(ctx, {
       caption: q,
-      skip: offset,
-      top: PAGE_SIZE,
+      page,
+      pageSize: PAGE_SIZE,
     });
 
     type Photo = {

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -11,13 +11,10 @@ import { handleServiceError } from '../errorHandler';
 
 const { photosSearchPhotos, photosGetPhoto, photosUpload } = getPhotos();
 
-export async function searchPhotos(
-  ctx: Context,
-  filter: FilterDto & { top?: number; skip?: number },
-): Promise<PhotosSearchPhotosResult> {
+export async function searchPhotos(ctx: Context, filter: FilterDto): Promise<PhotosSearchPhotosResult> {
   try {
     setRequestContext(ctx);
-    return await photosSearchPhotos(filter as FilterDto);
+    return await photosSearchPhotos(filter);
   } catch (err: unknown) {
     handleServiceError(err);
     throw err;


### PR DESCRIPTION
## Summary
- switch the photos page command to request results by page/pageSize instead of skip/top
- pass the pagination arguments through the shared photo search service without casting
- update the inline handler to issue page-based search requests so offsets stay in sync

## Testing
- pnpm --filter telegram-bot test *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0484d46083289060ab994d31a81a