### PR TITLE
feat: reuse metadata badges in photo table

### DIFF
--- a/frontend/packages/frontend/src/components/MetadataBadgeList.test.tsx
+++ b/frontend/packages/frontend/src/components/MetadataBadgeList.test.tsx
@@ -6,7 +6,11 @@ import MetadataBadgeList from './MetadataBadgeList';
 
 describe('MetadataBadgeList', () => {
   it('renders limited items and extra count', () => {
-    const map = { 1: 'Alice', 2: 'Bob', 3: 'Carol' };
+    const map = new Map<number, string>([
+      [1, 'Alice'],
+      [2, 'Bob'],
+      [3, 'Carol'],
+    ]);
     render(
       <MetadataBadgeList
         icon={User}
@@ -19,6 +23,21 @@ describe('MetadataBadgeList', () => {
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByText('Bob')).toBeInTheDocument();
     expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
+  it('renders string labels without an icon', () => {
+    const { container } = render(
+      <MetadataBadgeList
+        items={['Alice', 'Bob', 'Carol']}
+        maxVisible={2}
+        variant="outline"
+      />,
+    );
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- extend MetadataBadgeList to support optional icons, pre-resolved labels, and Map inputs
- update component tests to cover string labels and icon-less rendering
- reuse MetadataBadgeList in photoColumns to drop custom BadgeList helper

## Testing
- pnpm --filter @photobank/frontend exec vitest run src/components/MetadataBadgeList.test.tsx src/features/photos/components/photoColumns.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ce9f56459c83289a0427de229658d8