### PR TITLE
test: add validation coverage for FaceApiOptions

### DIFF
--- a/backend/PhotoBank.DependencyInjection/FaceApiOptions.cs
+++ b/backend/PhotoBank.DependencyInjection/FaceApiOptions.cs
@@ -1,7 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace PhotoBank.DependencyInjection;
 
 public sealed class FaceApiOptions
 {
+    [Required(AllowEmptyStrings = false)]
     public string Endpoint { get; init; } = string.Empty;
+
+    [Required(AllowEmptyStrings = false)]
     public string Key { get; init; } = string.Empty;
 }

--- a/backend/PhotoBank.UnitTests/FaceApiOptionsTests.cs
+++ b/backend/PhotoBank.UnitTests/FaceApiOptionsTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using PhotoBank.DependencyInjection;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class FaceApiOptionsTests
+{
+    [Test]
+    public void Bind_WithValidConfiguration_BindsValuesAndPassesValidation()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Face:Endpoint"] = "https://face.example.com",
+                ["Face:Key"] = "secret-key"
+            })
+            .Build();
+
+        var options = configuration.GetSection("Face").Get<FaceApiOptions>()!;
+
+        var validation = () => Validator.ValidateObject(options, new ValidationContext(options), validateAllProperties: true);
+
+        validation.Should().NotThrow();
+        options.Endpoint.Should().Be("https://face.example.com");
+        options.Key.Should().Be("secret-key");
+    }
+
+    [Test]
+    public void Bind_WithMissingEndpoint_ThrowsValidationException()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Face:Key"] = "secret-key"
+            })
+            .Build();
+
+        var options = configuration.GetSection("Face").Get<FaceApiOptions>()!;
+
+        var validation = () => Validator.ValidateObject(options, new ValidationContext(options), validateAllProperties: true);
+
+        validation.Should().Throw<ValidationException>()
+            .WithMessage("*Endpoint*");
+    }
+
+    [Test]
+    public void Bind_WithEmptyKey_ThrowsValidationException()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Face:Endpoint"] = "https://face.example.com",
+                ["Face:Key"] = string.Empty
+            })
+            .Build();
+
+        var options = configuration.GetSection("Face").Get<FaceApiOptions>()!;
+
+        var validation = () => Validator.ValidateObject(options, new ValidationContext(options), validateAllProperties: true);
+
+        validation.Should().Throw<ValidationException>()
+            .WithMessage("*Key*");
+    }
+}


### PR DESCRIPTION
## Summary
- mark FaceApiOptions properties as required for validation scenarios
- add unit tests covering successful binding and validation failures for FaceApiOptions

## Testing
- dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cffd7c0600832889c5bb720224a4dc