### PR TITLE
refactor: centralize service context handling

### DIFF
--- a/frontend/packages/telegram-bot/src/services/call-with-context.ts
+++ b/frontend/packages/telegram-bot/src/services/call-with-context.ts
@@ -1,0 +1,18 @@
+import type { Context } from 'grammy';
+
+import { setRequestContext } from '../api/axios-instance';
+import { handleServiceError } from '../errorHandler';
+
+export async function callWithContext<Fn extends (...args: any[]) => unknown>(
+  ctx: Context,
+  fn: Fn,
+  ...args: Parameters<Fn>
+): Promise<Awaited<ReturnType<Fn>>> {
+  try {
+    setRequestContext(ctx);
+    return await fn(...args);
+  } catch (error: unknown) {
+    handleServiceError(error);
+    throw error;
+  }
+}

--- a/frontend/packages/telegram-bot/src/services/dictionary.ts
+++ b/frontend/packages/telegram-bot/src/services/dictionary.ts
@@ -4,8 +4,7 @@ import { getPaths } from '../api/photobank/paths/paths';
 import { getPersons } from '../api/photobank/persons/persons';
 import { getStorages } from '../api/photobank/storages/storages';
 import { getTags } from '../api/photobank/tags/tags';
-import { setRequestContext } from '../api/axios-instance';
-import { handleServiceError } from '../errorHandler';
+import { callWithContext } from './call-with-context';
 
 const { pathsGetAll } = getPaths();
 const { personsGetAll } = getPersons();
@@ -13,41 +12,17 @@ const { storagesGetAll } = getStorages();
 const { tagsGetAll } = getTags();
 
 export async function fetchTags(ctx: Context) {
-  try {
-    setRequestContext(ctx);
-    return await tagsGetAll();
-  } catch (err: unknown) {
-    handleServiceError(err);
-    throw err;
-  }
+  return callWithContext(ctx, tagsGetAll);
 }
 
 export async function fetchPersons(ctx: Context) {
-  try {
-    setRequestContext(ctx);
-    return await personsGetAll();
-  } catch (err: unknown) {
-    handleServiceError(err);
-    throw err;
-  }
+  return callWithContext(ctx, personsGetAll);
 }
 
 export async function fetchStorages(ctx: Context) {
-  try {
-    setRequestContext(ctx);
-    return await storagesGetAll();
-  } catch (err: unknown) {
-    handleServiceError(err);
-    throw err;
-  }
+  return callWithContext(ctx, storagesGetAll);
 }
 
 export async function fetchPaths(ctx: Context) {
-  try {
-    setRequestContext(ctx);
-    return await pathsGetAll();
-  } catch (err: unknown) {
-    handleServiceError(err);
-    throw err;
-  }
+  return callWithContext(ctx, pathsGetAll);
 }

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -6,32 +6,19 @@ import {
   type PhotosGetPhotoResult,
   type PhotosSearchPhotosResult,
 } from '../api/photobank/photos/photos';
-import { setRequestContext } from '../api/axios-instance';
-import { handleServiceError } from '../errorHandler';
+import { callWithContext } from './call-with-context';
 
 const { photosSearchPhotos, photosGetPhoto, photosUpload } = getPhotos();
 
 export async function searchPhotos(ctx: Context, filter: FilterDto): Promise<PhotosSearchPhotosResult> {
-  try {
-    setRequestContext(ctx);
-    return await photosSearchPhotos(filter);
-  } catch (err: unknown) {
-    handleServiceError(err);
-    throw err;
-  }
+  return callWithContext(ctx, photosSearchPhotos, filter);
 }
 
 export async function getPhoto(
   ctx: Context,
   id: number,
 ): Promise<PhotosGetPhotoResult> {
-  try {
-    setRequestContext(ctx);
-    return await photosGetPhoto(id);
-  } catch (err: unknown) {
-    handleServiceError(err);
-    throw err;
-  }
+  return callWithContext(ctx, photosGetPhoto, id);
 }
 
 export type UploadFile = { data: BlobPart | ArrayBuffer | Uint8Array; name: string };
@@ -42,11 +29,5 @@ export async function uploadPhotos(
 ) {
   const { files, storageId, path } = options;
   const blobs = files.map(({ data, name }) => new File([data as BlobPart], name));
-  try {
-    setRequestContext(ctx);
-    return await photosUpload({ files: blobs, storageId, path });
-  } catch (err: unknown) {
-    handleServiceError(err);
-    throw err;
-  }
+  return callWithContext(ctx, photosUpload, { files: blobs, storageId, path });
 }

--- a/frontend/packages/telegram-bot/test/call-with-context.test.ts
+++ b/frontend/packages/telegram-bot/test/call-with-context.test.ts
@@ -1,0 +1,51 @@
+import type { Context } from 'grammy';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  setRequestContext: vi.fn(),
+  handleServiceError: vi.fn(),
+}));
+
+vi.mock('../src/api/axios-instance', () => ({
+  setRequestContext: mocks.setRequestContext,
+}));
+
+vi.mock('../src/errorHandler', () => ({
+  handleServiceError: mocks.handleServiceError,
+}));
+
+const { setRequestContext, handleServiceError } = mocks;
+
+import { callWithContext } from '../src/services/call-with-context';
+
+describe('callWithContext', () => {
+  const ctx = { from: { id: 42 } } as unknown as Context;
+
+  beforeEach(() => {
+    setRequestContext.mockReset();
+    handleServiceError.mockReset();
+  });
+
+  it('sets the context, forwards arguments, and returns the result', async () => {
+    const fn = vi.fn<[string, number], Promise<string>>().mockResolvedValue('ok');
+
+    await expect(callWithContext(ctx, fn, 'value', 123)).resolves.toBe('ok');
+
+    expect(setRequestContext).toHaveBeenCalledTimes(1);
+    expect(setRequestContext).toHaveBeenCalledWith(ctx);
+    expect(fn).toHaveBeenCalledWith('value', 123);
+    expect(handleServiceError).not.toHaveBeenCalled();
+  });
+
+  it('funnels errors through handleServiceError and rethrows', async () => {
+    const error = new Error('boom');
+    const fn = vi.fn<[], Promise<void>>().mockRejectedValue(error);
+
+    await expect(callWithContext(ctx, fn)).rejects.toBe(error);
+
+    expect(setRequestContext).toHaveBeenCalledTimes(1);
+    expect(setRequestContext).toHaveBeenCalledWith(ctx);
+    expect(handleServiceError).toHaveBeenCalledTimes(1);
+    expect(handleServiceError).toHaveBeenCalledWith(error);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable `callWithContext` helper to set request context and delegate error handling
- refactor dictionary and photo services to use the helper instead of duplicated try/catch blocks
- cover the helper with unit tests validating argument forwarding and error funneling

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ce9db098808328ae4d1ca1a2a499af