### PR TITLE
test: add reusable api web factory for controller tests

### DIFF
--- a/backend/PhotoBank.IntegrationTests/Admin/AdminAccessProfilesControllerTests.cs
+++ b/backend/PhotoBank.IntegrationTests/Admin/AdminAccessProfilesControllerTests.cs
@@ -4,31 +4,22 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
-using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using Testcontainers.MsSql;
 using FluentAssertions;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Minio;
 using Moq;
 using NUnit.Framework;
 using PhotoBank.AccessControl;
-using PhotoBank.Api;
 using PhotoBank.DbContext.DbContext;
 using Respawn;
+using PhotoBank.IntegrationTests.Infra;
 
 namespace PhotoBank.IntegrationTests.Admin;
 
@@ -36,13 +27,11 @@ namespace PhotoBank.IntegrationTests.Admin;
 public class AdminAccessProfilesControllerTests
 {
     private const string AdminRole = "Admin";
-    private const string UserHeader = "X-Test-User";
-    private const string RolesHeader = "X-Test-Roles";
 
     private MsSqlContainer _dbContainer = null!;
     private Respawner _respawner = null!;
     private string _connectionString = string.Empty;
-    private TestWebApplicationFactory _factory = null!;
+    private ApiWebApplicationFactory _factory = null!;
     private HttpClient _client = null!;
     private JsonSerializerOptions _jsonOptions = null!;
 
@@ -124,7 +113,16 @@ public class AdminAccessProfilesControllerTests
             await _respawner.ResetAsync(conn);
         }
 
-        _factory = new TestWebApplicationFactory(_connectionString);
+        var configuration = TestConfiguration.Build(_connectionString);
+
+        _factory = new ApiWebApplicationFactory(
+            configuration: configuration,
+            configureServices: services =>
+            {
+                services.AddTestAuthentication();
+                services.RemoveAll<IEffectiveAccessProvider>();
+                services.AddSingleton(Mock.Of<IEffectiveAccessProvider>());
+            });
         _client = _factory.CreateClient(new WebApplicationFactoryClientOptions
         {
             BaseAddress = new Uri("http://localhost")
@@ -400,7 +398,7 @@ public class AdminAccessProfilesControllerTests
     public async Task List_WhenUserWithoutAdminRole_ReturnsForbidden()
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, "/api/admin/access-profiles");
-        request.Headers.Add(UserHeader, "user");
+        request.Headers.Add(TestAuthenticationDefaults.UserHeader, "user");
 
         var response = await _client.SendAsync(request);
 
@@ -409,8 +407,8 @@ public class AdminAccessProfilesControllerTests
 
     private static void AddAdminHeaders(HttpRequestMessage request)
     {
-        request.Headers.Add(UserHeader, "admin");
-        request.Headers.Add(RolesHeader, AdminRole);
+        request.Headers.Add(TestAuthenticationDefaults.UserHeader, "admin");
+        request.Headers.Add(TestAuthenticationDefaults.RolesHeader, AdminRole);
     }
 
     private async Task<AccessProfile> SeedProfileAsync(AccessProfile profile)
@@ -422,89 +420,4 @@ public class AdminAccessProfilesControllerTests
         return profile;
     }
 
-    private sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
-    {
-        private readonly string _connectionString;
-
-        public TestWebApplicationFactory(string connectionString)
-        {
-            _connectionString = connectionString;
-        }
-
-        protected override void ConfigureWebHost(IWebHostBuilder builder)
-        {
-            builder.UseEnvironment(Environments.Development);
-            builder.ConfigureAppConfiguration((context, configBuilder) =>
-            {
-                var overrides = new Dictionary<string, string?>
-                {
-                    ["ConnectionStrings:DefaultConnection"] = _connectionString,
-                    ["Jwt:Issuer"] = "issuer",
-                    ["Jwt:Audience"] = "audience",
-                    ["Jwt:Key"] = "super-secret"
-                };
-                configBuilder.AddInMemoryCollection(overrides);
-            });
-
-            builder.ConfigureTestServices(services =>
-            {
-                services.RemoveAll<IMinioClient>();
-                services.AddSingleton(Mock.Of<IMinioClient>());
-
-                services.RemoveAll<IEffectiveAccessProvider>();
-                services.AddSingleton(Mock.Of<IEffectiveAccessProvider>());
-
-                services.AddAuthentication(options =>
-                {
-                    options.DefaultAuthenticateScheme = TestAuthHandler.SchemeName;
-                    options.DefaultChallengeScheme = TestAuthHandler.SchemeName;
-                    options.DefaultScheme = TestAuthHandler.SchemeName;
-                }).AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, _ => { });
-            });
-        }
-    }
-
-    private sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
-    {
-        public const string SchemeName = "Test";
-
-        public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, System.Text.Encodings.Web.UrlEncoder encoder, ISystemClock clock)
-            : base(options, logger, encoder, clock)
-        {
-        }
-
-        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
-        {
-            if (!Request.Headers.TryGetValue(UserHeader, out var userValues))
-            {
-                return Task.FromResult(AuthenticateResult.NoResult());
-            }
-
-            var user = userValues.ToString();
-            if (string.IsNullOrWhiteSpace(user))
-            {
-                return Task.FromResult(AuthenticateResult.Fail("User header missing"));
-            }
-
-            var claims = new List<Claim>
-            {
-                new(ClaimTypes.NameIdentifier, user),
-                new(ClaimTypes.Name, user)
-            };
-
-            if (Request.Headers.TryGetValue(RolesHeader, out var rolesValues))
-            {
-                var roles = rolesValues.ToString().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                foreach (var role in roles)
-                {
-                    claims.Add(new Claim(ClaimTypes.Role, role));
-                }
-            }
-
-            var identity = new ClaimsIdentity(claims, Scheme.Name);
-            var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, Scheme.Name);
-            return Task.FromResult(AuthenticateResult.Success(ticket));
-        }
-    }
 }

--- a/backend/PhotoBank.IntegrationTests/Infra/ApiWebApplicationFactory.cs
+++ b/backend/PhotoBank.IntegrationTests/Infra/ApiWebApplicationFactory.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Minio;
+using Moq;
+using PhotoBank.Api;
+
+namespace PhotoBank.IntegrationTests.Infra;
+
+public sealed class ApiWebApplicationFactory : WebApplicationFactory<Program>
+{
+    private readonly string _environment;
+    private readonly IReadOnlyDictionary<string, string?> _configuration;
+    private readonly Action<IServiceCollection>? _configureServices;
+
+    public ApiWebApplicationFactory(
+        IReadOnlyDictionary<string, string?>? configuration = null,
+        Action<IServiceCollection>? configureServices = null,
+        string environment = "Development")
+    {
+        _environment = environment;
+        _configuration = configuration ?? new Dictionary<string, string?>();
+        _configureServices = configureServices;
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment(_environment);
+
+        if (_configuration.Count > 0)
+        {
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(_configuration);
+            });
+        }
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<IMinioClient>();
+            services.AddSingleton(Mock.Of<IMinioClient>());
+
+            _configureServices?.Invoke(services);
+        });
+    }
+}

--- a/backend/PhotoBank.IntegrationTests/Infra/TestAuthenticationExtensions.cs
+++ b/backend/PhotoBank.IntegrationTests/Infra/TestAuthenticationExtensions.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace PhotoBank.IntegrationTests.Infra;
+
+public static class TestAuthenticationDefaults
+{
+    public const string SchemeName = "IntegrationTest";
+    public const string UserHeader = "X-Test-User";
+    public const string RolesHeader = "X-Test-Roles";
+}
+
+public sealed class TestAuthenticationOptions
+{
+    public string SchemeName { get; set; } = TestAuthenticationDefaults.SchemeName;
+    public bool ConfigureFallbackPolicy { get; set; }
+}
+
+public static class TestAuthenticationServiceCollectionExtensions
+{
+    public static IServiceCollection AddTestAuthentication(
+        this IServiceCollection services,
+        Action<TestAuthenticationOptions>? configure = null)
+    {
+        var options = new TestAuthenticationOptions();
+        configure?.Invoke(options);
+
+        services.AddAuthentication(authOptions =>
+            {
+                authOptions.DefaultAuthenticateScheme = options.SchemeName;
+                authOptions.DefaultChallengeScheme = options.SchemeName;
+                authOptions.DefaultScheme = options.SchemeName;
+            })
+            .AddScheme<AuthenticationSchemeOptions, HeaderAuthenticationHandler>(options.SchemeName, _ => { });
+
+        if (options.ConfigureFallbackPolicy)
+        {
+            services.PostConfigure<AuthorizationOptions>(authorizationOptions =>
+            {
+                authorizationOptions.FallbackPolicy = new AuthorizationPolicyBuilder()
+                    .AddAuthenticationSchemes(options.SchemeName)
+                    .RequireAuthenticatedUser()
+                    .Build();
+            });
+        }
+
+        return services;
+    }
+}
+
+internal sealed class HeaderAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public HeaderAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        ISystemClock clock)
+        : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(TestAuthenticationDefaults.UserHeader, out var userValues))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var user = userValues.ToString();
+        if (string.IsNullOrWhiteSpace(user))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("User header missing"));
+        }
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, user),
+            new(ClaimTypes.Name, user)
+        };
+
+        if (Request.Headers.TryGetValue(TestAuthenticationDefaults.RolesHeader, out var rolesValues))
+        {
+            var roles = rolesValues.ToString().Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (var role in roles)
+            {
+                claims.Add(new Claim(ClaimTypes.Role, role));
+            }
+        }
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/backend/PhotoBank.IntegrationTests/Infra/TestConfiguration.cs
+++ b/backend/PhotoBank.IntegrationTests/Infra/TestConfiguration.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace PhotoBank.IntegrationTests.Infra;
+
+public static class TestConfiguration
+{
+    public static Dictionary<string, string?> Build(
+        string connectionString,
+        IReadOnlyDictionary<string, string?>? overrides = null)
+    {
+        var configuration = new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:DefaultConnection"] = connectionString,
+            ["Jwt:Issuer"] = "issuer",
+            ["Jwt:Audience"] = "audience",
+            ["Jwt:Key"] = "super-secret"
+        };
+
+        if (overrides is not null)
+        {
+            foreach (var (key, value) in overrides)
+            {
+                configuration[key] = value;
+            }
+        }
+
+        return configuration;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `ApiWebApplicationFactory` profile for integration tests with configurable configuration and service overrides
- provide shared authentication helpers and configuration builder utilities for API tests
- refactor controller integration tests to consume the new infra helpers instead of local factories

## Testing
- dotnet test backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj *(fails: Docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d05609fb2083289b321bfefd705e3f