### PR TITLE
fix: normalize photo table date formatting

### DIFF
--- a/frontend/packages/frontend/src/features/photos/components/photoColumns.test.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/photoColumns.test.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { render, screen, renderHook } from '@testing-library/react';
+import { compareAsc, parseISO } from 'date-fns';
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import type { PhotoItemDto } from '@photobank/shared/api/photobank';
+
+import { usePhotoColumns } from './photoColumns';
+
+type MockRootState = {
+  metadata: {
+    loaded: boolean;
+    persons: { id: number; name: string }[];
+    tags: { id: number; name: string }[];
+  };
+};
+
+let mockState: MockRootState;
+
+vi.mock('@/app/hook', () => ({
+  useAppSelector: (selector: (state: MockRootState) => unknown) => selector(mockState),
+}));
+
+const createPhoto = (id: number, takenDate?: string): PhotoItemDto => ({
+  id,
+  name: `Photo ${id}`,
+  storageName: 'storage',
+  relativePath: `photos/${id}.jpg`,
+  ...(takenDate ? { takenDate: takenDate as unknown as Date } : {}),
+});
+
+describe('usePhotoColumns - date column', () => {
+  beforeEach(() => {
+    mockState = {
+      metadata: {
+        loaded: true,
+        persons: [],
+        tags: [],
+      },
+    };
+  });
+
+  it('renders taken date in DD.MM.YYYY format', () => {
+    const { result } = renderHook(() => usePhotoColumns());
+    const dateColumn = result.current.find((col) => col.id === 'date');
+    expect(dateColumn).toBeDefined();
+    const photo = createPhoto(1, '2024-06-07T10:15:00+03:00');
+    const isoValue = dateColumn?.accessorFn?.(photo, 0) as string;
+    const cellNode = dateColumn?.cell?.({ getValue: () => isoValue } as never);
+
+    render(<>{cellNode}</>);
+
+    expect(screen.getByText('07.06.2024')).toBeInTheDocument();
+  });
+
+  it('returns ISO strings that preserve chronological sorting', () => {
+    const { result } = renderHook(() => usePhotoColumns());
+    const dateColumn = result.current.find((col) => col.id === 'date');
+    expect(dateColumn?.accessorFn).toBeDefined();
+
+    const photos = [
+      createPhoto(1, '2024-06-07T10:15:00+03:00'),
+      createPhoto(2, '2024-06-07T07:00:00Z'),
+      createPhoto(3, '2023-12-31T23:30:00-02:00'),
+    ];
+
+    const expectedOrder = photos
+      .slice()
+      .sort((a, b) =>
+        compareAsc(
+          parseISO((a.takenDate as unknown as string) ?? ''),
+          parseISO((b.takenDate as unknown as string) ?? ''),
+        ),
+      )
+      .map((p) => p.id);
+
+    const sortedByAccessor = photos
+      .slice()
+      .sort((a, b) => {
+        const isoA = (dateColumn?.accessorFn?.(a, 0) as string) ?? '';
+        const isoB = (dateColumn?.accessorFn?.(b, 0) as string) ?? '';
+        return isoA.localeCompare(isoB);
+      })
+      .map((p) => p.id);
+
+    expect(sortedByAccessor).toEqual(expectedOrder);
+  });
+});

--- a/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { format, formatISO, isValid, parseISO } from 'date-fns';
 import type { ColumnDef } from '@tanstack/react-table';
 import type {
   PhotoItemDto,
@@ -112,11 +113,25 @@ export function usePhotoColumns(): ColumnDef<PhotoItemDto>[] {
     {
       id: 'date',
       header: 'Taken',
-      accessorFn: (p) => (p.takenDate ? new Date(p.takenDate).toISOString() : ''),
+      accessorFn: (p) => {
+        const rawValue = p.takenDate;
+        if (!rawValue) return '';
+        const isoInput =
+          typeof rawValue === 'string'
+            ? rawValue
+            : rawValue instanceof Date
+              ? rawValue.toISOString()
+              : '';
+        if (!isoInput) return '';
+        const parsed = parseISO(isoInput);
+        return isValid(parsed) ? formatISO(parsed) : '';
+      },
       cell: ({ getValue }) => {
         const iso = getValue() as string;
         if (!iso) return null;
-        return <span className="text-sm">{new Date(iso).toLocaleDateString()}</span>;
+        const parsed = parseISO(iso);
+        if (!isValid(parsed)) return null;
+        return <span className="text-sm">{format(parsed, 'dd.MM.yyyy')}</span>;
       },
       size: 120,
     },

--- a/frontend/packages/frontend/test-setup.ts
+++ b/frontend/packages/frontend/test-setup.ts
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom/vitest';
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = ResizeObserver;
+
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      media: query,
+      matches: false,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false;
+      },
+    }),
+  });
+}

--- a/frontend/packages/frontend/vitest.config.ts
+++ b/frontend/packages/frontend/vitest.config.ts
@@ -1,21 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import * as path from 'node:path';
 
-import '@testing-library/jest-dom/vitest';
-
-// Моки для JSDOM
-class ResizeObserver { observe(){} unobserve(){} disconnect(){} }
-(globalThis as any).ResizeObserver = ResizeObserver;
-
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (q: string) => ({
-    media: q, matches: false, onchange: null,
-    addListener() {}, removeListener() {}, addEventListener() {}, removeEventListener() {},
-    dispatchEvent() { return false; }
-  }),
-});
-
 export default defineConfig({
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- normalize the photo list date column by parsing ISO strings with date-fns before formatting
- add focused hook tests that verify formatting and sortable ISO output
- move Vitest polyfills into the shared setup file to keep configuration lean

## Testing
- pnpm --filter @photobank/frontend exec -- vitest run --reporter=dot src/features/photos/components/photoColumns.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc34e5d93c832895ce6b1c79d37d9c