### PR TITLE
feat: restore telegram subscriptions

### DIFF
--- a/frontend/packages/telegram-bot/src/api/auth.ts
+++ b/frontend/packages/telegram-bot/src/api/auth.ts
@@ -1,4 +1,5 @@
 import { configureApi } from '@photobank/shared';
+import type { TelegramSubscriptionDto } from '@photobank/shared/api/photobank';
 import { customFetcher } from '@photobank/shared/api/photobank/fetcher';
 
 import { BOT_SERVICE_KEY } from '../config';
@@ -23,4 +24,17 @@ export async function exchangeTelegramUserToken(telegramUserId: number, username
     },
   );
   return res.data;
+}
+
+export async function fetchTelegramSubscriptions(): Promise<TelegramSubscriptionDto[]> {
+  const res = await customFetcher<{ data: TelegramSubscriptionDto[] }>(
+    '/auth/telegram/subscriptions',
+    {
+      method: 'GET',
+      headers: {
+        'X-Service-Key': serviceKey,
+      },
+    },
+  );
+  return res.data ?? [];
 }

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -14,7 +14,7 @@ import { captionCache } from "./photo";
 import { sendSearchPage, searchCommand, decodeSearchCallback } from "./commands/search";
 import { aiCommand, sendAiPage } from "./commands/ai";
 import { helpCommand } from "./commands/help";
-import { subscribeCommand, initSubscriptionScheduler } from "./commands/subscribe";
+import { subscribeCommand, initSubscriptionScheduler, restoreSubscriptions } from "./commands/subscribe";
 import { tagsCommand, sendTagsPage } from "./commands/tags";
 import { personsCommand, sendPersonsPage } from "./commands/persons";
 import { storagesCommand, sendStoragesPage } from "./commands/storages";
@@ -205,4 +205,5 @@ await bot.api.setMyCommands(groupCommands('ru'), {
 
 bot.start();
 logger.info('bot started');
+await restoreSubscriptions(bot);
 initSubscriptionScheduler(bot);

--- a/frontend/packages/telegram-bot/test/openaiDisabled.test.ts
+++ b/frontend/packages/telegram-bot/test/openaiDisabled.test.ts
@@ -18,7 +18,11 @@ describe('bot without OpenAI', () => {
     vi.mock('../src/commands/search', () => ({ sendSearchPage: vi.fn(), searchCommand: vi.fn(), decodeSearchCallback: vi.fn(() => null) }));
     vi.mock('../src/commands/ai', () => ({ aiCommand: vi.fn(), sendAiPage: vi.fn() }));
     vi.mock('../src/commands/help', () => ({ helpCommand: vi.fn() }));
-    vi.mock('../src/commands/subscribe', () => ({ subscribeCommand: vi.fn(), initSubscriptionScheduler: vi.fn() }));
+    vi.mock('../src/commands/subscribe', () => ({
+      subscribeCommand: vi.fn(),
+      initSubscriptionScheduler: vi.fn(),
+      restoreSubscriptions: vi.fn(() => Promise.resolve()),
+    }));
     vi.mock('../src/commands/tags', () => ({ tagsCommand: vi.fn(), sendTagsPage: vi.fn() }));
     vi.mock('../src/commands/persons', () => ({ personsCommand: vi.fn(), sendPersonsPage: vi.fn() }));
     vi.mock('../src/commands/storages', () => ({ storagesCommand: vi.fn(), sendStoragesPage: vi.fn() }));

--- a/frontend/packages/telegram-bot/test/subscriptionScheduler.test.ts
+++ b/frontend/packages/telegram-bot/test/subscriptionScheduler.test.ts
@@ -7,11 +7,25 @@ const sendThisDayPage = vi.hoisted(() =>
   vi.fn<[MyContext, number, boolean?], Promise<void>>(() => Promise.resolve()),
 );
 
+const fetchTelegramSubscriptions = vi.hoisted(() =>
+  vi.fn<[], Promise<Array<{ telegramUserId: number; telegramSendTimeUtc: string }>>>(
+    () => Promise.resolve([]),
+  ),
+);
+
 vi.mock('../src/commands/thisday', () => ({
   sendThisDayPage,
 }));
 
-import { initSubscriptionScheduler, subscriptions } from '../src/commands/subscribe';
+vi.mock('../src/api/auth', async () => {
+  const actual = await vi.importActual<typeof import('../src/api/auth')>('../src/api/auth');
+  return {
+    ...actual,
+    fetchTelegramSubscriptions,
+  };
+});
+
+import { initSubscriptionScheduler, restoreSubscriptions, subscriptions } from '../src/commands/subscribe';
 
 describe('initSubscriptionScheduler', () => {
   it('reuses stored telegram user info when triggering scheduled send', () => {
@@ -49,6 +63,69 @@ describe('initSubscriptionScheduler', () => {
             id: from.id,
             username: from.username,
           }),
+        }),
+        1,
+      );
+    } finally {
+      subscriptions.clear();
+      intervalSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('restores saved subscriptions before scheduler tick', async () => {
+    subscriptions.clear();
+    sendThisDayPage.mockClear();
+    fetchTelegramSubscriptions.mockClear();
+    fetchTelegramSubscriptions.mockResolvedValueOnce([
+      { telegramUserId: 123, telegramSendTimeUtc: '05:10:00' },
+    ]);
+
+    const getChat = vi.fn(() =>
+      Promise.resolve({
+        id: 123,
+        type: 'private',
+        first_name: 'Restored',
+        username: 'restored_user',
+      }),
+    );
+    const bot = {
+      api: {
+        sendMessage: vi.fn(() => Promise.resolve(undefined)),
+        getChat,
+      },
+    } as unknown as Bot<MyContext>;
+
+    await restoreSubscriptions(bot);
+
+    expect(fetchTelegramSubscriptions).toHaveBeenCalledTimes(1);
+    expect(getChat).toHaveBeenCalledWith(123);
+    expect(subscriptions.get(123)).toMatchObject({
+      time: '05:10',
+      locale: 'en',
+      from: expect.objectContaining({
+        id: 123,
+        first_name: 'Restored',
+        username: 'restored_user',
+      }),
+    });
+
+    vi.useFakeTimers();
+    const intervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+    try {
+      initSubscriptionScheduler(bot);
+
+      expect(intervalSpy).toHaveBeenCalledTimes(1);
+      const intervalCallback = intervalSpy.mock.calls[0]![0] as () => void;
+
+      vi.setSystemTime(new Date('2024-01-01T05:10:00Z'));
+      intervalCallback();
+
+      expect(sendThisDayPage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chat: expect.objectContaining({ id: 123 }),
+          from: expect.objectContaining({ id: 123 }),
         }),
         1,
       );


### PR DESCRIPTION
## Summary
- add a service-key authenticated helper to read saved Telegram subscriptions from the API
- hydrate the in-memory subscription map during startup with restored entries and chat metadata
- ensure the scheduler bootstrap path is covered with new Vitest cases

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68cd392ff87483288f14898e1fb3d645