### PR TITLE
feat: add search reference data service for filters

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -30,6 +30,7 @@ public static partial class ServiceCollectionExtensions
         services.AddScoped<IFaceStorageService, FaceStorageService>();
         services.AddScoped<MinioObjectService>();
         services.AddScoped<IPhotoService, PhotoService>();
+        services.AddScoped<ISearchReferenceDataService, SearchReferenceDataService>();
         services.AddPhotoEvents();
         if (configuration != null)
         {

--- a/backend/PhotoBank.Services/Search/ISearchReferenceDataService.cs
+++ b/backend/PhotoBank.Services/Search/ISearchReferenceDataService.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Services.Search;
+
+public interface ISearchReferenceDataService
+{
+    Task<IReadOnlyList<PersonDto>> GetPersonsAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<TagDto>> GetTagsAsync(CancellationToken cancellationToken = default);
+    void InvalidatePersonsCache();
+}

--- a/backend/PhotoBank.Services/Search/SearchReferenceDataService.cs
+++ b/backend/PhotoBank.Services/Search/SearchReferenceDataService.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using PhotoBank.AccessControl;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+using PhotoBank.Services.Internal;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Services.Search;
+
+public sealed class SearchReferenceDataService : ISearchReferenceDataService
+{
+    private readonly IRepository<Person> _personRepository;
+    private readonly IRepository<Tag> _tagRepository;
+    private readonly ICurrentUser _currentUser;
+    private readonly IMemoryCache _cache;
+    private readonly IMapper _mapper;
+
+    private readonly Lazy<Task<IReadOnlyList<PersonDto>>> _persons;
+    private readonly Lazy<Task<IReadOnlyList<TagDto>>> _tags;
+
+    private static readonly MemoryCacheEntryOptions CacheOptions = new()
+    {
+        AbsoluteExpiration = null,
+        SlidingExpiration = null
+    };
+
+    public SearchReferenceDataService(
+        IRepository<Person> personRepository,
+        IRepository<Tag> tagRepository,
+        ICurrentUser currentUser,
+        IMemoryCache cache,
+        IMapper mapper)
+    {
+        _personRepository = personRepository;
+        _tagRepository = tagRepository;
+        _currentUser = currentUser;
+        _cache = cache;
+        _mapper = mapper;
+
+        _persons = new Lazy<Task<IReadOnlyList<PersonDto>>>(() =>
+            GetCachedAsync(CacheKeys.Persons(_currentUser), async () =>
+            {
+                var query = _personRepository.GetAll()
+                    .AsNoTracking()
+                    .MaybeApplyAcl(_currentUser);
+
+                var items = await query
+                    .OrderBy(p => p.Name).ThenBy(p => p.Id)
+                    .ProjectTo<PersonDto>(_mapper.ConfigurationProvider)
+                    .ToListAsync();
+                return (IReadOnlyList<PersonDto>)items;
+            }));
+
+        _tags = new Lazy<Task<IReadOnlyList<TagDto>>>(() =>
+            GetCachedAsync(CacheKeys.Tags, async () =>
+            {
+                var items = await _tagRepository.GetAll()
+                    .AsNoTracking()
+                    .OrderBy(t => t.Name).ThenBy(t => t.Id)
+                    .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
+                    .ToListAsync();
+                return (IReadOnlyList<TagDto>)items;
+            }));
+    }
+
+    public Task<IReadOnlyList<PersonDto>> GetPersonsAsync(CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<PersonDto>>(cancellationToken);
+        }
+
+        return _persons.Value;
+    }
+
+    public Task<IReadOnlyList<TagDto>> GetTagsAsync(CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<TagDto>>(cancellationToken);
+        }
+
+        return _tags.Value;
+    }
+
+    public void InvalidatePersonsCache()
+    {
+        _cache.Remove(CacheKeys.PersonsAll);
+        _cache.Remove(CacheKeys.PersonsOf(_currentUser.UserId));
+    }
+
+    private async Task<IReadOnlyList<T>> GetCachedAsync<T>(string key, Func<Task<IReadOnlyList<T>>> factory)
+    {
+        if (!_cache.TryGetValue(key, out IReadOnlyList<T> values))
+        {
+            values = await factory();
+            _cache.Set(key, values, CacheOptions);
+        }
+
+        return values;
+    }
+}

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -14,6 +14,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Search;
 using System;
 using System.Threading.Tasks;
 
@@ -35,6 +36,7 @@ public class PersonGroupServiceTests
         services.AddMemoryCache();
         services.AddAutoMapper(cfg => cfg.AddProfile<MappingProfile>());
         services.AddScoped<ICurrentUser, DummyCurrentUser>();
+        services.AddScoped<ISearchReferenceDataService, SearchReferenceDataService>();
         _provider = services.BuildServiceProvider();
 
         var db = _provider.GetRequiredService<PhotoBankDbContext>();
@@ -48,12 +50,12 @@ public class PersonGroupServiceTests
             _provider.GetRequiredService<IRepository<Person>>(),
             _provider.GetRequiredService<IRepository<Face>>(),
             _provider.GetRequiredService<IRepository<Storage>>(),
-            _provider.GetRequiredService<IRepository<Tag>>(),
             _provider.GetRequiredService<IRepository<PersonGroup>>(),
             _provider.GetRequiredService<IRepository<PersonFace>>(),
             _provider.GetRequiredService<IMapper>(),
             _provider.GetRequiredService<IMemoryCache>(),
             _provider.GetRequiredService<ICurrentUser>(),
+            _provider.GetRequiredService<ISearchReferenceDataService>(),
             new Mock<IS3ResourceService>().Object,
             new MinioObjectService(new Mock<IMinioClient>().Object),
             new Mock<IMinioClient>().Object,

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -16,10 +16,12 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Search;
 using PhotoBank.ViewModel.Dto;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PhotoBank.UnitTests.Services
@@ -49,18 +51,26 @@ namespace PhotoBank.UnitTests.Services
             services.AddDbContext<PhotoBankDbContext>(o => o.UseInMemoryDatabase(dbName));
             var provider = services.BuildServiceProvider();
             var context = provider.GetRequiredService<PhotoBankDbContext>();
+            var referenceDataService = new Mock<ISearchReferenceDataService>();
+            referenceDataService
+                .Setup(s => s.GetPersonsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<PersonDto>());
+            referenceDataService
+                .Setup(s => s.GetTagsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<TagDto>());
+
             return new PhotoService(
                 context,
                 new Repository<Photo>(provider),
                 new Repository<Person>(provider),
                 new Repository<Face>(provider),
                 new Repository<Storage>(provider),
-                new Repository<Tag>(provider),
                 new Repository<PersonGroup>(provider),
                 new Repository<PersonFace>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser(),
+                referenceDataService.Object,
                 new Mock<IS3ResourceService>().Object,
                 new MinioObjectService(new Mock<IMinioClient>().Object),
                 new Mock<IMinioClient>().Object,

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -15,9 +15,12 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Search;
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
+using PhotoBank.ViewModel.Dto;
 
 namespace PhotoBank.UnitTests.Services
 {
@@ -36,6 +39,34 @@ namespace PhotoBank.UnitTests.Services
             _mapper = provider.GetRequiredService<IMapper>();
         }
 
+        private PhotoService CreateService(PhotoBankDbContext context, IServiceProvider provider)
+        {
+            var referenceDataService = new Mock<ISearchReferenceDataService>();
+            referenceDataService
+                .Setup(s => s.GetPersonsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<PersonDto>());
+            referenceDataService
+                .Setup(s => s.GetTagsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<TagDto>());
+
+            return new PhotoService(
+                context,
+                new Repository<Photo>(provider),
+                new Repository<Person>(provider),
+                new Repository<Face>(provider),
+                new Repository<Storage>(provider),
+                new Repository<PersonGroup>(provider),
+                new Repository<PersonFace>(provider),
+                _mapper,
+                new MemoryCache(new MemoryCacheOptions()),
+                new DummyCurrentUser(),
+                referenceDataService.Object,
+                new Mock<IS3ResourceService>().Object,
+                new MinioObjectService(new Mock<IMinioClient>().Object),
+                new Mock<IMinioClient>().Object,
+                new Mock<IOptions<S3Options>>().Object);
+        }
+
         [Test]
         public async Task UploadPhotosAsync_SavesFilesToStorage()
         {
@@ -49,22 +80,7 @@ namespace PhotoBank.UnitTests.Services
             context.Storages.Add(storage);
             await context.SaveChangesAsync();
 
-            var service = new PhotoService(
-                context,
-                new Repository<Photo>(provider),
-                new Repository<Person>(provider),
-                new Repository<Face>(provider),
-                new Repository<Storage>(provider),
-                new Repository<Tag>(provider),
-                new Repository<PersonGroup>(provider),
-                new Repository<PersonFace>(provider),
-                _mapper,
-                new MemoryCache(new MemoryCacheOptions()),
-                new DummyCurrentUser(),
-                new Mock<IS3ResourceService>().Object,
-                new MinioObjectService(new Mock<IMinioClient>().Object),
-                new Mock<IMinioClient>().Object,
-                new Mock<IOptions<S3Options>>().Object);
+            var service = CreateService(context, provider);
 
             var bytes = new byte[] { 1, 2, 3, 4 };
             await using var ms = new MemoryStream(bytes);
@@ -91,22 +107,7 @@ namespace PhotoBank.UnitTests.Services
             context.Storages.Add(storage);
             await context.SaveChangesAsync();
 
-            var service = new PhotoService(
-                context,
-                new Repository<Photo>(provider),
-                new Repository<Person>(provider),
-                new Repository<Face>(provider),
-                new Repository<Storage>(provider),
-                new Repository<Tag>(provider),
-                new Repository<PersonGroup>(provider),
-                new Repository<PersonFace>(provider),
-                _mapper,
-                new MemoryCache(new MemoryCacheOptions()),
-                new DummyCurrentUser(),
-                new Mock<IS3ResourceService>().Object,
-                new MinioObjectService(new Mock<IMinioClient>().Object),
-                new Mock<IMinioClient>().Object,
-                new Mock<IOptions<S3Options>>().Object);
+            var service = CreateService(context, provider);
 
             var bytes = new byte[] { 1, 2, 3, 4 };
             await using var ms1 = new MemoryStream(bytes);
@@ -137,22 +138,7 @@ namespace PhotoBank.UnitTests.Services
             context.Storages.Add(storage);
             await context.SaveChangesAsync();
 
-            var service = new PhotoService(
-                context,
-                new Repository<Photo>(provider),
-                new Repository<Person>(provider),
-                new Repository<Face>(provider),
-                new Repository<Storage>(provider),
-                new Repository<Tag>(provider),
-                new Repository<PersonGroup>(provider),
-                new Repository<PersonFace>(provider),
-                _mapper,
-                new MemoryCache(new MemoryCacheOptions()),
-                new DummyCurrentUser(),
-                new Mock<IS3ResourceService>().Object,
-                new MinioObjectService(new Mock<IMinioClient>().Object),
-                new Mock<IMinioClient>().Object,
-                new Mock<IOptions<S3Options>>().Object);
+            var service = CreateService(context, provider);
 
             var bytes1 = new byte[] { 1, 2, 3, 4 };
             await using var ms1 = new MemoryStream(bytes1);

--- a/backend/PhotoBank.UnitTests/Services/SearchFilterNormalizerTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/SearchFilterNormalizerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -5,7 +6,6 @@ using FluentAssertions;
 using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using NUnit.Framework;
-using PhotoBank.Services.Api;
 using PhotoBank.Services.Search;
 using PhotoBank.Services.Translator;
 using PhotoBank.ViewModel.Dto;
@@ -25,11 +25,15 @@ public class SearchFilterNormalizerTests
                 new TranslateResponse(req.Texts.Select(x => x + "_en").ToArray()));
 
         var cache = new MemoryCache(new MemoryCacheOptions());
-        var photoService = new Mock<IPhotoService>();
-        photoService.Setup(s => s.GetAllPersonsAsync()).ReturnsAsync(Enumerable.Empty<PersonDto>());
-        photoService.Setup(s => s.GetAllTagsAsync()).ReturnsAsync(Enumerable.Empty<TagDto>());
+        var referenceDataService = new Mock<ISearchReferenceDataService>();
+        referenceDataService
+            .Setup(s => s.GetPersonsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PersonDto>());
+        referenceDataService
+            .Setup(s => s.GetTagsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<TagDto>());
 
-        var normalizer = new SearchFilterNormalizer(translator.Object, cache, photoService.Object);
+        var normalizer = new SearchFilterNormalizer(translator.Object, cache, referenceDataService.Object);
 
         var normalized1 = await normalizer.NormalizeAsync(new FilterDto { Caption = "Привет" });
         normalized1.Caption.Should().Be("Привет_en");
@@ -54,11 +58,15 @@ public class SearchFilterNormalizerTests
         var persons = new[] { new PersonDto { Id = 1, Name = "John" } };
         var tags = new[] { new TagDto { Id = 10, Name = "car" } };
 
-        var photoService = new Mock<IPhotoService>();
-        photoService.Setup(s => s.GetAllPersonsAsync()).ReturnsAsync(persons);
-        photoService.Setup(s => s.GetAllTagsAsync()).ReturnsAsync(tags);
+        var referenceDataService = new Mock<ISearchReferenceDataService>();
+        referenceDataService
+            .Setup(s => s.GetPersonsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(persons);
+        referenceDataService
+            .Setup(s => s.GetTagsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tags);
 
-        var normalizer = new SearchFilterNormalizer(translator.Object, cache, photoService.Object);
+        var normalizer = new SearchFilterNormalizer(translator.Object, cache, referenceDataService.Object);
 
         var filter = new FilterDto
         {


### PR DESCRIPTION
## Summary
- introduce ISearchReferenceDataService with a caching SearchReferenceDataService implementation used for person and tag reference data
- update PhotoService and SearchFilterNormalizer to rely on the new service and register it in DI
- refresh unit tests to mock the new dependency and keep existing coverage passing

## Testing
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ce6d8c6e0883288e9ea3d44661978a