### PR TITLE
fix: validate photo dates in Telegram bot listing

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photosPage.test.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { FilterDto } from '@photobank/shared';
+import type { PhotoDto } from '@photobank/shared/api/photobank';
+
+vi.mock('../services/photo', () => ({
+  searchPhotos: vi.fn(),
+}));
+
+vi.mock('../errorHandler', () => ({
+  handleCommandError: vi.fn(),
+}));
+
+import { sendPhotosPage, PHOTOS_PAGE_SIZE } from './photosPage';
+import type { MyContext } from '../i18n';
+import { captionCache, currentPagePhotos } from '../photo';
+import { searchPhotos } from '../services/photo';
+
+const searchPhotosMock = vi.mocked(searchPhotos);
+
+function createPhoto(overrides: Partial<PhotoDto> = {}): PhotoDto {
+  return {
+    id: 1,
+    name: 'Sample Photo Name',
+    storageName: 'Main Storage',
+    relativePath: 'album/photo.jpg',
+    takenDate: '2024-05-01T10:00:00Z',
+    captions: ['A quick caption'],
+    persons: [],
+    isAdultContent: false,
+    isRacyContent: false,
+    ...overrides,
+  } as PhotoDto;
+}
+
+function createContext(): MyContext {
+  const reply = vi.fn().mockResolvedValue({ message_id: 1 });
+  const editMessageText = vi.fn().mockResolvedValue({});
+  const t = vi.fn((key: string, params?: Record<string, number>) => {
+    if (key === 'unknown-year') return 'Unknown Year';
+    if (key === 'page-info') return `Page ${params?.page} / ${params?.total}`;
+    if (key === 'people-count') return `👥 ${params?.count}`;
+    if (key === 'untitled') return 'Untitled';
+    return key;
+  });
+
+  return {
+    chat: { id: 123 },
+    reply,
+    editMessageText,
+    t,
+  } as unknown as MyContext;
+}
+
+describe('sendPhotosPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captionCache.clear();
+    currentPagePhotos.clear();
+  });
+
+  it('renders the year for a valid ISO takenDate', async () => {
+    const ctx = createContext();
+    searchPhotosMock.mockResolvedValue({
+      totalCount: 1,
+      items: [createPhoto({ takenDate: '2023-08-15T00:00:00Z' })],
+    });
+
+    await sendPhotosPage({
+      ctx,
+      filter: {} as FilterDto,
+      page: 1,
+      fallbackMessage: 'No photos found',
+      buildCallbackData: (page) => `page:${page}`,
+    });
+
+    expect(searchPhotosMock).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ page: 1, pageSize: PHOTOS_PAGE_SIZE })
+    );
+    expect(ctx.reply).toHaveBeenCalledWith(
+      expect.stringContaining('<b>2023</b>'),
+      expect.objectContaining({ parse_mode: 'HTML' })
+    );
+  });
+
+  it('falls back to unknown year when takenDate is invalid', async () => {
+    const ctx = createContext();
+    searchPhotosMock.mockResolvedValue({
+      totalCount: 1,
+      items: [createPhoto({ takenDate: 'not-a-date' })],
+    });
+
+    await sendPhotosPage({
+      ctx,
+      filter: {} as FilterDto,
+      page: 1,
+      fallbackMessage: 'No photos found',
+      buildCallbackData: (page) => `page:${page}`,
+    });
+
+    expect(ctx.reply).toHaveBeenCalledWith(
+      expect.stringContaining('<b>Unknown Year</b>'),
+      expect.objectContaining({ parse_mode: 'HTML' })
+    );
+  });
+});

--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -1,4 +1,5 @@
 import { InlineKeyboard } from 'grammy';
+import { getYear, isValid, parseISO } from 'date-fns';
 import { firstNWords, type FilterDto } from '@photobank/shared';
 
 import type { MyContext } from '../i18n';
@@ -60,7 +61,11 @@ export async function sendPhotosPage({
   const byYear = new Map<number, Map<string, typeof items>>();
 
   for (const photo of queryResult.items) {
-    const year = photo.takenDate ? new Date(photo.takenDate).getFullYear() : 0;
+    let year = 0;
+    if (photo.takenDate) {
+      const parsed = parseISO(photo.takenDate);
+      year = isValid(parsed) ? getYear(parsed) : 0;
+    }
     let yearMap = byYear.get(year);
     if (!yearMap) {
       yearMap = new Map();

--- a/frontend/packages/telegram-bot/test-setup.ts
+++ b/frontend/packages/telegram-bot/test-setup.ts
@@ -2,7 +2,8 @@ import { afterAll, afterEach, beforeAll } from 'vitest';
 import { setupServer } from 'msw/node';
 let handlers: any[] = [];
 try {
-  ({ handlers } = await import('@photobank/shared/api/photobank/msw'));
+  const module = await import('@photobank/shared/api/photobank/msw');
+  handlers = Array.isArray(module.handlers) ? module.handlers : [];
 } catch {
   // shared MSW handlers are optional for lightweight tests
 }


### PR DESCRIPTION
## Summary
- use date-fns parsing with validation when grouping photos by year
- ensure MSW test setup safely falls back when shared handlers are unavailable
- add unit tests for sendPhotosPage covering valid and invalid takenDate values

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68cc383f9388832898770e1e0a084f03