### PR TITLE
refactor: stream duplicate detection

### DIFF
--- a/backend/PhotoBank.Services/ImageHashHelper.cs
+++ b/backend/PhotoBank.Services/ImageHashHelper.cs
@@ -18,7 +18,15 @@ public static class ImageHashHelper
             return double.MaxValue;
 
         var h1 = new PerceptualHash(hash1);
+        return HammingDistance(h1, hash2);
+    }
+
+    public static double HammingDistance(PerceptualHash referenceHash, string? hash2)
+    {
+        if (referenceHash == null || string.IsNullOrEmpty(hash2))
+            return double.MaxValue;
+
         var h2 = new PerceptualHash(hash2);
-        return h1.SumSquaredDistance(h2);
+        return referenceHash.SumSquaredDistance(h2);
     }
 }


### PR DESCRIPTION
## Summary
- stream duplicate photo lookup to project only duplicate detection fields and filter while enumerating
- reuse a single parsed perceptual hash when comparing candidate hashes
- extend the image hash helper to support reusing parsed hashes

## Testing
- dotnet build PhotoBank.Services.csproj

------
https://chatgpt.com/codex/tasks/task_e_68ce8103470883288b2bbe1475a0fa78