### PR TITLE
fix: normalize photo upload blob parts

### DIFF
--- a/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
+++ b/frontend/packages/shared/src/adapters/photos-upload.adapter.ts
@@ -5,12 +5,19 @@ export type UploadFileData = BlobPart | ArrayBuffer | Uint8Array;
 export type UploadFile = { data: UploadFileData; name: string };
 
 function normalizeToBlobPart(data: UploadFileData): BlobPart {
-  if (data instanceof Uint8Array) {
-    return data;
+  if (ArrayBuffer.isView(data)) {
+    const { buffer, byteOffset, byteLength } = data;
+    if (buffer instanceof ArrayBuffer) {
+      return buffer.slice(byteOffset, byteOffset + byteLength);
+    }
+
+    const copy = new Uint8Array(byteLength);
+    copy.set(new Uint8Array(buffer, byteOffset, byteLength));
+    return copy.buffer;
   }
 
   if (data instanceof ArrayBuffer) {
-    return new Uint8Array(data);
+    return data;
   }
 
   return data;


### PR DESCRIPTION
## Summary
- ensure photo upload adapter converts typed array inputs into ArrayBuffers covering only the intended bytes
- reuse ArrayBuffer inputs without unnecessary Uint8Array wrapping

## Testing
- pnpm --filter @photobank/shared build

------
https://chatgpt.com/codex/tasks/task_e_68ceddc60d0c8328b383fa85a40956c2