### PR TITLE
feat: normalize photo filters in service

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PhotosController.cs
+++ b/backend/PhotoBank.Api/Controllers/PhotosController.cs
@@ -2,7 +2,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PhotoBank.Services.Api;
-using PhotoBank.Services.Search;
 using PhotoBank.ViewModel.Dto;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,8 +14,7 @@ namespace PhotoBank.Api.Controllers
     [ApiController]
     public class PhotosController(
         ILogger<PhotosController> logger,
-        IPhotoService photoService,
-        ISearchFilterNormalizer normalizer)
+        IPhotoService photoService)
         : ControllerBase
     {
         [HttpPost("search")]
@@ -25,8 +23,7 @@ namespace PhotoBank.Api.Controllers
         public async Task<ActionResult<PageResponse<PhotoItemDto>>> SearchPhotos([FromBody] FilterDto request)
         {
             logger.LogInformation("Searching photos with filter {@Filter}", request);
-            await normalizer.NormalizeAsync(request);
-            var result = await photoService.GetAllPhotosAsync(request);
+            var result = await photoService.GetAllPhotosAsync(request, HttpContext.RequestAborted);
             logger.LogInformation("Found {Count} photos", result.TotalCount);
             return Ok(result);
         }

--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -29,6 +29,7 @@ public static partial class ServiceCollectionExtensions
         services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
         services.AddScoped<IFaceStorageService, FaceStorageService>();
         services.AddScoped<MinioObjectService>();
+        services.AddScoped<ISearchFilterNormalizer, SearchFilterNormalizer>();
         services.AddScoped<IPhotoService, PhotoService>();
         services.AddScoped<ISearchReferenceDataService, SearchReferenceDataService>();
         services.AddPhotoEvents();
@@ -45,7 +46,6 @@ public static partial class ServiceCollectionExtensions
         }
         services.AddHttpClient<ITranslatorService, TranslatorService>()
             .AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, attempt => TimeSpan.FromMilliseconds(100 * attempt)));
-        services.AddScoped<ISearchFilterNormalizer, SearchFilterNormalizer>();
         services.AddAutoMapper(cfg =>
         {
             cfg.AddProfile<MappingProfile>();

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -16,7 +16,9 @@ using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
 using PhotoBank.Services.Search;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
+using PhotoBank.ViewModel.Dto;
 
 namespace PhotoBank.UnitTests;
 
@@ -44,6 +46,11 @@ public class PersonGroupServiceTests
         db.PersonGroups.Add(new PersonGroup { Id = 1, Name = "Family" });
         db.SaveChanges();
 
+        var normalizer = new Mock<ISearchFilterNormalizer>();
+        normalizer
+            .Setup(n => n.NormalizeAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((FilterDto f, CancellationToken _) => f);
+
         _service = new PhotoService(
             db,
             _provider.GetRequiredService<IRepository<Photo>>(),
@@ -56,6 +63,7 @@ public class PersonGroupServiceTests
             _provider.GetRequiredService<IMemoryCache>(),
             _provider.GetRequiredService<ICurrentUser>(),
             _provider.GetRequiredService<ISearchReferenceDataService>(),
+            normalizer.Object,
             new Mock<IS3ResourceService>().Object,
             new MinioObjectService(new Mock<IMinioClient>().Object),
             new Mock<IMinioClient>().Object,

--- a/backend/PhotoBank.UnitTests/PhotosControllerTests.cs
+++ b/backend/PhotoBank.UnitTests/PhotosControllerTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -8,7 +7,6 @@ using Moq;
 using NUnit.Framework;
 using PhotoBank.Api.Controllers;
 using PhotoBank.Services.Api;
-using PhotoBank.Services.Search;
 using PhotoBank.ViewModel.Dto;
 
 namespace PhotoBank.UnitTests;
@@ -17,38 +15,25 @@ namespace PhotoBank.UnitTests;
 public class PhotosControllerTests
 {
     [Test]
-    public async Task SearchPhotos_NormalizesFilter()
+    public async Task SearchPhotos_CallsServiceWithFilter()
     {
         // Arrange
         var logger = Mock.Of<ILogger<PhotosController>>();
         var filter = new FilterDto { PersonNames = ["John"], TagNames = ["car"] };
 
-        var normalizer = new Mock<ISearchFilterNormalizer>();
-        normalizer
-            .Setup(n => n.NormalizeAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
-            .Callback<FilterDto, CancellationToken>((f, _) =>
-            {
-                f.Persons = new[] { 1 };
-                f.Tags = new[] { 2 };
-            })
-            .ReturnsAsync((FilterDto f, CancellationToken _) => f);
-
         var page = new PageResponse<PhotoItemDto>();
         var photoService = new Mock<IPhotoService>();
         photoService
-            .Setup(s => s.GetAllPhotosAsync(It.IsAny<FilterDto>()))
+            .Setup(s => s.GetAllPhotosAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(page);
 
-        var controller = new PhotosController(logger, photoService.Object, normalizer.Object);
+        var controller = new PhotosController(logger, photoService.Object);
 
         // Act
         var result = await controller.SearchPhotos(filter);
 
         // Assert
-        normalizer.Verify(n => n.NormalizeAsync(filter, It.IsAny<CancellationToken>()), Times.Once);
-        photoService.Verify(s => s.GetAllPhotosAsync(It.Is<FilterDto>(f =>
-            f.Persons!.SequenceEqual(new[] { 1 }) && f.Tags!.SequenceEqual(new[] { 2 })
-        )), Times.Once);
+        photoService.Verify(s => s.GetAllPhotosAsync(filter, It.IsAny<CancellationToken>()), Times.Once);
         result.Result.Should().BeOfType<OkObjectResult>();
     }
 }

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -49,6 +49,11 @@ namespace PhotoBank.UnitTests.Services
                 .Setup(s => s.GetTagsAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Array.Empty<TagDto>());
 
+            var normalizer = new Mock<ISearchFilterNormalizer>();
+            normalizer
+                .Setup(n => n.NormalizeAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((FilterDto f, CancellationToken _) => f);
+
             return new PhotoService(
                 context,
                 new Repository<Photo>(provider),
@@ -61,6 +66,7 @@ namespace PhotoBank.UnitTests.Services
                 new MemoryCache(new MemoryCacheOptions()),
                 new DummyCurrentUser(),
                 referenceDataService.Object,
+                normalizer.Object,
                 new Mock<IS3ResourceService>().Object,
                 new MinioObjectService(new Mock<IMinioClient>().Object),
                 new Mock<IMinioClient>().Object,


### PR DESCRIPTION
## Summary
- inject and use `ISearchFilterNormalizer` inside `PhotoService.GetAllPhotosAsync`
- simplify the photos controller by delegating filter normalization to the service
- update dependency registrations and unit tests for the new service dependency

## Testing
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj` *(fails: Microsoft.Build.Logging.TerminalLogger.ArgumentOutOfRangeException)*


------
https://chatgpt.com/codex/tasks/task_e_68ce74cd38648328a10048c552bf81c3