### PR TITLE
feat: document date filters in search usage

### DIFF
--- a/frontend/packages/telegram-bot/src/locales/en.ftl
+++ b/frontend/packages/telegram-bot/src/locales/en.ftl
@@ -15,7 +15,17 @@ caption-missing = No caption.
 photo-usage = ❗ Use: /photo <id>
 photo-not-found = ❌ Photo not found.
 subscribe-usage = ❗ Use: /subscribe HH:MM
-search-usage = ❗ Use: /search <caption>
+search-usage = ❗ Советы по /search:
+1. Введите текст подписи или фразу в кавычках — ищем по caption.
+2. Добавляйте теги: #семья или tags:family,kids.
+3. Уточняйте людей: @anna или people:anna,ivan.
+4. Фильтруйте по датам: date:2020, date:2020-07..2020-08, одиночные 2020-05-15 или границы before:2020-01 / after:2019.
+
+Tips for /search:
+1. Type caption keywords or wrap phrases in quotes — searches by caption.
+2. Add tags: #family or tags:family,kids.
+3. Narrow by people: @anna or people:anna,ivan.
+4. Filter by dates: date:2020, date:2020-07..2020-08, single 2020-05-15, or bounds like before:2020-01 / after:2019.
 ai-usage = ❗ Use: /ai <prompt>
 ai-filter-empty = ⚠️ Could not determine filter from request. Please clarify.
 todays-photos-empty = 📭 No photos for today yet.

--- a/frontend/packages/telegram-bot/src/locales/ru.ftl
+++ b/frontend/packages/telegram-bot/src/locales/ru.ftl
@@ -15,7 +15,17 @@ caption-missing = Без подписи.
 photo-usage = ❗ Используй: /photo <id>
 photo-not-found = ❌ Фото не найдено.
 subscribe-usage = ❗ Используй: /subscribe HH:MM
-search-usage = ❗ Используй: /search <caption>
+search-usage = ❗ Советы по /search:
+1. Введите текст подписи или фразу в кавычках — ищем по caption.
+2. Добавляйте теги: #семья или tags:family,kids.
+3. Уточняйте людей: @anna или people:anna,ivan.
+4. Фильтруйте по датам: date:2020, date:2020-07..2020-08, одиночные 2020-05-15 или границы before:2020-01 / after:2019.
+
+Tips for /search:
+1. Type caption keywords or wrap phrases in quotes — searches by caption.
+2. Add tags: #family or tags:family,kids.
+3. Narrow by people: @anna or people:anna,ivan.
+4. Filter by dates: date:2020, date:2020-07..2020-08, single 2020-05-15, or bounds like before:2020-01 / after:2019.
 ai-usage = ❗ Используй: /ai <prompt>
 ai-filter-empty = ⚠️ Не удалось определить фильтр по запросу. Попробуйте уточнить.
 todays-photos-empty = 📭 Сегодняшних фото пока нет.


### PR DESCRIPTION
## Summary
- add bilingual guidance about date filters to the `/search` usage prompt so users know how to filter by ranges

## Testing
- pnpm --filter telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68d2f9d6466c8328904600958d6ad3f6