### PR TITLE
fix: escape telegram html output

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photosPage.test.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.test.ts
@@ -34,16 +34,21 @@ function createPhoto(overrides: PhotoOverrides = {}): PhotoItemDto {
   } satisfies PhotoItemDto;
 }
 
-function createContext(): MyContext {
+type ContextOverrides = {
+  t?: ReturnType<typeof vi.fn>;
+};
+
+function createContext(overrides: ContextOverrides = {}): MyContext {
   const reply = vi.fn().mockResolvedValue({ message_id: 1 });
   const editMessageText = vi.fn().mockResolvedValue({});
-  const t = vi.fn((key: string, params?: Record<string, number>) => {
+  const defaultT = vi.fn((key: string, params?: Record<string, number>) => {
     if (key === 'unknown-year') return 'Unknown Year';
     if (key === 'page-info') return `Page ${params?.page} / ${params?.total}`;
     if (key === 'people-count') return `👥 ${params?.count}`;
     if (key === 'untitled') return 'Untitled';
     return key;
   });
+  const t = overrides.t ?? defaultT;
 
   return {
     chat: { id: 123 },
@@ -104,5 +109,53 @@ describe('sendPhotosPage', () => {
       expect.stringContaining('<b>Unknown Year</b>'),
       expect.objectContaining({ parse_mode: 'HTML' })
     );
+  });
+
+  it('escapes HTML special characters from API data and translations', async () => {
+    const customT = vi.fn((key: string, params?: Record<string, number>) => {
+      if (key === 'unknown-year') return 'Unknown & <Year>';
+      if (key === 'page-info') return `Page <${params?.page}> & ${params?.total}`;
+      if (key === 'people-count') return `👥 ${params?.count} & friends`;
+      if (key === 'untitled') return 'Untitled & <Photo>';
+      return key;
+    });
+    const ctx = createContext({ t: customT });
+    searchPhotosMock.mockResolvedValue({
+      totalCount: 1,
+      items: [
+        createPhoto({
+          id: 99,
+          name: '',
+          storageName: 'Main & Storage',
+          relativePath: "album/it's<ok>.jpg",
+          takenDate: new Date('not-a-date'),
+          captions: ['<b>bold & fun</b> "caption"'],
+          persons: ([{}] as unknown) as PhotoItemDto['persons'],
+          isAdultContent: true,
+        }),
+      ],
+    });
+
+    await sendPhotosPage({
+      ctx,
+      filter: {} as FilterDto,
+      page: 1,
+      fallbackMessage: 'No photos found',
+      buildCallbackData: (page) => `page:${page}`,
+    });
+
+    const replyMock = ctx.reply as unknown as ReturnType<typeof vi.fn>;
+    expect(replyMock).toHaveBeenCalled();
+    const [[text, options]] = replyMock.mock.calls as [[string, { parse_mode?: string }]];
+
+    expect(options?.parse_mode).toBe('HTML');
+    expect(text).toContain('📅 <b>Unknown &amp; &lt;Year&gt;</b>');
+    expect(text).toContain('📁 Main &amp; Storage / album/it&#39;s&lt;ok&gt;.jpg');
+    expect(text).toContain('[1] <b>Untitled &amp; &lt;Photo&gt;</b>');
+    expect(text).toContain('&lt;b&gt;bold &amp; fun&lt;/b&gt; &quot;caption&quot;');
+    expect(text).toContain('👥 1 &amp; friends');
+    expect(text).toContain('🔞');
+    expect(text).toContain('Page &lt;1&gt; &amp; 1');
+    expect(text).not.toContain('<b>bold & fun</b>');
   });
 });

--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -1,29 +1,43 @@
 import { formatDate, type PhotoDto } from "@photobank/shared";
 
 import { getPersonName } from "./dictionaries";
+import { escapeHtml } from "./utils/escapeHtml";
 
 export function formatPhotoMessage(photo: PhotoDto): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
   const lines: string[] = [];
 
-  lines.push(`📸 <b>${photo.name}</b>`);
+  const name = escapeHtml(photo.name ?? "");
+  lines.push(`📸 <b>${name}</b>`);
   if (photo.takenDate) {
-    lines.push(`📅 ${formatDate(photo.takenDate)}`);
+    lines.push(`📅 ${escapeHtml(formatDate(photo.takenDate))}`);
   }
 
   // lines.push(`📏 ${photo.width}×${photo.height}`);
 
-  if (photo.captions?.[0]) lines.push(`📝 ${photo.captions[0]}`);
-  if (photo.tags?.length) lines.push(`🏷️ ${photo.tags.join(", ")}`);
+  const firstCaption = photo.captions?.[0];
+  if (firstCaption) {
+    lines.push(`📝 ${escapeHtml(firstCaption)}`);
+  }
+  if (photo.tags?.length) {
+    const safeTags = photo.tags.map((tag) => escapeHtml(tag)).join(", ");
+    lines.push(`🏷️ ${safeTags}`);
+  }
 
   if (photo.location) {
     const { latitude, longitude } = photo.location;
     const coords = `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
-    lines.push(`📍 <a href="https://www.google.com/maps?q=${latitude},${longitude}">${coords}</a>`);
+    const safeCoords = escapeHtml(coords);
+    const mapUrl = `https://www.google.com/maps?q=${encodeURIComponent(latitude)},${encodeURIComponent(longitude)}`;
+    lines.push(`📍 <a href="${escapeHtml(mapUrl)}">${safeCoords}</a>`);
   }
 
   if (photo.faces?.length) {
-    const people = photo.faces.map((f: { personId?: number | null }) => getPersonName(f.personId ?? null));
-    if (people.some(Boolean)) {
+    const people = photo.faces
+      .map((f: { personId?: number | null }) => getPersonName(f.personId ?? null))
+      .map((personName) => personName.trim())
+      .filter((personName) => personName.length > 0)
+      .map((personName) => escapeHtml(personName));
+    if (people.length) {
       lines.push(`👤 ${people.join(", ")}`);
     }
   }

--- a/frontend/packages/telegram-bot/src/photo.test.ts
+++ b/frontend/packages/telegram-bot/src/photo.test.ts
@@ -4,6 +4,7 @@ import type { PhotoDto } from '@photobank/shared/api/photobank';
 
 import { formatPhotoMessage } from './formatPhotoMessage';
 import { loadPhotoFile } from './photo';
+import * as dictionaries from './dictionaries';
 
 function createPhoto(overrides: Partial<PhotoDto> = {}): PhotoDto {
   return {
@@ -14,6 +15,10 @@ function createPhoto(overrides: Partial<PhotoDto> = {}): PhotoDto {
 }
 
 describe('formatPhotoMessage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('formats ISO string takenDate values without throwing', () => {
     const isoString = '2023-02-01T15:30:00.000Z';
     const photo = createPhoto({
@@ -26,6 +31,27 @@ describe('formatPhotoMessage', () => {
     }).not.toThrow();
 
     expect(result?.caption).toContain('📅 01.02.2023');
+  });
+
+  it('escapes HTML-sensitive characters in captions and metadata', () => {
+    vi.spyOn(dictionaries, 'getPersonName').mockReturnValue('Alice & <Bob>');
+
+    const photo = createPhoto({
+      name: 'Summer <Sunset & "Glow">',
+      captions: ['Loved <friends> & "family"'],
+      tags: ['<tag>', 'rock & roll'],
+      location: { latitude: 51.5, longitude: -0.141 } as PhotoDto['location'],
+      faces: ([{ personId: 1 }] as unknown) as PhotoDto['faces'],
+    });
+
+    const result = formatPhotoMessage(photo);
+
+    expect(result.caption).toContain('Summer &lt;Sunset &amp; &quot;Glow&quot;&gt;');
+    expect(result.caption).toContain('📝 Loved &lt;friends&gt; &amp; &quot;family&quot;');
+    expect(result.caption).toContain('🏷️ &lt;tag&gt;, rock &amp; roll');
+    expect(result.caption).toContain('👤 Alice &amp; &lt;Bob&gt;');
+    expect(result.caption).not.toContain('<friends>');
+    expect(result.caption).not.toContain('Alice & <Bob>');
   });
 });
 

--- a/frontend/packages/telegram-bot/src/utils/escapeHtml.ts
+++ b/frontend/packages/telegram-bot/src/utils/escapeHtml.ts
@@ -1,0 +1,11 @@
+const ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+export function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => ESCAPE_MAP[char] ?? char);
+}


### PR DESCRIPTION
## Summary
- add a shared `escapeHtml` helper for consistent HTML entity encoding in the bot
- sanitize photo list rendering by escaping API- and translation-derived strings and extend coverage for tricky characters
- escape caption components in `formatPhotoMessage` and add regression tests for HTML-sensitive metadata

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68d19f2d71d083289edde4d848fed37d