### PR TITLE
fix: ensure telegram bot formats taken date correctly

### DIFF
--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -7,7 +7,7 @@ export function formatPhotoMessage(photo: PhotoDto): { caption: string; hasSpoil
 
   lines.push(`📸 <b>${photo.name}</b>`);
   if (photo.takenDate) {
-    lines.push(`📅 ${formatDate(photo.takenDate)}`);
+    lines.push(`📅 ${formatDate(photo.takenDate.toISOString())}`);
   }
 
   // lines.push(`📏 ${photo.width}×${photo.height}`);


### PR DESCRIPTION
## Summary
- convert taken date to an ISO string before using the shared formatter for telegram captions

## Testing
- pnpm --filter @photobank/telegram-bot build

------
https://chatgpt.com/codex/tasks/task_e_68cc2fe36a3c832891d96b1f7f37250a