### PR TITLE
chore: add node tsconfig for frontend tooling

### DIFF
--- a/frontend/packages/frontend/src/main.tsx
+++ b/frontend/packages/frontend/src/main.tsx
@@ -12,9 +12,8 @@ import App from './app/App';
 
 import './index.css';
 
-async function start() {
+function start() {
   configureApi(API_BASE_URL);
-
 
   const root = document.getElementById('root')!;
   ReactDOM.createRoot(root).render(

--- a/frontend/packages/frontend/tsconfig.node.json
+++ b/frontend/packages/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts", "vitest.config.ts", "test-setup.ts"]
+}


### PR DESCRIPTION
## Summary
- add a Node-oriented tsconfig for the frontend package so tooling configs lint with Node types
- drop an unused async marker from the app bootstrap to satisfy the updated lint run

## Testing
- pnpm --filter @photobank/frontend lint

------
https://chatgpt.com/codex/tasks/task_e_68cf05a7c67083289ef9d0f6683fb882