### PR TITLE
test: cover DomainException behavior

### DIFF
--- a/backend/PhotoBank.UnitTests/DomainExceptionTests.cs
+++ b/backend/PhotoBank.UnitTests/DomainExceptionTests.cs
@@ -1,0 +1,32 @@
+using FluentAssertions;
+using NUnit.Framework;
+using PhotoBank.Api;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class DomainExceptionTests
+{
+    [Test]
+    public void Constructor_ShouldPreserveProvidedMessage()
+    {
+        // Arrange
+        const string message = "Custom domain error";
+
+        // Act
+        var exception = new DomainException(message);
+
+        // Assert
+        exception.Message.Should().Be(message);
+    }
+
+    [Test]
+    public void Constructor_ShouldNotSetInnerException()
+    {
+        // Arrange & Act
+        var exception = new DomainException("message");
+
+        // Assert
+        exception.InnerException.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- add NUnit tests to verify DomainException preserves message and leaves inner exception unset

## Testing
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --filter DomainExceptionTests --verbosity minimal

------
https://chatgpt.com/codex/tasks/task_e_68d04c103fd48328832c8f2b0c420ad8