### PR TITLE
fix: decode telegram search filter dates

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/search.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.ts
@@ -255,23 +255,30 @@ function decodeFilter(b64: string): FilterDto | null {
     ) as SerializableFilter;
 
     const { takenDateFrom, takenDateTo, ...rest } = payload;
-    const filter: FilterDto = { ...rest };
 
+    let parsedTakenDateFrom: Date | null | undefined;
     if (typeof takenDateFrom === "string") {
       const parsed = parseISO(takenDateFrom);
-      if (isValid(parsed)) filter.takenDateFrom = parsed;
-      else delete filter.takenDateFrom;
+      if (isValid(parsed)) parsedTakenDateFrom = parsed;
     } else if (takenDateFrom === null) {
-      filter.takenDateFrom = null;
+      parsedTakenDateFrom = null;
     }
 
+    let parsedTakenDateTo: Date | null | undefined;
     if (typeof takenDateTo === "string") {
       const parsed = parseISO(takenDateTo);
-      if (isValid(parsed)) filter.takenDateTo = parsed;
-      else delete filter.takenDateTo;
+      if (isValid(parsed)) parsedTakenDateTo = parsed;
     } else if (takenDateTo === null) {
-      filter.takenDateTo = null;
+      parsedTakenDateTo = null;
     }
+
+    const filter: FilterDto = {
+      ...rest,
+      ...(parsedTakenDateFrom !== undefined && {
+        takenDateFrom: parsedTakenDateFrom,
+      }),
+      ...(parsedTakenDateTo !== undefined && { takenDateTo: parsedTakenDateTo }),
+    };
 
     return filter;
   } catch {


### PR DESCRIPTION
## Summary
- ensure the telegram search filter decoder rebuilds non-date fields from the serialized payload
- parse persisted date strings back into Date instances or clear them when decoding the filter payload

## Testing
- pnpm --filter @photobank/telegram-bot build

------
https://chatgpt.com/codex/tasks/task_e_68cc2ee0dbac8328aa80a33be36b8917