### PR TITLE
fix: validate computer vision options

### DIFF
--- a/backend/PhotoBank.DependencyInjection/ComputerVisionOptions.cs
+++ b/backend/PhotoBank.DependencyInjection/ComputerVisionOptions.cs
@@ -1,7 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace PhotoBank.DependencyInjection;
 
 public sealed class ComputerVisionOptions
 {
+    [Required(AllowEmptyStrings = false)]
     public string Endpoint { get; init; } = string.Empty;
+
+    [Required(AllowEmptyStrings = false)]
     public string Key { get; init; } = string.Empty;
 }

--- a/backend/PhotoBank.UnitTests/ComputerVisionOptionsTests.cs
+++ b/backend/PhotoBank.UnitTests/ComputerVisionOptionsTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using PhotoBank.DependencyInjection;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class ComputerVisionOptionsTests
+{
+    [Test]
+    public void Bind_WithValidConfiguration_BindsValuesAndPassesValidation()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ComputerVision:Endpoint"] = "https://computer-vision.example.com",
+                ["ComputerVision:Key"] = "super-secret-key"
+            })
+            .Build();
+
+        var options = configuration.GetSection("ComputerVision").Get<ComputerVisionOptions>()!;
+
+        var validation = () => Validator.ValidateObject(options, new ValidationContext(options), validateAllProperties: true);
+
+        validation.Should().NotThrow();
+        options.Endpoint.Should().Be("https://computer-vision.example.com");
+        options.Key.Should().Be("super-secret-key");
+    }
+
+    [Test]
+    public void Bind_WithMissingEndpoint_ThrowsValidationException()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ComputerVision:Key"] = "super-secret-key"
+            })
+            .Build();
+
+        var options = configuration.GetSection("ComputerVision").Get<ComputerVisionOptions>()!;
+
+        var validation = () => Validator.ValidateObject(options, new ValidationContext(options), validateAllProperties: true);
+
+        validation.Should().Throw<ValidationException>()
+            .WithMessage("*Endpoint*");
+    }
+
+    [Test]
+    public void Bind_WithEmptyKey_ThrowsValidationException()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ComputerVision:Endpoint"] = "https://computer-vision.example.com",
+                ["ComputerVision:Key"] = string.Empty
+            })
+            .Build();
+
+        var options = configuration.GetSection("ComputerVision").Get<ComputerVisionOptions>()!;
+
+        var validation = () => Validator.ValidateObject(options, new ValidationContext(options), validateAllProperties: true);
+
+        validation.Should().Throw<ValidationException>()
+            .WithMessage("*Key*");
+    }
+}


### PR DESCRIPTION
## Summary
- add required validation attributes to `ComputerVisionOptions`
- cover successful binding and validation failure scenarios with dedicated unit tests

## Testing
- dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68cfff42d49c832894b81cf2aaec84d5