### PR TITLE
fix: keep telegram search pagination buttons active

### DIFF
--- a/frontend/packages/telegram-bot/src/cache/searchFilterCache.ts
+++ b/frontend/packages/telegram-bot/src/cache/searchFilterCache.ts
@@ -68,6 +68,9 @@ export function resolveSearchFilterToken(token: string): FilterDto | undefined {
     return undefined;
   }
 
+  entry.expiresAt = now + TOKEN_TTL_MS;
+  cache.set(token, entry);
+
   return entry.filter;
 }
 

--- a/frontend/packages/telegram-bot/test/searchFilterCache.test.ts
+++ b/frontend/packages/telegram-bot/test/searchFilterCache.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import {
+  clearSearchFilterTokens,
+  registerSearchFilterToken,
+  resolveSearchFilterToken,
+} from '../src/cache/searchFilterCache';
+
+const FIFTEEN_MINUTES = 15 * 60 * 1000;
+
+describe('searchFilterCache', () => {
+  afterEach(() => {
+    clearSearchFilterTokens();
+    vi.useRealTimers();
+  });
+
+  it('extends token expiration when the filter is resolved', () => {
+    vi.useFakeTimers({ now: 0 });
+
+    const filter = { caption: 'hello' };
+    const token = registerSearchFilterToken(filter);
+
+    vi.setSystemTime(FIFTEEN_MINUTES - 1000);
+    expect(resolveSearchFilterToken(token)).toBe(filter);
+
+    vi.setSystemTime(FIFTEEN_MINUTES + 100);
+    expect(resolveSearchFilterToken(token)).toBe(filter);
+
+    vi.setSystemTime(FIFTEEN_MINUTES * 2 + 200);
+    expect(resolveSearchFilterToken(token)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- refresh search filter cache entries whenever a callback resolves so pagination buttons stay usable
- add a regression test covering the refreshed expiration behaviour

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68d44be3e85c8328ad841849770eb416