### PR TITLE
test: add jest-dom vitest types

### DIFF
--- a/frontend/packages/frontend/tsconfig.app.json
+++ b/frontend/packages/frontend/tsconfig.app.json
@@ -4,7 +4,11 @@
     "jsx": "react-jsx",
     "noEmit": true,                       // фронт не эмитит; сборка делается Vite
     "moduleDetection": "force",
-    "types": ["vite/client", "vitest/globals"],
+    "types": [
+      "vite/client",
+      "vitest/globals",
+      "@testing-library/jest-dom/vitest"
+    ],
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"],


### PR DESCRIPTION
## Summary
- add @testing-library/jest-dom/vitest to the frontend tsconfig types so Vitest sees jest-dom matchers
- tighten the photoColumns unit test typings to access the date column accessor safely

## Testing
- pnpm --filter @photobank/frontend build

------
https://chatgpt.com/codex/tasks/task_e_68cc3e75e30883288f199bd65e85943d