### PR TITLE
fix: validate photo filter date parsing

### DIFF
--- a/frontend/packages/shared/src/ai/__tests__/filter.spec.ts
+++ b/frontend/packages/shared/src/ai/__tests__/filter.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { PhotoFilterSchema } from '../filter';
+
+describe('PhotoFilterSchema date transformations', () => {
+  it('parses ISO datetime strings into Date instances', () => {
+    const isoFrom = '2024-06-07T08:09:10Z';
+    const isoTo = '2024-06-08T09:10:11Z';
+    const expectedFrom = new Date(isoFrom).toISOString();
+    const expectedTo = new Date(isoTo).toISOString();
+
+    const result = PhotoFilterSchema.parse({
+      dateFrom: isoFrom,
+      dateTo: isoTo,
+    });
+
+    expect(result.dateFrom).toBeInstanceOf(Date);
+    expect(result.dateFrom?.toISOString()).toBe(expectedFrom);
+    expect(result.dateTo).toBeInstanceOf(Date);
+    expect(result.dateTo?.toISOString()).toBe(expectedTo);
+  });
+
+  it('parses day strings into UTC midnight Date instances', () => {
+    const result = PhotoFilterSchema.parse({
+      dateFrom: '2024-06-07',
+      dateTo: '2024-06-08',
+    });
+
+    expect(result.dateFrom).toBeInstanceOf(Date);
+    expect(result.dateFrom?.toISOString()).toBe('2024-06-07T00:00:00.000Z');
+    expect(result.dateTo).toBeInstanceOf(Date);
+    expect(result.dateTo?.toISOString()).toBe('2024-06-08T00:00:00.000Z');
+  });
+
+  it('returns null for invalid ISO datetime strings', () => {
+    const result = PhotoFilterSchema.parse({
+      dateFrom: '2024-13-01T00:00:00Z',
+      dateTo: '2024-02-30T12:00:00Z',
+    });
+
+    expect(result.dateFrom).toBeNull();
+    expect(result.dateTo).toBeNull();
+  });
+
+  it('returns null for invalid day strings', () => {
+    const result = PhotoFilterSchema.parse({
+      dateFrom: '2024-13-01',
+      dateTo: 'not-a-date',
+    });
+
+    expect(result.dateFrom).toBeNull();
+    expect(result.dateTo).toBeNull();
+  });
+});

--- a/frontend/packages/shared/src/ai/filter.ts
+++ b/frontend/packages/shared/src/ai/filter.ts
@@ -1,4 +1,18 @@
+import { isValid, parseISO } from 'date-fns';
 import { z } from "zod";
+
+const toFilterDate = (value: string | null): Date | null => {
+  if (!value) return null;
+
+  const iso = value.includes('T') ? value : `${value}T00:00:00Z`;
+  const parsed = parseISO(iso);
+
+  if (!isValid(parsed)) {
+    return null;
+  }
+
+  return parsed;
+};
 
 export const PhotoFilterSchema = z.object({
   personNames: z.array(z.string()).default([]),
@@ -7,21 +21,13 @@ export const PhotoFilterSchema = z.object({
     .string()
     .nullable()
     .default(null)
-    .transform((val) => {
-      if (!val) return null;
-      const iso = val.includes('T') ? val : `${val}T00:00:00Z`;
-      return new Date(iso);
-    }),
+    .transform((val) => toFilterDate(val)),
 
   dateTo: z
     .string()
     .nullable()
     .default(null)
-    .transform((val) => {
-      if (!val) return null;
-      const iso = val.includes('T') ? val : `${val}T00:00:00Z`;
-      return new Date(iso);
-    }),
+    .transform((val) => toFilterDate(val)),
 });
 
 export const photoFilterSchemaForLLM = {


### PR DESCRIPTION
## Summary
- replace photo filter date transforms to use parseISO with validation
- return null for invalid date inputs instead of Invalid Date objects
- add unit tests covering ISO and day-based inputs for the photo filter schema

## Testing
- pnpm --filter @photobank/shared build
- pnpm --filter @photobank/shared test

------
https://chatgpt.com/codex/tasks/task_e_68cc36c3054c8328afb108a2948ca218