### PR TITLE
fix: align telegram dictionary request bindings

### DIFF
--- a/frontend/packages/telegram-bot/src/services/dictionary.ts
+++ b/frontend/packages/telegram-bot/src/services/dictionary.ts
@@ -6,23 +6,23 @@ import { getStorages } from '../api/photobank/storages/storages';
 import { getTags } from '../api/photobank/tags/tags';
 import { callWithContext } from './call-with-context';
 
-const { pathsGetAll } = getPaths();
-const { personsGetAll } = getPersons();
-const { storagesGetAll } = getStorages();
-const { tagsGetAll } = getTags();
+const { getPaths: fetchPathsRequest } = getPaths();
+const { personsGetAll: fetchPersonsRequest } = getPersons();
+const { getStorages: fetchStoragesRequest } = getStorages();
+const { getTags: fetchTagsRequest } = getTags();
 
 export async function fetchTags(ctx: Context) {
-  return callWithContext(ctx, tagsGetAll);
+  return callWithContext(ctx, fetchTagsRequest);
 }
 
 export async function fetchPersons(ctx: Context) {
-  return callWithContext(ctx, personsGetAll);
+  return callWithContext(ctx, fetchPersonsRequest);
 }
 
 export async function fetchStorages(ctx: Context) {
-  return callWithContext(ctx, storagesGetAll);
+  return callWithContext(ctx, fetchStoragesRequest);
 }
 
 export async function fetchPaths(ctx: Context) {
-  return callWithContext(ctx, pathsGetAll);
+  return callWithContext(ctx, fetchPathsRequest);
 }


### PR DESCRIPTION
## Summary
- destructure generated dictionary API helpers using their actual request names
- update context wrappers to use the new bindings for each request

## Testing
- pnpm --filter @photobank/telegram-bot run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cee34e838883288f358886f88eaebb