### PR TITLE
fix: align metadata API usage

### DIFF
--- a/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
+++ b/frontend/packages/frontend/src/features/meta/model/metaSlice.ts
@@ -69,10 +69,10 @@ export const loadMetadata = createAsyncThunk('metadata/load', async (_, { signal
     if (fromCache) return fromCache;
 
     const { tags, persons, paths, storages } = await fetchReferenceData({
-        fetchTags: () => Api.tagsGetAll({ signal }).then((response) => response.data),
+        fetchTags: () => Api.getTags({ signal }).then((response) => response.data),
         fetchPersons: () => Api.personsGetAll({ signal }).then((response) => response.data),
-        fetchStorages: () => Api.storagesGetAll({ signal }).then((response) => response.data),
-        fetchPaths: () => Api.pathsGetAll({ signal }).then((response) => response.data),
+        fetchStorages: () => Api.getStorages({ signal }).then((response) => response.data),
+        fetchPaths: () => Api.getPaths({ signal }).then((response) => response.data),
     });
 
     const result: MetadataPayload = {


### PR DESCRIPTION
## Summary
- update the metadata slice to call the existing getTags/getStorages/getPaths client helpers when loading reference data

## Testing
- pnpm --filter frontend build

------
https://chatgpt.com/codex/tasks/task_e_68cf08ae517c8328ac5b8f38c912d0a7