### PR TITLE
refactor: centralize reference metadata fetching

### DIFF
--- a/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
+++ b/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import * as Api from '@photobank/shared/api/photobank';
+import { fetchReferenceData } from '@photobank/shared/api/photobank';
 import type { PathDto, PersonDto, StorageDto, TagDto } from '@photobank/shared/api/photobank';
 import {
   METADATA_CACHE_KEY,
@@ -67,10 +68,12 @@ export const loadMetadata = createAsyncThunk('metadata/load', async (_, { signal
     const fromCache = loadFromCache();
     if (fromCache) return fromCache;
 
-    const storages = (await Api.storagesGetAll({ signal })).data;
-    const tags = (await Api.tagsGetAll({ signal })).data;
-    const persons = (await Api.personsGetAll({ signal })).data;
-    const paths = (await Api.pathsGetAll({ signal })).data;
+    const { tags, persons, paths, storages } = await fetchReferenceData({
+        fetchTags: () => Api.tagsGetAll({ signal }).then((response) => response.data),
+        fetchPersons: () => Api.personsGetAll({ signal }).then((response) => response.data),
+        fetchStorages: () => Api.storagesGetAll({ signal }).then((response) => response.data),
+        fetchPaths: () => Api.pathsGetAll({ signal }).then((response) => response.data),
+    });
 
     const result: MetadataPayload = {
         tags,

--- a/frontend/packages/shared/src/api/photobank/index.ts
+++ b/frontend/packages/shared/src/api/photobank/index.ts
@@ -8,4 +8,5 @@ export * from './storages/storages';
 export * from './tags/tags';
 export * from './version/version';
 export * from './auth/auth';
+export * from './reference-data';
 export { configureApi, configureApiAuth, setImpersonateUser } from './fetcher';

--- a/frontend/packages/shared/src/api/photobank/reference-data.ts
+++ b/frontend/packages/shared/src/api/photobank/reference-data.ts
@@ -1,0 +1,31 @@
+import type { PathDto, PersonDto, StorageDto, TagDto } from './photoBankApi.schemas';
+
+export type ReferenceDataFetchers = {
+  fetchTags: () => Promise<TagDto[]>;
+  fetchPersons: () => Promise<PersonDto[]>;
+  fetchStorages: () => Promise<StorageDto[]>;
+  fetchPaths: () => Promise<PathDto[]>;
+};
+
+export type ReferenceData = {
+  tags: TagDto[];
+  persons: PersonDto[];
+  storages: StorageDto[];
+  paths: PathDto[];
+};
+
+export async function fetchReferenceData({
+  fetchTags,
+  fetchPersons,
+  fetchStorages,
+  fetchPaths,
+}: ReferenceDataFetchers): Promise<ReferenceData> {
+  const [tags, persons, storages, paths] = await Promise.all([
+    fetchTags(),
+    fetchPersons(),
+    fetchStorages(),
+    fetchPaths(),
+  ]);
+
+  return { tags, persons, storages, paths };
+}

--- a/frontend/packages/shared/test/reference-data.test.ts
+++ b/frontend/packages/shared/test/reference-data.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchReferenceData } from '../src/api/photobank/reference-data';
+
+describe('fetchReferenceData', () => {
+  it('collects reference collections concurrently', async () => {
+    const fetchTags = vi.fn().mockResolvedValue([{ id: 1, name: 'tag' }]);
+    const fetchPersons = vi.fn().mockResolvedValue([{ id: 2, name: 'person' }]);
+    const fetchStorages = vi.fn().mockResolvedValue([{ id: 3, name: 'storage' }]);
+    const fetchPaths = vi.fn().mockResolvedValue([{ storageId: 3, path: '/a' }]);
+
+    const result = await fetchReferenceData({
+      fetchTags,
+      fetchPersons,
+      fetchStorages,
+      fetchPaths,
+    });
+
+    expect(result).toEqual({
+      tags: [{ id: 1, name: 'tag' }],
+      persons: [{ id: 2, name: 'person' }],
+      storages: [{ id: 3, name: 'storage' }],
+      paths: [{ storageId: 3, path: '/a' }],
+    });
+    expect(fetchTags).toHaveBeenCalledTimes(1);
+    expect(fetchPersons).toHaveBeenCalledTimes(1);
+    expect(fetchStorages).toHaveBeenCalledTimes(1);
+    expect(fetchPaths).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/packages/telegram-bot/src/dictionaries.ts
+++ b/frontend/packages/telegram-bot/src/dictionaries.ts
@@ -1,3 +1,4 @@
+import { fetchReferenceData } from '@photobank/shared/api/photobank';
 import type {
   PersonDto,
   StorageDto,
@@ -48,13 +49,16 @@ function getDict(): DictData {
 
 export async function loadDictionaries(ctx: MyContext) {
   if (cache.has(currentUser)) return;
-  const tagList = await fetchTags(ctx);
+  const { tags: tagList, persons: personList, storages: storageList, paths: pathList } =
+    await fetchReferenceData({
+      fetchTags: () => fetchTags(ctx),
+      fetchPersons: () => fetchPersons(ctx),
+      fetchStorages: () => fetchStorages(ctx),
+      fetchPaths: () => fetchPaths(ctx),
+    });
   const tagMap = new Map<number, string>(tagList.map((t) => [t.id, t.name]));
-  const personList = await fetchPersons(ctx);
   const personMap = new Map<number, string>(personList.map((p) => [p.id, p.name]));
-  const storageList = await fetchStorages(ctx);
   const storageMap = new Map<number, string>(storageList.map((s) => [s.id, s.name]));
-  const pathList = await fetchPaths(ctx);
   const pathsMap = new Map<number, string[]>();
   for (const p of pathList) {
     const arr = pathsMap.get(p.storageId) ?? [];


### PR DESCRIPTION
## Summary
- add a shared helper for fetching reference collections concurrently and export it via the photobank API barrel
- refactor the frontend metadata slice to consume the helper and simplify tests
- switch the telegram bot dictionaries loader and tests to use the shared helper

## Testing
- pnpm --filter @photobank/shared test -- reference-data.test.ts
- pnpm --filter @photobank/frontend exec vitest run metaSlice.test.ts
- pnpm --filter @photobank/telegram-bot exec vitest run openaiDisabled.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cecf0414a08328812941052fc78b79