### PR TITLE
refactor: centralize memory cache helper

### DIFF
--- a/backend/PhotoBank.Services/Internal/CacheHelper.cs
+++ b/backend/PhotoBank.Services/Internal/CacheHelper.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace PhotoBank.Services.Internal;
+
+internal static class CacheHelper
+{
+    internal static MemoryCacheEntryOptions CacheOptions { get; } = new()
+    {
+        AbsoluteExpiration = null,
+        SlidingExpiration = null
+    };
+
+    internal static async Task<TItem> GetOrCreateAsync<TItem>(
+        this IMemoryCache cache,
+        object key,
+        Func<Task<TItem>> factory,
+        MemoryCacheEntryOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(factory);
+
+        if (!cache.TryGetValue(key, out TItem? value))
+        {
+            value = await factory().ConfigureAwait(false);
+            cache.Set(key, value, options ?? CacheOptions);
+        }
+
+        return value;
+    }
+}


### PR DESCRIPTION
## Summary
- add an internal CacheHelper to expose shared memory cache options and async wrapper
- update PhotoService and SearchReferenceDataService to consume the shared helper and remove duplicate logic

## Testing
- dotnet test PhotoBank.Backend.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ceb4e20aec8328962700a2d1dbddcb