### PR TITLE
feat: show reverse geocoded addresses in captions

### DIFF
--- a/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
+++ b/frontend/packages/telegram-bot/src/formatPhotoMessage.ts
@@ -1,8 +1,12 @@
-import { formatDate, type PhotoDto } from "@photobank/shared";
+import { formatDate, getPlaceByGeoPoint, type PhotoDto } from "@photobank/shared";
 
 import { getPersonName } from "./dictionaries";
 
-export function formatPhotoMessage(photo: PhotoDto): { caption: string; hasSpoiler: boolean; imageUrl?: string } {
+export async function formatPhotoMessage(photo: PhotoDto): Promise<{
+  caption: string;
+  hasSpoiler: boolean;
+  imageUrl?: string;
+}> {
   const lines: string[] = [];
 
   lines.push(`📸 <b>${photo.name}</b>`);
@@ -17,8 +21,15 @@ export function formatPhotoMessage(photo: PhotoDto): { caption: string; hasSpoil
 
   if (photo.location) {
     const { latitude, longitude } = photo.location;
-    const coords = `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
-    lines.push(`📍 <a href="https://www.google.com/maps?q=${latitude},${longitude}">${coords}</a>`);
+    if (Math.abs(latitude) + Math.abs(longitude) !== 0) {
+      const coords = `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
+      const placeName = await getPlaceByGeoPoint({ latitude, longitude });
+      lines.push(
+        `📍 <a href="https://www.google.com/maps?q=${latitude},${longitude}">${
+          placeName || coords
+        }</a>`
+      );
+    }
   }
 
   if (photo.faces?.length) {

--- a/frontend/packages/telegram-bot/src/photo.test.ts
+++ b/frontend/packages/telegram-bot/src/photo.test.ts
@@ -14,18 +14,15 @@ function createPhoto(overrides: Partial<PhotoDto> = {}): PhotoDto {
 }
 
 describe('formatPhotoMessage', () => {
-  it('formats ISO string takenDate values without throwing', () => {
+  it('formats ISO string takenDate values without throwing', async () => {
     const isoString = '2023-02-01T15:30:00.000Z';
     const photo = createPhoto({
       takenDate: isoString as unknown as Date,
     });
 
-    let result: ReturnType<typeof formatPhotoMessage> | undefined;
-    expect(() => {
-      result = formatPhotoMessage(photo);
-    }).not.toThrow();
-
-    expect(result?.caption).toContain('📅 01.02.2023');
+    await expect(formatPhotoMessage(photo)).resolves.toMatchObject({
+      caption: expect.stringContaining('📅 01.02.2023'),
+    });
   });
 });
 

--- a/frontend/packages/telegram-bot/src/photo.ts
+++ b/frontend/packages/telegram-bot/src/photo.ts
@@ -48,7 +48,7 @@ export async function loadPhotoFile(photo: PhotoDto): Promise<{
   hasSpoiler: boolean;
   photoFile?: InputFile;
 }> {
-  const { caption, hasSpoiler, imageUrl } = formatPhotoMessage(photo);
+  const { caption, hasSpoiler, imageUrl } = await formatPhotoMessage(photo);
   if (!imageUrl) {
     return { caption, hasSpoiler };
   }

--- a/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
+++ b/frontend/packages/telegram-bot/test/formatPhotoMessage.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as shared from '@photobank/shared';
 import { formatPhotoMessage } from '../src/formatPhotoMessage';
 import type { PhotoDto } from '@photobank/shared/api/photobank';
 
 vi.mock('../src/dictionaries', () => ({
   getPersonName: (id: number | null | undefined) => id == null ? 'Неизвестный' : `Person ${id}`,
 }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('formatPhotoMessage', () => {
   const basePhoto: PhotoDto = {
@@ -17,8 +22,8 @@ describe('formatPhotoMessage', () => {
     width: 100,
   };
 
-  it('includes main fields in caption', () => {
-    const { caption, imageUrl } = formatPhotoMessage({
+  it('includes main fields in caption', async () => {
+    const { caption, imageUrl } = await formatPhotoMessage({
       ...basePhoto,
       takenDate: '2024-01-02T00:00:00Z',
       captions: ['hello'],
@@ -33,26 +38,48 @@ describe('formatPhotoMessage', () => {
     expect(imageUrl).toBeUndefined();
   });
 
-  it('uses preview url when provided', () => {
-    const { imageUrl } = formatPhotoMessage({ ...basePhoto, previewUrl: 'http://example.com/preview.jpg' });
+  it('uses preview url when provided', async () => {
+    const { imageUrl } = await formatPhotoMessage({
+      ...basePhoto,
+      previewUrl: 'http://example.com/preview.jpg',
+    });
     expect(imageUrl).toBe('http://example.com/preview.jpg');
   });
 
-  it('replaces missing person with unknown label', () => {
-    const { caption } = formatPhotoMessage({
+  it('replaces missing person with unknown label', async () => {
+    const { caption } = await formatPhotoMessage({
       ...basePhoto,
       faces: [{ id: 1, personId: null, faceBox: { top:0, left:0, width:1, height:1}, friendlyFaceAttributes: '' }],
     });
     expect(caption).toContain('👤 Неизвестный');
   });
 
-  it('adds geo point link when location is present', () => {
-    const { caption } = formatPhotoMessage({
+  it('adds geo point link when location is present', async () => {
+    const getPlaceByGeoPointSpy = vi
+      .spyOn(shared, 'getPlaceByGeoPoint')
+      .mockResolvedValue('Mock Address');
+
+    const { caption } = await formatPhotoMessage({
       ...basePhoto,
       location: { latitude: 10, longitude: 20 },
     });
     expect(caption).toContain('📍');
     expect(caption).toContain('https://www.google.com/maps?q=10,20');
-    expect(caption).toContain('10.00000, 20.00000');
+    expect(caption).toContain('Mock Address');
+    expect(getPlaceByGeoPointSpy).toHaveBeenCalledWith({ latitude: 10, longitude: 20 });
+  });
+
+  it('omits location when coordinates are zero', async () => {
+    const getPlaceByGeoPointSpy = vi
+      .spyOn(shared, 'getPlaceByGeoPoint')
+      .mockResolvedValue('Should not be used');
+
+    const { caption } = await formatPhotoMessage({
+      ...basePhoto,
+      location: { latitude: 0, longitude: 0 },
+    });
+
+    expect(getPlaceByGeoPointSpy).not.toHaveBeenCalled();
+    expect(caption).not.toContain('📍');
   });
 });


### PR DESCRIPTION
## Summary
- add reverse geocoding to Telegram photo captions and skip (0,0) coordinates
- make the formatter async and update the photo loader plus related tests
- cover address rendering and zero-coordinate cases with refreshed unit tests

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68d2c88d84a883289673efb149763e35