### PR TITLE
refactor: use date-fns for shared date formatting

### DIFF
--- a/frontend/packages/shared/src/format/index.ts
+++ b/frontend/packages/shared/src/format/index.ts
@@ -1,22 +1,20 @@
-export type DateInput = string | number | Date | null | undefined;
+import { format } from 'date-fns';
+
+import {
+  DEFAULT_DATE_FORMAT,
+  DEFAULT_DATE_TIME_FORMAT,
+  toDate,
+  type FlexibleDateInput,
+} from '../utils/parseDate';
+
+export type DateInput = FlexibleDateInput;
 
 const locale =
   typeof navigator !== 'undefined' && navigator.language
     ? navigator.language
     : 'en-US';
 
-const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
 const numberFormatterCache = new Map<string, Intl.NumberFormat>();
-
-function getDateFormatter(opts?: Intl.DateTimeFormatOptions) {
-  const key = JSON.stringify(opts ?? {});
-  let fmt = dateFormatterCache.get(key);
-  if (!fmt) {
-    fmt = new Intl.DateTimeFormat(locale, opts);
-    dateFormatterCache.set(key, fmt);
-  }
-  return fmt;
-}
 
 function getNumberFormatter(opts?: Intl.NumberFormatOptions) {
   const key = JSON.stringify(opts ?? {});
@@ -28,25 +26,16 @@ function getNumberFormatter(opts?: Intl.NumberFormatOptions) {
   return fmt;
 }
 
-export function formatDate(
-  d: DateInput,
-  opts?: Intl.DateTimeFormatOptions
-): string {
-  if (d === null || d === undefined) return '';
-  const date = typeof d === 'string' || typeof d === 'number' ? new Date(d) : d;
-  if (!date || isNaN(date.getTime())) return '';
-  return getDateFormatter(opts).format(date);
+export function formatDate(d: DateInput): string {
+  const date = toDate(d);
+  if (!date) return '';
+  return format(date, DEFAULT_DATE_FORMAT);
 }
 
 export function formatDateTime(d: DateInput): string {
-  return formatDate(d, {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).replace(',', '');
+  const date = toDate(d);
+  if (!date) return '';
+  return format(date, DEFAULT_DATE_TIME_FORMAT);
 }
 
 export function formatBytes(n?: number | null): string {

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -1,39 +1,25 @@
 // packages/shared/src/index.ts
 
-type FlexibleDateInput = string | number | Date | null | undefined;
+import { format } from 'date-fns';
 
-const ruDateTimeFormatter = new Intl.DateTimeFormat('ru-RU', {
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
-});
+import {
+  DEFAULT_DATE_FORMAT,
+  toDate,
+  type FlexibleDateInput,
+} from './utils/parseDate';
 
 export const formatDate = (dateInput?: FlexibleDateInput) => {
   if (dateInput === null || dateInput === undefined) return 'не указана дата';
-  if (typeof dateInput === 'string' && dateInput.length === 0) {
+  if (typeof dateInput === 'string' && dateInput.trim().length === 0) {
     return 'не указана дата';
   }
 
-  let date: Date;
-
-  if (dateInput instanceof Date) {
-    date = dateInput;
-  } else if (typeof dateInput === 'number') {
-    date = new Date(dateInput);
-  } else if (typeof dateInput === 'string') {
-    date = new Date(dateInput);
-  } else {
+  const parsedDate = toDate(dateInput);
+  if (!parsedDate) {
     return 'неверный формат даты';
   }
 
-  if (Number.isNaN(date.getTime())) {
-    return 'неверный формат даты';
-  }
-
-  return ruDateTimeFormatter.format(date);
+  return format(parsedDate, DEFAULT_DATE_FORMAT);
 };
 
 export const getGenderText = (gender?: boolean | null) => {

--- a/frontend/packages/shared/src/utils/parseDate.ts
+++ b/frontend/packages/shared/src/utils/parseDate.ts
@@ -1,0 +1,59 @@
+import { fromUnixTime, isValid, parse, parseISO } from 'date-fns';
+
+export type FlexibleDateInput = string | number | Date | null | undefined;
+
+const UNIX_SECONDS_THRESHOLD = 1_000_000_000_000; // ~ Sat Nov 20 33658
+
+const STRING_PARSE_PATTERNS = [
+  'dd.MM.yyyy HH:mm:ss',
+  'dd.MM.yyyy HH:mm',
+  'dd.MM.yyyy',
+];
+
+export const DEFAULT_DATE_FORMAT = 'dd.MM.yyyy';
+export const DEFAULT_DATE_TIME_FORMAT = 'dd.MM.yyyy HH:mm';
+
+export function toDate(value: FlexibleDateInput): Date | null {
+  if (value instanceof Date) {
+    return isValid(value) ? value : null;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+
+    if (Math.abs(value) < UNIX_SECONDS_THRESHOLD) {
+      const unixDate = fromUnixTime(value);
+      if (isValid(unixDate)) {
+        return unixDate;
+      }
+    }
+
+    const millisecondDate = new Date(value);
+    return isValid(millisecondDate) ? millisecondDate : null;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const isoParsed = parseISO(trimmed);
+    if (isValid(isoParsed)) {
+      return isoParsed;
+    }
+
+    for (const pattern of STRING_PARSE_PATTERNS) {
+      const parsed = parse(trimmed, pattern, new Date());
+      if (isValid(parsed)) {
+        return parsed;
+      }
+    }
+
+    return null;
+  }
+
+  return null;
+}

--- a/frontend/packages/shared/test/format.module.test.ts
+++ b/frontend/packages/shared/test/format.module.test.ts
@@ -1,0 +1,73 @@
+import { format, fromUnixTime, parseISO } from 'date-fns';
+import { describe, expect, it } from 'vitest';
+
+import { formatDate, formatDateTime } from '../src/format';
+
+const DATE_FORMAT = 'dd.MM.yyyy';
+const DATE_TIME_FORMAT = 'dd.MM.yyyy HH:mm';
+
+describe('format module', () => {
+  describe('formatDate', () => {
+    it('formats ISO strings', () => {
+      const iso = '2024-01-02T03:04:05Z';
+      expect(formatDate(iso)).toBe(format(parseISO(iso), DATE_FORMAT));
+    });
+
+    it('formats localized strings supported by parse()', () => {
+      expect(formatDate('07.06.2024 15:30')).toBe('07.06.2024');
+    });
+
+    it('formats timestamps and Date objects', () => {
+      const seconds = 1_700_000_000;
+      const millis = 1_700_000_000_000;
+      const date = new Date('2024-06-07T11:22:33Z');
+
+      expect(formatDate(seconds)).toBe(format(fromUnixTime(seconds), DATE_FORMAT));
+      expect(formatDate(millis)).toBe(format(new Date(millis), DATE_FORMAT));
+      expect(formatDate(date)).toBe(format(date, DATE_FORMAT));
+    });
+
+    it('returns empty string for invalid values', () => {
+      expect(formatDate(undefined)).toBe('');
+      expect(formatDate(null)).toBe('');
+      expect(formatDate('')).toBe('');
+      expect(formatDate('   ')).toBe('');
+      expect(formatDate('not-a-date')).toBe('');
+      expect(formatDate(Number.NaN)).toBe('');
+    });
+  });
+
+  describe('formatDateTime', () => {
+    it('formats ISO strings with time', () => {
+      const iso = '2024-01-02T03:04:05Z';
+      expect(formatDateTime(iso)).toBe(format(parseISO(iso), DATE_TIME_FORMAT));
+    });
+
+    it('formats localized strings supported by parse()', () => {
+      expect(formatDateTime('07.06.2024 15:30')).toBe('07.06.2024 15:30');
+    });
+
+    it('formats timestamps and Date objects', () => {
+      const seconds = 1_700_000_000;
+      const millis = 1_700_000_000_000;
+      const date = new Date('2024-06-07T11:22:33Z');
+
+      expect(formatDateTime(seconds)).toBe(
+        format(fromUnixTime(seconds), DATE_TIME_FORMAT),
+      );
+      expect(formatDateTime(millis)).toBe(
+        format(new Date(millis), DATE_TIME_FORMAT),
+      );
+      expect(formatDateTime(date)).toBe(format(date, DATE_TIME_FORMAT));
+    });
+
+    it('returns empty string for invalid values', () => {
+      expect(formatDateTime(undefined)).toBe('');
+      expect(formatDateTime(null)).toBe('');
+      expect(formatDateTime('')).toBe('');
+      expect(formatDateTime('   ')).toBe('');
+      expect(formatDateTime('not-a-date')).toBe('');
+      expect(formatDateTime(Number.NaN)).toBe('');
+    });
+  });
+});

--- a/frontend/packages/shared/test/formatDate.test.ts
+++ b/frontend/packages/shared/test/formatDate.test.ts
@@ -1,37 +1,39 @@
+import { format, fromUnixTime } from 'date-fns';
 import { describe, expect, it } from 'vitest';
 
 import { formatDate } from '../src/index';
 
-const options: Intl.DateTimeFormatOptions = {
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
-};
+const DATE_FORMAT = 'dd.MM.yyyy';
 
 describe('formatDate (legacy export)', () => {
-  it('formats ISO strings using ru-RU locale', () => {
+  it('formats ISO strings through date-fns', () => {
     const value = '2024-01-02T03:04:05Z';
-    const expected = new Intl.DateTimeFormat('ru-RU', options).format(
-      new Date(value),
-    );
+    expect(formatDate(value)).toBe(format(new Date(value), DATE_FORMAT));
+  });
 
-    expect(formatDate(value)).toBe(expected);
+  it('formats localized strings supported by parse()', () => {
+    expect(formatDate('07.06.2024')).toBe('07.06.2024');
+  });
+
+  it('formats unix timestamps in seconds and milliseconds', () => {
+    const seconds = 1_700_000_000;
+    const millis = 1_700_000_000_000;
+
+    expect(formatDate(seconds)).toBe(format(fromUnixTime(seconds), DATE_FORMAT));
+    expect(formatDate(millis)).toBe(format(new Date(millis), DATE_FORMAT));
   });
 
   it('formats Date instances with the same rules', () => {
     const value = new Date('2024-05-06T07:08:09Z');
-    const expected = new Intl.DateTimeFormat('ru-RU', options).format(value);
-
-    expect(formatDate(value)).toBe(expected);
+    expect(formatDate(value)).toBe(format(value, DATE_FORMAT));
   });
 
   it('keeps legacy fallback messages', () => {
     expect(formatDate(undefined)).toBe('не указана дата');
     expect(formatDate(null)).toBe('не указана дата');
     expect(formatDate('')).toBe('не указана дата');
+    expect(formatDate('   ')).toBe('не указана дата');
+    expect(formatDate(Number.NaN)).toBe('неверный формат даты');
     expect(formatDate('definitely-not-a-date')).toBe('неверный формат даты');
   });
 });


### PR DESCRIPTION
## Summary
- refactor shared date helpers to parse inputs with date-fns and emit dd.MM.yyyy patterns
- add reusable parse utility covering ISO strings, localized inputs, and numeric timestamps
- expand shared unit tests to cover string, numeric, and Date inputs along with invalid fallbacks

## Testing
- pnpm --filter @photobank/shared test

------
https://chatgpt.com/codex/tasks/task_e_68cc3313a51c8328850c788f83e34462