### PR TITLE
feat: cache search filters in telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/src/cache/searchFilterCache.ts
+++ b/frontend/packages/telegram-bot/src/cache/searchFilterCache.ts
@@ -1,0 +1,76 @@
+import { randomBytes } from 'node:crypto';
+import type { FilterDto } from '@photobank/shared/api/photobank';
+
+const TOKEN_TTL_MS = 1000 * 60 * 15; // 15 minutes
+const MAX_ENTRIES = 1000;
+
+interface CacheEntry {
+  filter: FilterDto;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function generateToken(): string {
+  return randomBytes(9).toString('base64url');
+}
+
+function purgeExpired(now = Date.now()) {
+  for (const [token, entry] of cache) {
+    if (entry.expiresAt <= now) {
+      cache.delete(token);
+    }
+  }
+}
+
+function ensureCapacity() {
+  if (cache.size <= MAX_ENTRIES) return;
+
+  const entries = [...cache.entries()].sort(
+    (a, b) => a[1].expiresAt - b[1].expiresAt,
+  );
+
+  while (cache.size > MAX_ENTRIES && entries.length) {
+    const [token] = entries.shift()!;
+    cache.delete(token);
+  }
+}
+
+export function registerSearchFilterToken(filter: FilterDto): string {
+  const now = Date.now();
+  purgeExpired(now);
+
+  let token: string;
+  do {
+    token = generateToken();
+  } while (cache.has(token));
+
+  cache.set(token, {
+    filter,
+    expiresAt: now + TOKEN_TTL_MS,
+  });
+
+  ensureCapacity();
+
+  return token;
+}
+
+export function resolveSearchFilterToken(token: string): FilterDto | undefined {
+  const now = Date.now();
+  purgeExpired(now);
+
+  const entry = cache.get(token);
+  if (!entry) {
+    return undefined;
+  }
+  if (entry.expiresAt <= now) {
+    cache.delete(token);
+    return undefined;
+  }
+
+  return entry.filter;
+}
+
+export function clearSearchFilterTokens() {
+  cache.clear();
+}


### PR DESCRIPTION
## Summary
- add a TTL-backed token cache for search filters and expose helpers to register/resolve filters
- update search pagination callbacks to use compact tokens that fit within Telegram limits
- add a dedicated unit test ensuring long filters round-trip through the token cache and keep callback data short

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68d1a42c50188328b702bebd1bbfe15a