### PR TITLE
fix: rely on shared date parsing for photo captions

### DIFF
--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -7,7 +7,7 @@ export function formatPhotoMessage(photo: PhotoDto): { caption: string; hasSpoil
 
   lines.push(`📸 <b>${photo.name}</b>`);
   if (photo.takenDate) {
-    lines.push(`📅 ${formatDate(photo.takenDate.toISOString())}`);
+    lines.push(`📅 ${formatDate(photo.takenDate)}`);
   }
 
   // lines.push(`📏 ${photo.width}×${photo.height}`);

--- a/frontend/packages/telegram-bot/src/photo.test.ts
+++ b/frontend/packages/telegram-bot/src/photo.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { InputFile } from 'grammy';
 import type { PhotoDto } from '@photobank/shared/api/photobank';
 
+import { formatPhotoMessage } from './formatPhotoMessage';
 import { loadPhotoFile } from './photo';
 
 function createPhoto(overrides: Partial<PhotoDto> = {}): PhotoDto {
@@ -11,6 +12,22 @@ function createPhoto(overrides: Partial<PhotoDto> = {}): PhotoDto {
     ...overrides,
   } as PhotoDto;
 }
+
+describe('formatPhotoMessage', () => {
+  it('formats ISO string takenDate values without throwing', () => {
+    const isoString = '2023-02-01T15:30:00.000Z';
+    const photo = createPhoto({
+      takenDate: isoString as unknown as Date,
+    });
+
+    let result: ReturnType<typeof formatPhotoMessage> | undefined;
+    expect(() => {
+      result = formatPhotoMessage(photo);
+    }).not.toThrow();
+
+    expect(result?.caption).toContain('📅 01.02.2023');
+  });
+});
 
 describe('loadPhotoFile', () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary
- update the Telegram photo caption formatter to pass the raw takenDate value into the shared date helper
- add a unit test that verifies ISO string dates are formatted without throwing

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68cc566f32c8832889741a41400b5fe8