### PR TITLE
test: add reusable http fixtures for face providers

### DIFF
--- a/backend/PhotoBank.UnitTests/Infrastructure/FaceRecognition/Aws/RekognitionClientMockFactory.cs
+++ b/backend/PhotoBank.UnitTests/Infrastructure/FaceRecognition/Aws/RekognitionClientMockFactory.cs
@@ -1,0 +1,17 @@
+using Amazon;
+using Amazon.Rekognition;
+using Amazon.Runtime;
+using Moq;
+
+namespace PhotoBank.UnitTests.Infrastructure.FaceRecognition.Aws;
+
+internal static class RekognitionClientMockFactory
+{
+    public static Mock<AmazonRekognitionClient> Create()
+    {
+        return new Mock<AmazonRekognitionClient>(new AnonymousAWSCredentials(), new AmazonRekognitionConfig { RegionEndpoint = RegionEndpoint.USEast1 })
+        {
+            CallBase = false
+        };
+    }
+}

--- a/backend/PhotoBank.UnitTests/Infrastructure/FaceRecognition/Aws/RekognitionResponseBuilder.cs
+++ b/backend/PhotoBank.UnitTests/Infrastructure/FaceRecognition/Aws/RekognitionResponseBuilder.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.Rekognition.Model;
+
+namespace PhotoBank.UnitTests.Infrastructure.FaceRecognition.Aws;
+
+internal static class RekognitionResponseBuilder
+{
+    public static ListCollectionsResponse Collections(params string[] collectionIds)
+        => new() { CollectionIds = collectionIds.ToList() };
+
+    public static ListUsersResponse Users(params string[] userIds)
+        => new()
+        {
+            Users = userIds.Select(id => new User { UserId = id }).ToList()
+        };
+
+    public static CreateCollectionResponse CollectionCreated()
+        => new();
+
+    public static CreateUserResponse UserCreated()
+        => new();
+
+    public static DeleteUserResponse UserDeleted()
+        => new();
+
+    public static ListFacesResponse Faces(params string[] faceIds)
+        => new()
+        {
+            Faces = faceIds.Select(id => new Face { FaceId = id }).ToList()
+        };
+
+    public static IndexFacesResponse IndexedFaces(params string[] faceIds)
+        => new()
+        {
+            FaceRecords = faceIds.Select(id => new FaceRecord
+            {
+                Face = new Face { FaceId = id }
+            }).ToList()
+        };
+
+    public static AssociateFacesResponse AssociatedFaces(params string[] faceIds)
+        => new()
+        {
+            AssociatedFaces = faceIds.Select(id => new AssociatedFace { FaceId = id }).ToList()
+        };
+
+    public static DetectFacesResponse DetectedFaces(params FaceDetail[] faces)
+        => new() { FaceDetails = faces.ToList() };
+
+    public static DetectFacesResponse DetectedFaces(IList<FaceDetail> faces)
+        => new() { FaceDetails = faces as List<FaceDetail> ?? faces.ToList() };
+
+    public static SearchUsersByImageResponse UserMatches(params (string UserId, float? Similarity)[] matches)
+        => new()
+        {
+            UserMatches = matches.Select(match => new UserMatch
+            {
+                User = new MatchedUser { UserId = match.UserId },
+                Similarity = match.Similarity
+            }).ToList()
+        };
+
+    public static SearchUsersByImageResponse UserMatches(List<UserMatch> matches)
+        => new() { UserMatches = matches };
+}

--- a/backend/PhotoBank.UnitTests/Infrastructure/FaceRecognition/AzureFaceClientFactory.cs
+++ b/backend/PhotoBank.UnitTests/Infrastructure/FaceRecognition/AzureFaceClientFactory.cs
@@ -1,0 +1,19 @@
+using System.Net.Http;
+using Microsoft.Azure.CognitiveServices.Vision.Face;
+using Microsoft.Rest;
+using PhotoBank.Services.FaceRecognition.Azure;
+
+namespace PhotoBank.UnitTests.Infrastructure.FaceRecognition;
+
+internal static class AzureFaceClientFactory
+{
+    public static IFaceClient Create(AzureFaceOptions options, HttpMessageHandler handler)
+    {
+        var client = new FaceClient(new ApiKeyServiceClientCredentials(options.Key), new HttpClient(handler), true)
+        {
+            Endpoint = options.Endpoint
+        };
+
+        return client;
+    }
+}

--- a/backend/PhotoBank.UnitTests/Infrastructure/Http/HttpMockSequenceHandler.cs
+++ b/backend/PhotoBank.UnitTests/Infrastructure/Http/HttpMockSequenceHandler.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PhotoBank.UnitTests.Infrastructure.Http;
+
+internal sealed class HttpMockSequenceHandler : HttpMessageHandler
+{
+    private readonly Queue<Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>> _queue = new();
+
+    public int PendingHandlers => _queue.Count;
+
+    public void EnqueueResponse(HttpResponseMessage response)
+        => Enqueue((_, _) => Task.FromResult(response));
+
+    public void Enqueue(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        => _queue.Enqueue(handler);
+
+    public void Enqueue(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+        => _queue.Enqueue((request, _) => handler(request));
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (_queue.Count == 0)
+        {
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        }
+
+        return _queue.Dequeue().Invoke(request, cancellationToken);
+    }
+}

--- a/backend/PhotoBank.UnitTests/Infrastructure/Http/HttpRequestSnapshot.cs
+++ b/backend/PhotoBank.UnitTests/Infrastructure/Http/HttpRequestSnapshot.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace PhotoBank.UnitTests.Infrastructure.Http;
+
+internal sealed record HttpRequestSnapshot(HttpMethod Method, string Path, string Query, IReadOnlyDictionary<string, string[]> Headers, string? Body)
+{
+    public static HttpRequestSnapshot Capture(HttpRequestMessage request)
+    {
+        var headers = request.Headers.ToDictionary(h => h.Key, h => h.Value.ToArray(), StringComparer.OrdinalIgnoreCase);
+        string? body = null;
+
+        if (request.Content != null)
+        {
+            body = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        }
+
+        return new HttpRequestSnapshot(
+            request.Method,
+            request.RequestUri?.AbsolutePath ?? string.Empty,
+            request.RequestUri?.Query ?? string.Empty,
+            headers,
+            body);
+    }
+}

--- a/backend/PhotoBank.UnitTests/Infrastructure/Http/HttpResponseBuilder.cs
+++ b/backend/PhotoBank.UnitTests/Infrastructure/Http/HttpResponseBuilder.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+
+namespace PhotoBank.UnitTests.Infrastructure.Http;
+
+internal sealed class HttpResponseBuilder
+{
+    private HttpStatusCode _statusCode = HttpStatusCode.OK;
+    private string? _content;
+    private string? _mediaType;
+
+    public static HttpResponseBuilder Create() => new();
+
+    public HttpResponseBuilder WithStatus(HttpStatusCode statusCode)
+    {
+        _statusCode = statusCode;
+        return this;
+    }
+
+    public HttpResponseBuilder WithJson(object payload)
+    {
+        _content = JsonSerializer.Serialize(payload, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        _mediaType = "application/json";
+        return this;
+    }
+
+    public HttpResponseBuilder WithJson(string rawJson)
+    {
+        _content = rawJson;
+        _mediaType = "application/json";
+        return this;
+    }
+
+    public HttpResponseBuilder WithText(string text, string mediaType = "text/plain")
+    {
+        _content = text;
+        _mediaType = mediaType;
+        return this;
+    }
+
+    public HttpResponseBuilder WithoutContent()
+    {
+        _content = null;
+        _mediaType = null;
+        return this;
+    }
+
+    public HttpResponseBuilder WithError(string code, string message)
+    {
+        return WithJson(new { error = new { code, message } });
+    }
+
+    public HttpResponseMessage Build()
+    {
+        var response = new HttpResponseMessage(_statusCode);
+        if (_content != null)
+        {
+            response.Content = new StringContent(_content, Encoding.UTF8, _mediaType ?? "text/plain");
+        }
+
+        return response;
+    }
+}

--- a/backend/PhotoBank.UnitTests/Infrastructure/Http/QueryStringParser.cs
+++ b/backend/PhotoBank.UnitTests/Infrastructure/Http/QueryStringParser.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PhotoBank.UnitTests.Infrastructure.Http;
+
+internal static class QueryStringParser
+{
+    public static IReadOnlyDictionary<string, List<string>> Parse(string query)
+    {
+        if (string.IsNullOrEmpty(query))
+        {
+            return new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        return query.TrimStart('?')
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Split('=', 2))
+            .GroupBy(parts => Uri.UnescapeDataString(parts[0]), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(parts => parts.Length > 1 ? Uri.UnescapeDataString(parts[1]) : string.Empty).ToList(),
+                StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/backend/PhotoBank.UnitTests/Infrastructure/Logging/TestLogger.cs
+++ b/backend/PhotoBank.UnitTests/Infrastructure/Logging/TestLogger.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace PhotoBank.UnitTests.Infrastructure.Logging;
+
+internal sealed class TestLogger<T> : ILogger<T>
+{
+    public List<LogEntry> Entries { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+    }
+}
+
+internal sealed record LogEntry(LogLevel Level, string Message, Exception? Exception);
+
+internal sealed class NullScope : IDisposable
+{
+    public static readonly NullScope Instance = new();
+
+    public void Dispose()
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable HTTP mock utilities and test logger shared across face provider tests
- refactor AzureFaceProviderTests to use shared fixtures and JSON builders instead of ad-hoc handlers
- introduce Rekognition response builders and simplify FaceServiceAwsTests expectations to remove duplication

## Testing
- `dotnet vstest backend/PhotoBank.UnitTests/bin/Debug/net9.0/PhotoBank.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~AzureFaceProviderTests|FullyQualifiedName~FaceServiceAwsTests"`


------
https://chatgpt.com/codex/tasks/task_e_68d0524e77f483288ffac470721d30c7