### PR TITLE
refactor: centralize cached image response handling

### DIFF
--- a/backend/PhotoBank.Api/Controllers/CachedImageResponseBuilder.cs
+++ b/backend/PhotoBank.Api/Controllers/CachedImageResponseBuilder.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using PhotoBank.Services.Api;
+using System.Net.Mime;
+
+namespace PhotoBank.Api.Controllers;
+
+public static class CachedImageResponseBuilder
+{
+    private const string CacheControlValue = "public, max-age=31536000, immutable";
+
+    public static IActionResult Build(
+        ControllerBase controller,
+        PhotoPreviewResult result,
+        ILogger? logger = null,
+        CachedImageResponseCallbacks? callbacks = null)
+    {
+        var etag = $"\"{result.ETag}\"";
+        controller.Response.Headers.ETag = etag;
+        controller.Response.Headers.CacheControl = CacheControlValue;
+
+        if (controller.Request.Headers.IfNoneMatch.Contains(etag))
+        {
+            if (callbacks?.OnNotModified is not null)
+            {
+                callbacks.OnNotModified();
+            }
+            else
+            {
+                logger?.LogInformation("Cached image not modified");
+            }
+
+            return controller.StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        if (!string.IsNullOrEmpty(result.PreSignedUrl))
+        {
+            controller.Response.Headers.Location = result.PreSignedUrl;
+
+            if (callbacks?.OnRedirect is not null)
+            {
+                callbacks.OnRedirect();
+            }
+            else
+            {
+                logger?.LogInformation("Redirecting to cached image pre-signed URL");
+            }
+
+            return controller.StatusCode(StatusCodes.Status301MovedPermanently);
+        }
+
+        if (callbacks?.OnStream is not null)
+        {
+            callbacks.OnStream();
+        }
+        else
+        {
+            logger?.LogInformation("Streaming cached image content");
+        }
+
+        return controller.File(result.Data!, MediaTypeNames.Image.Jpeg);
+    }
+}
+
+public record CachedImageResponseCallbacks(Action? OnNotModified = null, Action? OnRedirect = null, Action? OnStream = null);

--- a/backend/PhotoBank.Api/Controllers/FacesController.cs
+++ b/backend/PhotoBank.Api/Controllers/FacesController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using PhotoBank.Services.Api;
 using PhotoBank.DbContext.Models;
 using PhotoBank.ViewModel.Dto;
-using System.Net.Mime;
 
 namespace PhotoBank.Api.Controllers;
 
@@ -38,19 +37,6 @@ public class FacesController(IPhotoService photoService) : ControllerBase
         if (result is null)
             return NotFound();
 
-        var etag = $"\"{result.ETag}\"";
-        Response.Headers.ETag = etag;
-        Response.Headers.CacheControl = "public, max-age=31536000, immutable";
-
-        if (Request.Headers.IfNoneMatch.Contains(etag))
-            return StatusCode(StatusCodes.Status304NotModified);
-
-        if (result.PreSignedUrl is not null)
-        {
-            Response.Headers.Location = result.PreSignedUrl;
-            return StatusCode(StatusCodes.Status301MovedPermanently);
-        }
-
-        return File(result.Data!, MediaTypeNames.Image.Jpeg);
+        return CachedImageResponseBuilder.Build(this, result);
     }
 }


### PR DESCRIPTION
## Summary
- add a CachedImageResponseBuilder helper to centralize cached image response behavior
- delegate PhotosController.GetPreview and FacesController.GetImage to the shared helper while keeping existing logging hooks

## Testing
- dotnet test backend/PhotoBank.Backend.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cec10885f48328bd718e827b3456a7