### PR TITLE
feat: add telegram subscriptions endpoint

### DIFF
--- a/backend/PhotoBank.IntegrationTests/Auth/TelegramSubscriptionsTests.cs
+++ b/backend/PhotoBank.IntegrationTests/Auth/TelegramSubscriptionsTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using Testcontainers.MsSql;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Minio;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.Api;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.ViewModel.Dto;
+using Respawn;
+
+namespace PhotoBank.IntegrationTests.Auth;
+
+[TestFixture]
+public class TelegramSubscriptionsTests
+{
+    private const string ServiceKey = "integration-telegram-key";
+
+    private MsSqlContainer _dbContainer = null!;
+    private Respawner _respawner = null!;
+    private string _connectionString = string.Empty;
+    private TestWebApplicationFactory _factory = null!;
+    private HttpClient _client = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetup()
+    {
+        try
+        {
+            _dbContainer = new MsSqlBuilder()
+                .WithPassword("yourStrong(!)Password")
+                .Build();
+            await _dbContainer.StartAsync();
+        }
+        catch (ArgumentException ex) when (ex.Message.Contains("Docker endpoint"))
+        {
+            Assert.Ignore("Docker not available: " + ex.Message);
+        }
+
+        _connectionString = _dbContainer.GetConnectionString();
+
+        var options = new DbContextOptionsBuilder<PhotoBankDbContext>()
+            .UseSqlServer(_connectionString, builder =>
+            {
+                builder.MigrationsAssembly(typeof(PhotoBankDbContext).Assembly.GetName().Name);
+                builder.UseNetTopologySuite();
+            })
+            .Options;
+
+        await using (var db = new PhotoBankDbContext(options))
+        {
+            await db.Database.MigrateAsync();
+        }
+
+        await using var conn = new SqlConnection(_connectionString);
+        await conn.OpenAsync();
+        _respawner = await Respawner.CreateAsync(conn, new RespawnerOptions
+        {
+            DbAdapter = DbAdapter.SqlServer,
+            TablesToIgnore = new[]
+            {
+                new Respawn.Graph.Table("__EFMigrationsHistory")
+            }
+        });
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dbContainer != null)
+        {
+            await _dbContainer.DisposeAsync();
+        }
+    }
+
+    [SetUp]
+    public async Task Setup()
+    {
+        if (_respawner == null)
+        {
+            Assert.Ignore("Database respawner is not available.");
+        }
+
+        await using (var conn = new SqlConnection(_connectionString))
+        {
+            await conn.OpenAsync();
+            await _respawner.ResetAsync(conn);
+        }
+
+        _factory = new TestWebApplicationFactory(_connectionString, ServiceKey);
+        _client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("http://localhost")
+        });
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+    }
+
+    [Test]
+    public async Task GetTelegramSubscriptions_WithoutServiceKey_ReturnsUnauthorized()
+    {
+        var response = await _client.GetAsync("/api/auth/telegram/subscriptions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task GetTelegramSubscriptions_WithServiceKey_ReturnsSubscriptions()
+    {
+        await SeedUsersAsync();
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/auth/telegram/subscriptions");
+        request.Headers.Add("X-Service-Key", ServiceKey);
+
+        var response = await _client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payload = await response.Content.ReadAsStringAsync();
+        var result = JsonSerializer.Deserialize<List<TelegramSubscriptionDto>>(payload, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        result.Should().NotBeNull();
+        result!.Should().BeEquivalentTo(new[]
+        {
+            new TelegramSubscriptionDto
+            {
+                TelegramUserId = 123456789,
+                TelegramSendTimeUtc = TimeSpan.FromHours(8)
+            },
+            new TelegramSubscriptionDto
+            {
+                TelegramUserId = 987654321,
+                TelegramSendTimeUtc = TimeSpan.FromHours(9)
+            }
+        }, options => options.WithStrictOrdering());
+    }
+
+    private async Task SeedUsersAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var alice = new ApplicationUser
+        {
+            UserName = "alice@example.com",
+            Email = "alice@example.com",
+            TelegramUserId = 123456789,
+            TelegramSendTimeUtc = TimeSpan.FromHours(8)
+        };
+
+        var bob = new ApplicationUser
+        {
+            UserName = "bob@example.com",
+            Email = "bob@example.com",
+            TelegramUserId = 987654321,
+            TelegramSendTimeUtc = TimeSpan.FromHours(9)
+        };
+
+        var charlie = new ApplicationUser
+        {
+            UserName = "charlie@example.com",
+            Email = "charlie@example.com",
+            TelegramUserId = 555,
+            TelegramSendTimeUtc = null
+        };
+
+        var dana = new ApplicationUser
+        {
+            UserName = "dana@example.com",
+            Email = "dana@example.com",
+            TelegramUserId = null,
+            TelegramSendTimeUtc = TimeSpan.FromHours(10)
+        };
+
+        var result1 = await userManager.CreateAsync(alice);
+        result1.Succeeded.Should().BeTrue();
+
+        var result2 = await userManager.CreateAsync(bob);
+        result2.Succeeded.Should().BeTrue();
+
+        var result3 = await userManager.CreateAsync(charlie);
+        result3.Succeeded.Should().BeTrue();
+
+        var result4 = await userManager.CreateAsync(dana);
+        result4.Succeeded.Should().BeTrue();
+    }
+
+    private sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
+    {
+        private readonly string _connectionString;
+        private readonly string _serviceKey;
+
+        public TestWebApplicationFactory(string connectionString, string serviceKey)
+        {
+            _connectionString = connectionString;
+            _serviceKey = serviceKey;
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment(Environments.Development);
+            builder.ConfigureAppConfiguration((context, configBuilder) =>
+            {
+                var overrides = new Dictionary<string, string?>
+                {
+                    ["ConnectionStrings:DefaultConnection"] = _connectionString,
+                    ["Jwt:Issuer"] = "issuer",
+                    ["Jwt:Audience"] = "audience",
+                    ["Jwt:Key"] = "super-secret",
+                    ["Auth:Telegram:ServiceKey"] = _serviceKey
+                };
+                configBuilder.AddInMemoryCollection(overrides);
+            });
+
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IMinioClient>();
+                services.AddSingleton(Mock.Of<IMinioClient>());
+            });
+        }
+    }
+}

--- a/backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj
+++ b/backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.2" />
     <PackageReference Include="FluentAssertions" Version="8.6.0" />
     <PackageReference Include="nunit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />

--- a/backend/PhotoBank.ViewModel.Dto/TelegramSubscriptionDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/TelegramSubscriptionDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace PhotoBank.ViewModel.Dto;
+
+public class TelegramSubscriptionDto
+{
+    public required long TelegramUserId { get; init; }
+
+    public required TimeSpan TelegramSendTimeUtc { get; init; }
+}


### PR DESCRIPTION
## Summary
- add a Telegram subscription DTO for exposing linked chat IDs and send times
- extend the auth controller with a service-key protected Telegram subscription export endpoint
- cover the new endpoint with integration tests backed by SQL Server Testcontainers and WebApplicationFactory

## Testing
- `dotnet test backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccff670e688328ba4bb84674ecd54d