### PR TITLE
refactor: reuse shared photo upload adapter

### DIFF
--- a/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
+++ b/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
@@ -1,6 +1,20 @@
 import { photosUpload } from '../api/photobank';
 
-export type UploadFile = { data: BlobPart; name: string };
+export type UploadFileData = BlobPart | ArrayBuffer | Uint8Array;
+
+export type UploadFile = { data: UploadFileData; name: string };
+
+function normalizeToBlobPart(data: UploadFileData): BlobPart {
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  }
+
+  return data;
+}
 
 export async function uploadPhotosAdapter(params: {
   files: UploadFile[];
@@ -8,6 +22,6 @@ export async function uploadPhotosAdapter(params: {
   path: string;
 }) {
   const { files, storageId, path } = params;
-  const blobs = files.map(({ data, name }) => new File([data], name));
-  await photosUpload({ files: blobs, storageId, path });
+  const blobs = files.map(({ data, name }) => new File([normalizeToBlobPart(data)], name));
+  return photosUpload({ files: blobs, storageId, path });
 }

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -53,7 +53,7 @@ export const firstNWords = (sentence: string, count: number): string => {
 export { useIsAdmin } from './hooks/useIsAdmin';
 export { useCanSeeNsfw } from './hooks/useCanSeeNsfw';
 export { getPlaceByGeoPoint } from './utils/geocode';
-export { uploadPhotosAdapter } from './adapters/photos-upload.adapter';
+export { uploadPhotosAdapter, type UploadFile, type UploadFileData } from './adapters/photos-upload.adapter';
 
 export * from './format';
 export * from './auth';

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'grammy';
+import { uploadPhotosAdapter, type UploadFile } from '@photobank/shared';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 
 import {
@@ -8,7 +9,7 @@ import {
 } from '../api/photobank/photos/photos';
 import { callWithContext } from './call-with-context';
 
-const { photosSearchPhotos, photosGetPhoto, photosUpload } = getPhotos();
+const { photosSearchPhotos, photosGetPhoto } = getPhotos();
 
 export async function searchPhotos(ctx: Context, filter: FilterDto): Promise<PhotosSearchPhotosResult> {
   return callWithContext(ctx, photosSearchPhotos, filter);
@@ -21,13 +22,10 @@ export async function getPhoto(
   return callWithContext(ctx, photosGetPhoto, id);
 }
 
-export type UploadFile = { data: BlobPart | ArrayBuffer | Uint8Array; name: string };
-
 export async function uploadPhotos(
   ctx: Context,
   options: { files: UploadFile[]; storageId: number; path: string },
 ) {
   const { files, storageId, path } = options;
-  const blobs = files.map(({ data, name }) => new File([data as BlobPart], name));
-  return callWithContext(ctx, photosUpload, { files: blobs, storageId, path });
+  return callWithContext(ctx, uploadPhotosAdapter, { files, storageId, path });
 }


### PR DESCRIPTION
## Summary
- widen the shared photo upload adapter to accept blob, buffer, or typed array inputs and reuse existing upload response
- expose the adapter upload types from the shared entrypoint for package consumers
- switch the telegram bot photo service to use the shared adapter directly

## Testing
- pnpm --filter @photobank/shared test
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68ced0d296888328bf682604b474d267