### PR TITLE
fix: align photo list layout with navbar height

### DIFF
--- a/frontend/packages/frontend/src/app/App.tsx
+++ b/frontend/packages/frontend/src/app/App.tsx
@@ -21,8 +21,12 @@ export default function App() {
 
   return (
     <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
-      {loggedIn && <NavBar />}
-      <AppRoutes />
+      <div className="min-h-screen flex flex-col">
+        {loggedIn && <NavBar />}
+        <main className="flex-1 min-h-0">
+          <AppRoutes />
+        </main>
+      </div>
       <Lightbox />
     </ThemeProvider>
   );

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -47,7 +47,7 @@ const PhotoListPage = () => {
   }: UseInfinitePhotosResult = useInfinitePhotos(filter);
   const navigate = useNavigate();
   const location = useLocation();
-  const scrollAreaRef = useRef<HTMLDivElement>(null);
+  const scrollViewportRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   const [detailsId, setDetailsId] = useState<number | null>(null);
@@ -126,7 +126,7 @@ const PhotoListPage = () => {
 
   useEffect(() => {
     const element = sentinelRef.current;
-    const root = scrollAreaRef.current ?? undefined;
+    const root = scrollViewportRef.current ?? undefined;
     if (!element || !root) return;
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -147,7 +147,7 @@ const PhotoListPage = () => {
   }, []);
 
   return (
-    <div className="w-full h-screen flex flex-col bg-background">
+    <div className="flex w-full flex-1 min-h-0 flex-col bg-background">
       <div className="p-6 border-b flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">{t('photoGalleryTitle')}</h1>
@@ -160,10 +160,7 @@ const PhotoListPage = () => {
         </Button>
       </div>
 
-      <ScrollArea
-        className="h-[calc(100vh-240px)]"
-        ref={scrollAreaRef}
-      >
+      <ScrollArea className="flex-1 min-h-0" viewportRef={scrollViewportRef}>
         <div className="p-6">
           {/* Desktop/Tablet View */}
           <div className="hidden lg:block">


### PR DESCRIPTION
## Summary
- wrap the navbar and routed content in a flex column so pages only fill the area beneath the header
- let the photo list page grow within the routed viewport and observe the scroll area viewport for infinite loading

## Testing
- pnpm --filter frontend dev --host 0.0.0.0 --port 5173 *(fails: missing @tanstack/react-query-devtools)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c531aa948328aa2c876a48e2342c