### PR TITLE
Refactor dictionary commands with shared factory

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/dictionaryFactory.ts
+++ b/frontend/packages/telegram-bot/src/commands/dictionaryFactory.ts
@@ -1,0 +1,94 @@
+import type { Bot, MiddlewareFn } from 'grammy';
+
+import type { MyContext } from '../i18n';
+import { parsePrefix, sendNamedItemsPage, type NamedItem } from './helpers';
+
+export type WithRegistered = <T extends MyContext>(
+  handler: (ctx: T) => Promise<void>,
+) => MiddlewareFn<T>;
+
+export interface DictionaryFactoryOptions<T extends { name: string }> {
+  command: string;
+  fetchAll: () => Promise<T[]> | T[];
+  errorKey: string;
+  mapItem?: (item: T) => NamedItem;
+  filter?: (item: T) => boolean;
+}
+
+export interface DictionaryHandlers<T extends { name: string }> {
+  command: string;
+  callbackPattern: RegExp;
+  sendPage: (
+    ctx: MyContext,
+    prefix: string,
+    page: number,
+    edit?: boolean,
+  ) => Promise<void>;
+  commandHandler: (ctx: MyContext) => Promise<void>;
+  register: (bot: Bot<MyContext>, withRegistered: WithRegistered) => void;
+}
+
+function defaultMapItem<T extends { name: string }>(item: T): NamedItem {
+  return { name: item.name };
+}
+
+export function createDictionaryCommand<T extends { name: string }>(
+  options: DictionaryFactoryOptions<T>,
+): DictionaryHandlers<T> {
+  const { command, fetchAll, errorKey, filter, mapItem = defaultMapItem } = options;
+
+  const callbackPattern = new RegExp(`^${command}:(\\d+):(.*)$`);
+  let handlers: DictionaryHandlers<T>;
+
+  const sendPage: DictionaryHandlers<T>['sendPage'] = async (
+    ctx,
+    prefix,
+    page,
+    edit = false,
+  ) => {
+    await sendNamedItemsPage({
+      ctx,
+      command,
+      fetchAll: async () => {
+        const items = await Promise.resolve(fetchAll());
+        const filteredItems = filter ? items.filter(filter) : items;
+        return filteredItems.map((item) => mapItem(item));
+      },
+      prefix,
+      page,
+      edit,
+      errorMsg: ctx.t(errorKey),
+    });
+  };
+
+  const commandHandler: DictionaryHandlers<T>['commandHandler'] = async (ctx) => {
+    const prefix = parsePrefix(ctx.message?.text);
+    await handlers.sendPage(ctx, prefix, 1);
+  };
+
+  const register: DictionaryHandlers<T>['register'] = (bot, withRegistered) => {
+    bot.command(command, withRegistered(commandHandler));
+    bot.callbackQuery(
+      callbackPattern,
+      withRegistered(async (ctx) => {
+        if (!ctx.match || typeof ctx.match === 'string') {
+          throw new Error('Callback query match is undefined.');
+        }
+        const page = parseInt(ctx.match[1]!, 10);
+        const prefix = decodeURIComponent(ctx.match[2]!);
+        await ctx.answerCallbackQuery();
+        await handlers.sendPage(ctx, prefix, page, true);
+      }),
+    );
+  };
+
+  handlers = {
+    command,
+    callbackPattern,
+    sendPage,
+    commandHandler,
+    register,
+  };
+
+  return handlers;
+}

--- a/frontend/packages/telegram-bot/src/commands/persons.ts
+++ b/frontend/packages/telegram-bot/src/commands/persons.ts
@@ -1,27 +1,14 @@
-import type { MyContext } from "../i18n";
 import { getAllPersons } from '../dictionaries';
-import { parsePrefix, sendNamedItemsPage } from "./helpers";
+import { createDictionaryCommand } from './dictionaryFactory';
 
-export async function sendPersonsPage(
-  ctx: MyContext,
-  prefix: string,
-  page: number,
-  edit = false,
-) {
-  await sendNamedItemsPage({
-    ctx,
-    command: "persons",
-    fetchAll: () => Promise.resolve(getAllPersons()),
-    prefix,
-    page,
-    edit,
-    errorMsg: ctx.t('persons-error'),
-    filter: (p) => p.id >= 1,
-  });
-}
+export const personsDictionary = createDictionaryCommand({
+  command: 'persons',
+  fetchAll: () => Promise.resolve(getAllPersons()),
+  errorKey: 'persons-error',
+  filter: (person) => person.id >= 1,
+});
 
-export async function personsCommand(ctx: MyContext) {
-  const prefix = parsePrefix(ctx.message?.text);
-  await sendPersonsPage(ctx, prefix, 1);
-}
-
+export const sendPersonsPage = personsDictionary.sendPage;
+export const personsCommand = personsDictionary.commandHandler;
+export const personsCallbackPattern = personsDictionary.callbackPattern;
+export const registerPersonsDictionary = personsDictionary.register;

--- a/frontend/packages/telegram-bot/src/commands/storages.ts
+++ b/frontend/packages/telegram-bot/src/commands/storages.ts
@@ -1,36 +1,22 @@
-import type { MyContext } from '../i18n';
 import { getAllStoragesWithPaths } from '../dictionaries';
-import { parsePrefix, sendNamedItemsPage } from './helpers';
+import { createDictionaryCommand } from './dictionaryFactory';
 
 const MAX_PATHS_PER_STORAGE = 20;
 
-export async function sendStoragesPage(
-  ctx: MyContext,
-  prefix: string,
-  page: number,
-  edit = false
-) {
-  await sendNamedItemsPage({
-    ctx,
-    command: 'storages',
-    fetchAll: () =>
-      Promise.resolve(
-        getAllStoragesWithPaths().map((s) => {
-          const paths = s.paths.slice(0, MAX_PATHS_PER_STORAGE);
-          const rest = s.paths.length > MAX_PATHS_PER_STORAGE ? ['  ...'] : [];
-          return {
-            name: `${s.name}\n${paths.map((p: string) => `  ${p}`).concat(rest).join('\n')}`,
-          };
-        })
-      ),
-    prefix,
-    page,
-    edit,
-    errorMsg: ctx.t('storages-error'),
-  });
-}
+export const storagesDictionary = createDictionaryCommand<{ name: string; paths: string[] }>({
+  command: 'storages',
+  fetchAll: () => Promise.resolve(getAllStoragesWithPaths()),
+  errorKey: 'storages-error',
+  mapItem: (storage) => {
+    const paths = storage.paths.slice(0, MAX_PATHS_PER_STORAGE);
+    const rest = storage.paths.length > MAX_PATHS_PER_STORAGE ? ['  ...'] : [];
+    return {
+      name: `${storage.name}\n${paths.map((path: string) => `  ${path}`).concat(rest).join('\n')}`,
+    };
+  },
+});
 
-export async function storagesCommand(ctx: MyContext) {
-  const prefix = parsePrefix(ctx.message?.text);
-  await sendStoragesPage(ctx, prefix, 1);
-}
+export const sendStoragesPage = storagesDictionary.sendPage;
+export const storagesCommand = storagesDictionary.commandHandler;
+export const storagesCallbackPattern = storagesDictionary.callbackPattern;
+export const registerStoragesDictionary = storagesDictionary.register;

--- a/frontend/packages/telegram-bot/src/commands/tags.ts
+++ b/frontend/packages/telegram-bot/src/commands/tags.ts
@@ -1,26 +1,13 @@
-import type { MyContext } from '../i18n';
 import { getAllTags } from '../dictionaries';
-import { parsePrefix, sendNamedItemsPage } from './helpers';
+import { createDictionaryCommand } from './dictionaryFactory';
 
-export async function sendTagsPage(
-  ctx: MyContext,
-  prefix: string,
-  page: number,
-  edit = false,
-) {
-  await sendNamedItemsPage({
-    ctx,
-    command: "tags",
-    fetchAll: () => Promise.resolve(getAllTags()),
-    prefix,
-    page,
-    edit,
-    errorMsg: ctx.t('tags-error'),
-  });
-}
+export const tagsDictionary = createDictionaryCommand({
+  command: 'tags',
+  fetchAll: () => Promise.resolve(getAllTags()),
+  errorKey: 'tags-error',
+});
 
-export async function tagsCommand(ctx: MyContext) {
-  const prefix = parsePrefix(ctx.message?.text);
-  await sendTagsPage(ctx, prefix, 1);
-}
-
+export const sendTagsPage = tagsDictionary.sendPage;
+export const tagsCommand = tagsDictionary.commandHandler;
+export const tagsCallbackPattern = tagsDictionary.callbackPattern;
+export const registerTagsDictionary = tagsDictionary.register;

--- a/frontend/packages/telegram-bot/src/index.ts
+++ b/frontend/packages/telegram-bot/src/index.ts
@@ -15,10 +15,9 @@ import { sendSearchPage, searchCommand, decodeSearchCallback } from "./commands/
 import { aiCommand, sendAiPage } from "./commands/ai";
 import { helpCommand } from "./commands/help";
 import { subscribeCommand, initSubscriptionScheduler, restoreSubscriptions } from "./commands/subscribe";
-import { tagsCommand, sendTagsPage } from "./commands/tags";
-import { personsCommand, sendPersonsPage } from "./commands/persons";
-import { storagesCommand, sendStoragesPage } from "./commands/storages";
-import { tagsCallbackPattern, personsCallbackPattern, storagesCallbackPattern } from "./patterns";
+import { registerTagsDictionary } from "./commands/tags";
+import { registerPersonsDictionary } from "./commands/persons";
+import { registerStoragesDictionary } from "./commands/storages";
 import { registerPhotoRoutes } from "./commands/photoRouter";
 import { profileCommand } from "./commands/profile";
 import { uploadCommand } from "./commands/upload";
@@ -101,9 +100,9 @@ bot.command("profile", profileCommand);
 bot.command("subscribe", withRegistered(subscribeCommand));
 bot.command("upload", withRegistered(uploadCommand));
 
-bot.command("tags", withRegistered(tagsCommand));
-bot.command("persons", withRegistered(personsCommand));
-bot.command("storages", withRegistered(storagesCommand));
+registerTagsDictionary(bot, withRegistered);
+registerPersonsDictionary(bot, withRegistered);
+registerStoragesDictionary(bot, withRegistered);
 
 bot.callbackQuery(/^thisday:(\d+)$/, withRegistered(async (ctx) => {
   if (!ctx.match || typeof ctx.match === 'string') {
@@ -123,35 +122,6 @@ bot.callbackQuery(/^caption:(\d+)$/, withRegistered(async (ctx) => {
   await ctx.answerCallbackQuery(caption ?? ctx.t('caption-missing'));
 }));
 
-bot.callbackQuery(tagsCallbackPattern, withRegistered(async (ctx) => {
-  if (!ctx.match || typeof ctx.match === 'string') {
-    throw new Error("Callback query match is undefined.");
-  }
-  const page = parseInt(ctx.match[1]!, 10);
-  const prefix = decodeURIComponent(ctx.match[2]!);
-  await ctx.answerCallbackQuery();
-  await sendTagsPage(ctx, prefix, page, true);
-}));
-
-bot.callbackQuery(personsCallbackPattern, withRegistered(async (ctx) => {
-  if (!ctx.match || typeof ctx.match === 'string') {
-    throw new Error("Callback query match is undefined.");
-  }
-  const page = parseInt(ctx.match[1]!, 10);
-  const prefix = decodeURIComponent(ctx.match[2]!);
-  await ctx.answerCallbackQuery();
-  await sendPersonsPage(ctx, prefix, page, true);
-}));
-
-bot.callbackQuery(storagesCallbackPattern, withRegistered(async (ctx) => {
-  if (!ctx.match || typeof ctx.match === 'string') {
-    throw new Error("Callback query match is undefined.");
-  }
-  const page = parseInt(ctx.match[1]!, 10);
-  const prefix = decodeURIComponent(ctx.match[2]!);
-  await ctx.answerCallbackQuery();
-  await sendStoragesPage(ctx, prefix, page, true);
-}));
 
 bot.callbackQuery(/^search:(\d+):(.+)$/, withRegistered(async (ctx) => {
   const data = ctx.callbackQuery?.data;

--- a/frontend/packages/telegram-bot/src/patterns.ts
+++ b/frontend/packages/telegram-bot/src/patterns.ts
@@ -1,3 +1,3 @@
-export const tagsCallbackPattern = /^tags:(\d+):(.*)$/;
-export const personsCallbackPattern = /^persons:(\d+):(.*)$/;
-export const storagesCallbackPattern = /^storages:(\d+):(.*)$/;
+export { tagsCallbackPattern } from './commands/tags';
+export { personsCallbackPattern } from './commands/persons';
+export { storagesCallbackPattern } from './commands/storages';

--- a/frontend/packages/telegram-bot/test/dictionaryFactory.test.ts
+++ b/frontend/packages/telegram-bot/test/dictionaryFactory.test.ts
@@ -1,16 +1,41 @@
-import { describe, it, expect, vi } from 'vitest';
-import { sendTagsPage } from '../src/commands/tags';
-import { sendPersonsPage } from '../src/commands/persons';
-import { sendStoragesPage } from '../src/commands/storages';
-import { tagsCallbackPattern, personsCallbackPattern, storagesCallbackPattern } from '../src/patterns';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  sendTagsPage,
+  tagsCallbackPattern,
+  tagsDictionary,
+} from '../src/commands/tags';
+import {
+  sendPersonsPage,
+  personsCallbackPattern,
+  personsDictionary,
+} from '../src/commands/persons';
+import {
+  sendStoragesPage,
+  storagesCallbackPattern,
+  storagesDictionary,
+} from '../src/commands/storages';
 import * as dict from '../src/dictionaries';
 import { i18n } from '../src/i18n';
+
+function createMockCtx() {
+  return {
+    reply: vi.fn().mockResolvedValue(undefined),
+    editMessageText: vi.fn().mockResolvedValue(undefined),
+    answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+    t: (key: string, params?: Record<string, unknown>) => i18n.t('ru', key, params as any),
+  } as any;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('sendTagsPage', () => {
   it('filters by prefix and paginates', async () => {
     const tags = Array.from({ length: 11 }, (_, i) => ({ id: i + 1, name: `ba${String(i).padStart(2, '0')}` }));
     vi.spyOn(dict, 'getAllTags').mockReturnValue(tags as any);
-    const ctx = { reply: vi.fn(), t: (k: string, p?: any) => i18n.t('ru', k, p) } as any;
+    const ctx = createMockCtx();
     await sendTagsPage(ctx, 'ba', 2);
     expect(ctx.reply).toHaveBeenCalled();
     const text = ctx.reply.mock.calls[0][0];
@@ -21,7 +46,7 @@ describe('sendTagsPage', () => {
   it('shows navigation to first and last pages', async () => {
     const tags = Array.from({ length: 25 }, (_, i) => ({ id: i + 1, name: `t${i}` }));
     vi.spyOn(dict, 'getAllTags').mockReturnValue(tags as any);
-    const ctx = { reply: vi.fn(), t: (k: string, p?: any) => i18n.t('ru', k, p) } as any;
+    const ctx = createMockCtx();
     await sendTagsPage(ctx, '', 2);
     const [, opts] = ctx.reply.mock.calls[0];
     const buttons = opts.reply_markup.inline_keyboard[0].map((b: any) => b.text);
@@ -38,7 +63,7 @@ describe('sendPersonsPage', () => {
   it('filters by prefix and paginates', async () => {
     const persons = Array.from({ length: 12 }, (_, i) => ({ id: i + 1, name: `al${String(i).padStart(2, '0')}` }));
     vi.spyOn(dict, 'getAllPersons').mockReturnValue(persons as any);
-    const ctx = { reply: vi.fn(), t: (k: string, p?: any) => i18n.t('ru', k, p) } as any;
+    const ctx = createMockCtx();
     await sendPersonsPage(ctx, 'al', 2);
     expect(ctx.reply).toHaveBeenCalled();
     const text = ctx.reply.mock.calls[0][0];
@@ -52,7 +77,7 @@ describe('sendPersonsPage', () => {
       { id: 1, name: 'al00' },
     ];
     vi.spyOn(dict, 'getAllPersons').mockReturnValue(persons as any);
-    const ctx = { reply: vi.fn(), t: (k: string, p?: any) => i18n.t('ru', k, p) } as any;
+    const ctx = createMockCtx();
     await sendPersonsPage(ctx, 'a', 1);
     expect(ctx.reply).toHaveBeenCalled();
     const text = ctx.reply.mock.calls[0][0];
@@ -68,7 +93,7 @@ describe('sendStoragesPage', () => {
       paths: [`p${i}`],
     }));
     vi.spyOn(dict, 'getAllStoragesWithPaths').mockReturnValue(storages as any);
-    const ctx = { reply: vi.fn(), t: (k: string, p?: any) => i18n.t('ru', k, p) } as any;
+    const ctx = createMockCtx();
     await sendStoragesPage(ctx, 'st', 2);
     expect(ctx.reply).toHaveBeenCalled();
     const text = ctx.reply.mock.calls[0][0];
@@ -86,7 +111,7 @@ describe('sendStoragesPage', () => {
       },
     ];
     vi.spyOn(dict, 'getAllStoragesWithPaths').mockReturnValue(storages as any);
-    const ctx = { reply: vi.fn(), t: (k: string, p?: any) => i18n.t('ru', k, p) } as any;
+    const ctx = createMockCtx();
     await sendStoragesPage(ctx, '', 1);
     expect(ctx.reply).toHaveBeenCalled();
     const text = ctx.reply.mock.calls[0][0];
@@ -113,5 +138,54 @@ describe('callback regex', () => {
     const match = 'storages:1:'.match(storagesCallbackPattern);
     expect(match?.[1]).toBe('1');
     expect(match?.[2]).toBe('');
+  });
+});
+
+describe('dictionary registration', () => {
+  async function expectDictionaryRegistration(dictionary: typeof tagsDictionary) {
+    const bot = {
+      command: vi.fn(),
+      callbackQuery: vi.fn(),
+    } as any;
+    const withRegistered = vi.fn((handler) => handler as any);
+    const sendSpy = vi.spyOn(dictionary, 'sendPage').mockResolvedValue(undefined);
+
+    dictionary.register(bot, withRegistered);
+
+    expect(bot.command).toHaveBeenCalledWith(dictionary.command, expect.any(Function));
+    expect(bot.callbackQuery).toHaveBeenCalledWith(dictionary.callbackPattern, expect.any(Function));
+    expect(withRegistered).toHaveBeenCalledTimes(2);
+
+    const commandHandler = bot.command.mock.calls[0][1];
+    const ctx = Object.assign(createMockCtx(), {
+      message: { text: `/${dictionary.command} prefix` },
+    });
+    await commandHandler(ctx);
+    expect(sendSpy).toHaveBeenCalledWith(ctx, 'prefix', 1);
+
+    const callbackHandler = bot.callbackQuery.mock.calls[0][1];
+    const match = ['full', '2', 'pref%20ix'] as RegExpExecArray;
+    match.index = 0;
+    match.input = `${dictionary.command}:2:pref%20ix`;
+    const callbackCtx = Object.assign(createMockCtx(), {
+      match,
+      answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+    });
+    await callbackHandler(callbackCtx);
+    expect(callbackCtx.answerCallbackQuery).toHaveBeenCalled();
+    expect(sendSpy).toHaveBeenLastCalledWith(callbackCtx, 'pref ix', 2, true);
+    sendSpy.mockRestore();
+  }
+
+  it('registers tags handlers', async () => {
+    await expectDictionaryRegistration(tagsDictionary);
+  });
+
+  it('registers persons handlers', async () => {
+    await expectDictionaryRegistration(personsDictionary);
+  });
+
+  it('registers storages handlers', async () => {
+    await expectDictionaryRegistration(storagesDictionary);
   });
 });

--- a/frontend/packages/telegram-bot/test/openaiDisabled.test.ts
+++ b/frontend/packages/telegram-bot/test/openaiDisabled.test.ts
@@ -23,10 +23,9 @@ describe('bot without OpenAI', () => {
       initSubscriptionScheduler: vi.fn(),
       restoreSubscriptions: vi.fn(() => Promise.resolve()),
     }));
-    vi.mock('../src/commands/tags', () => ({ tagsCommand: vi.fn(), sendTagsPage: vi.fn() }));
-    vi.mock('../src/commands/persons', () => ({ personsCommand: vi.fn(), sendPersonsPage: vi.fn() }));
-    vi.mock('../src/commands/storages', () => ({ storagesCommand: vi.fn(), sendStoragesPage: vi.fn() }));
-    vi.mock('../src/patterns', () => ({ tagsCallbackPattern: /.*/, personsCallbackPattern: /.*/, storagesCallbackPattern: /.*/ }));
+    vi.mock('../src/commands/tags', () => ({ registerTagsDictionary: vi.fn() }));
+    vi.mock('../src/commands/persons', () => ({ registerPersonsDictionary: vi.fn() }));
+    vi.mock('../src/commands/storages', () => ({ registerStoragesDictionary: vi.fn() }));
     vi.mock('../src/commands/photoRouter', () => ({ registerPhotoRoutes: vi.fn() }));
     vi.mock('../src/commands/profile', () => ({ profileCommand: vi.fn() }));
     vi.mock('../src/commands/upload', () => ({ uploadCommand: vi.fn() }));


### PR DESCRIPTION
## Summary
- add a reusable dictionary command factory to centralize pagination, slash-command handlers, and callback metadata
- refactor the persons, tags, and storages commands plus bot wiring to build on the shared factory
- refresh patterns exports and add focused tests that exercise pagination and registration logic for each dictionary

## Testing
- pnpm --filter @photobank/telegram-bot test
- pnpm --filter @photobank/telegram-bot typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d955a08bdc8328a1971c4dd6af7725