### PR TITLE
fix: adjust before filter boundaries

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/search.test.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseArgsToFilter } from './search';
+
+describe('parseArgsToFilter before:... handling', () => {
+  it('excludes entire year when using before:YYYY', () => {
+    const filter = parseArgsToFilter('before:2015');
+
+    expect(filter.takenDateTo?.toISOString()).toBe('2014-12-31T23:59:59.999Z');
+  });
+
+  it('excludes entire month when using before:YYYY-MM', () => {
+    const filter = parseArgsToFilter('before:2015-06');
+
+    expect(filter.takenDateTo?.toISOString()).toBe('2015-05-31T23:59:59.999Z');
+  });
+
+  it('excludes the given day when using before:YYYY-MM-DD', () => {
+    const filter = parseArgsToFilter('before:2015-06-10');
+
+    expect(filter.takenDateTo?.toISOString()).toBe('2015-06-09T23:59:59.999Z');
+  });
+});

--- a/frontend/packages/telegram-bot/src/commands/search.ts
+++ b/frontend/packages/telegram-bot/src/commands/search.ts
@@ -9,6 +9,7 @@ import {
   startOfDay,
   startOfMonth,
   startOfYear,
+  subMilliseconds,
 } from 'date-fns';
 import type { FilterDto } from '@photobank/shared/api/photobank';
 
@@ -103,7 +104,9 @@ function parseDateExpr(expr: string): { from?: Date; to?: Date } {
 function parseBefore(val?: string): { to?: Date } {
   if (!val) return {};
   const p = parseSingleLoose(val);
-  return p ? { to: endOfDay(p.to) } : {};
+  if (!p) return {};
+  const start = startOfDay(p.from);
+  return { to: subMilliseconds(start, 1) };
 }
 
 /** after:VAL → только нижняя граница */
@@ -125,7 +128,7 @@ function parseAfter(val?: string): { from?: Date } {
  *
  * ⚠️ В фильтре используем только имена.
  */
-function parseArgsToFilter(raw: string): FilterDto {
+export function parseArgsToFilter(raw: string): FilterDto {
   const tokens = tokenize(raw);
 
   const tagNames: string[] = [];


### PR DESCRIPTION
## Summary
- make before:… filters exclude the provided period by using the start of the range minus 1ms
- export parseArgsToFilter and cover before:YYYY / before:YYYY-MM / before:YYYY-MM-DD parsing in unit tests

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68d006b4741c8328b601d68345a7da52