### PR TITLE
fix: support flexible shared formatDate input

### DIFF
--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -1,13 +1,39 @@
 // packages/shared/src/index.ts
-import {format, parseISO} from "date-fns";
 
-export const formatDate = (dateString?: string) => {
-  if (!dateString) return 'не указана дата';
-  try {
-    return format(parseISO(dateString), 'dd.MM.yyyy, HH:mm');
-  } catch {
+type FlexibleDateInput = string | number | Date | null | undefined;
+
+const ruDateTimeFormatter = new Intl.DateTimeFormat('ru-RU', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+export const formatDate = (dateInput?: FlexibleDateInput) => {
+  if (dateInput === null || dateInput === undefined) return 'не указана дата';
+  if (typeof dateInput === 'string' && dateInput.length === 0) {
+    return 'не указана дата';
+  }
+
+  let date: Date;
+
+  if (dateInput instanceof Date) {
+    date = dateInput;
+  } else if (typeof dateInput === 'number') {
+    date = new Date(dateInput);
+  } else if (typeof dateInput === 'string') {
+    date = new Date(dateInput);
+  } else {
     return 'неверный формат даты';
   }
+
+  if (Number.isNaN(date.getTime())) {
+    return 'неверный формат даты';
+  }
+
+  return ruDateTimeFormatter.format(date);
 };
 
 export const getGenderText = (gender?: boolean | null) => {

--- a/frontend/packages/shared/test/formatDate.test.ts
+++ b/frontend/packages/shared/test/formatDate.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDate } from '../src/index';
+
+const options: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+};
+
+describe('formatDate (legacy export)', () => {
+  it('formats ISO strings using ru-RU locale', () => {
+    const value = '2024-01-02T03:04:05Z';
+    const expected = new Intl.DateTimeFormat('ru-RU', options).format(
+      new Date(value),
+    );
+
+    expect(formatDate(value)).toBe(expected);
+  });
+
+  it('formats Date instances with the same rules', () => {
+    const value = new Date('2024-05-06T07:08:09Z');
+    const expected = new Intl.DateTimeFormat('ru-RU', options).format(value);
+
+    expect(formatDate(value)).toBe(expected);
+  });
+
+  it('keeps legacy fallback messages', () => {
+    expect(formatDate(undefined)).toBe('не указана дата');
+    expect(formatDate(null)).toBe('не указана дата');
+    expect(formatDate('')).toBe('не указана дата');
+    expect(formatDate('definitely-not-a-date')).toBe('неверный формат даты');
+  });
+});


### PR DESCRIPTION
## Summary
- allow the legacy shared formatDate export to accept Date, number, or string inputs while preserving the historical fallbacks
- add unit coverage proving ISO strings, Date instances, and fallback messages behave as expected

## Testing
- pnpm --filter @photobank/shared test
- pnpm --filter @photobank/shared build
- pnpm -w build *(fails: @photobank/telegram-bot build)*

------
https://chatgpt.com/codex/tasks/task_e_68cc29cdc31c8328ab71475c4671c08c