### PR TITLE
fix: guard cancellation token usage in photos search

### DIFF
--- a/backend/PhotoBank.Api/Controllers/PhotosController.cs
+++ b/backend/PhotoBank.Api/Controllers/PhotosController.cs
@@ -5,6 +5,7 @@ using PhotoBank.Services.Api;
 using PhotoBank.ViewModel.Dto;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace PhotoBank.Api.Controllers
 {
@@ -22,7 +23,8 @@ namespace PhotoBank.Api.Controllers
         public async Task<ActionResult<PageResponse<PhotoItemDto>>> SearchPhotos([FromBody] FilterDto request)
         {
             logger.LogInformation("Searching photos with filter {@Filter}", request);
-            var result = await photoService.GetAllPhotosAsync(request, HttpContext.RequestAborted);
+            var cancellationToken = HttpContext?.RequestAborted ?? CancellationToken.None;
+            var result = await photoService.GetAllPhotosAsync(request, cancellationToken);
             logger.LogInformation("Found {Count} photos", result.TotalCount);
             return Ok(result);
         }


### PR DESCRIPTION
## Summary
- guard `HttpContext.RequestAborted` access in `PhotosController.SearchPhotos`
- reuse the safe cancellation token when invoking the photo service

## Testing
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68ced4cf5f608328a48ac796b2db3963