### PR TITLE
fix: preserve awaited type for contextual calls

### DIFF
--- a/frontend/packages/telegram-bot/src/services/call-with-context.ts
+++ b/frontend/packages/telegram-bot/src/services/call-with-context.ts
@@ -3,11 +3,19 @@ import type { Context } from 'grammy';
 import { setRequestContext } from '../api/axios-instance';
 import { handleServiceError } from '../errorHandler';
 
-export async function callWithContext<Fn extends (...args: any[]) => unknown>(
+type Awaitable<T> = T | PromiseLike<T>;
+
+export function callWithContext<Fn extends (...args: any[]) => Awaitable<unknown>>(
   ctx: Context,
   fn: Fn,
   ...args: Parameters<Fn>
-): Promise<Awaited<ReturnType<Fn>>> {
+): Promise<Awaited<ReturnType<Fn>>>;
+
+export async function callWithContext(
+  ctx: Context,
+  fn: (...args: any[]) => Awaitable<unknown>,
+  ...args: any[]
+): Promise<unknown> {
   try {
     setRequestContext(ctx);
     return await fn(...args);


### PR DESCRIPTION
## Summary
- add an `Awaitable` helper and overload signature so `callWithContext` preserves the awaited return type while keeping the runtime behavior unchanged

## Testing
- pnpm --filter @photobank/telegram-bot run typecheck *(fails: existing dictionary service type errors about missing `pathsGetAll`/`storagesGetAll`/`tagsGetAll`)*

------
https://chatgpt.com/codex/tasks/task_e_68cee10bca648328bf6b4a1e993cb2f4