### PR TITLE
fix: guard takenDate parsing for telegram photos listing

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photosPage.test.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { FilterDto } from '@photobank/shared';
-import type { PhotoDto } from '@photobank/shared/api/photobank';
+import type { PhotoItemDto } from '@photobank/shared/api/photobank';
 
 vi.mock('../services/photo', () => ({
   searchPhotos: vi.fn(),
@@ -17,7 +17,11 @@ import { searchPhotos } from '../services/photo';
 
 const searchPhotosMock = vi.mocked(searchPhotos);
 
-function createPhoto(overrides: Partial<PhotoDto> = {}): PhotoDto {
+type PhotoOverrides = Partial<Omit<PhotoItemDto, 'takenDate'>> & {
+  takenDate?: string | Date | null;
+};
+
+function createPhoto(overrides: PhotoOverrides = {}): PhotoItemDto {
   return {
     id: 1,
     name: 'Sample Photo Name',
@@ -29,7 +33,7 @@ function createPhoto(overrides: Partial<PhotoDto> = {}): PhotoDto {
     isAdultContent: false,
     isRacyContent: false,
     ...overrides,
-  } as PhotoDto;
+  } as unknown as PhotoItemDto;
 }
 
 function createContext(): MyContext {

--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -62,9 +62,22 @@ export async function sendPhotosPage({
 
   for (const photo of queryResult.items) {
     let year = 0;
-    if (photo.takenDate) {
-      const parsed = parseISO(photo.takenDate);
-      year = isValid(parsed) ? getYear(parsed) : 0;
+    const rawTakenDate = photo.takenDate;
+    let parsedDate: Date | null = null;
+
+    if (rawTakenDate instanceof Date) {
+      parsedDate = rawTakenDate;
+    } else {
+      const maybeTakenDateString = rawTakenDate as unknown;
+      if (typeof maybeTakenDateString === 'string') {
+        parsedDate = parseISO(maybeTakenDateString);
+      }
+    }
+
+    if (parsedDate) {
+      if (isValid(parsedDate)) {
+        year = getYear(parsedDate);
+      }
     }
     let yearMap = byYear.get(year);
     if (!yearMap) {


### PR DESCRIPTION
## Summary
- ensure the photos page year grouping handles Date objects and ISO strings safely
- align unit test helpers with PhotoItemDto shape while allowing string-based takenDate overrides

## Testing
- pnpm --filter @photobank/telegram-bot typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cc497bfd248328a9f4dc1406b2b802