### PR TITLE
fix: clear cached preview when starting new search

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/photosPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/photosPage.ts
@@ -29,7 +29,7 @@ export async function sendPhotosPage({
   const chatId = ctx.chat?.id;
   if (chatId) {
     const prev = currentPagePhotos.get(chatId);
-    if (prev && prev.page !== page) {
+    if (!edit || (prev && prev.page !== page)) {
       await deletePhotoMessage(ctx);
     }
   }


### PR DESCRIPTION
## Summary
- ensure `sendPhotosPage` clears any cached photo preview before replying to a fresh search
- cover the fresh search behaviour with a unit test that seeds cached state and expects `deletePhotoMessage`

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68d2f20735c88328bf3a812564c7dbb0