### PR TITLE
Refactor filter paging helper

### DIFF
--- a/frontend/packages/telegram-bot/src/commands/ai.test.ts
+++ b/frontend/packages/telegram-bot/src/commands/ai.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FilterDto } from '@photobank/shared/api/photobank';
+
+vi.mock('./photosPage', () => ({
+  sendPhotosPage: vi.fn(),
+}));
+
+import { decodeAiCallback, sendAiPage } from './ai';
+import { sendPhotosPage } from './photosPage';
+import { clearSearchFilterTokens } from '../cache/searchFilterCache';
+import type { MyContext } from '../i18n';
+
+const sendPhotosPageMock = vi.mocked(sendPhotosPage);
+
+function createContext(): MyContext {
+  return {
+    t: vi.fn((key: string) => key),
+  } as unknown as MyContext;
+}
+
+describe('sendAiPage', () => {
+  beforeEach(() => {
+    clearSearchFilterTokens();
+    sendPhotosPageMock.mockReset();
+    sendPhotosPageMock.mockResolvedValue(undefined);
+  });
+
+  it('reuses filter tokens for paging callbacks', async () => {
+    const ctx = createContext();
+    const filter: FilterDto = {
+      caption: 'sky photos',
+      tagNames: ['clouds', 'sunset'],
+      personNames: ['alice'],
+    };
+
+    await sendAiPage(ctx, filter, 3);
+
+    expect(sendPhotosPageMock).toHaveBeenCalledTimes(1);
+    const callArgs = sendPhotosPageMock.mock.calls[0];
+    const options = callArgs ? callArgs[0] : undefined;
+    expect(options?.buildCallbackData).toBeTypeOf('function');
+
+    const callbackData = options!.buildCallbackData(5);
+    expect(callbackData.startsWith('ai:')).toBe(true);
+    expect(callbackData.length).toBeLessThanOrEqual(64);
+
+    const decoded = decodeAiCallback(callbackData);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.page).toBe(5);
+    expect(decoded?.filter).toEqual(filter);
+  });
+});

--- a/frontend/packages/telegram-bot/src/commands/filterPage.ts
+++ b/frontend/packages/telegram-bot/src/commands/filterPage.ts
@@ -1,0 +1,69 @@
+import type { FilterDto } from '@photobank/shared/api/photobank';
+
+import type { MyContext } from '@/i18n';
+import {
+  registerSearchFilterToken,
+  resolveSearchFilterToken,
+} from '@/cache/searchFilterCache';
+
+import { sendPhotosPage } from './photosPage';
+
+const TELEGRAM_CALLBACK_LIMIT = 64;
+
+interface SendFilterPageOptions {
+  ctx: MyContext;
+  filter: FilterDto;
+  page: number;
+  edit?: boolean;
+  fallbackMessage: string;
+  callbackPrefix: string;
+}
+
+export async function sendFilterPage({
+  ctx,
+  filter,
+  page,
+  edit = false,
+  fallbackMessage,
+  callbackPrefix,
+}: SendFilterPageOptions) {
+  const token = registerSearchFilterToken(filter);
+
+  await sendPhotosPage({
+    ctx,
+    filter,
+    page,
+    edit,
+    fallbackMessage,
+    buildCallbackData: (p) => {
+      const callbackData = `${callbackPrefix}:${p}:${token}`;
+      if (callbackData.length > TELEGRAM_CALLBACK_LIMIT) {
+        throw new Error(
+          `${callbackPrefix} callback_data exceeds Telegram limit`,
+        );
+      }
+      return callbackData;
+    },
+  });
+}
+
+export function decodeFilterCallback(
+  callbackPrefix: string,
+  data: string,
+): { page: number; filter: FilterDto } | null {
+  if (!data.startsWith(`${callbackPrefix}:`)) return null;
+
+  const parts = data.split(':');
+  if (parts.length !== 3) return null;
+
+  const page = Number(parts[1]);
+  if (!Number.isInteger(page) || page < 1) return null;
+
+  const token = parts[2];
+  if (!token) return null;
+
+  const filter = resolveSearchFilterToken(token);
+  if (!filter) return null;
+
+  return { page, filter };
+}

--- a/frontend/packages/telegram-bot/test/aiCommand.test.skip.ts
+++ b/frontend/packages/telegram-bot/test/aiCommand.test.skip.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
-import { aiCommand, parseAiPrompt, aiFilters } from '../src/commands/ai';
+import { aiCommand, parseAiPrompt } from '../src/commands/ai';
 import * as openai from '@photobank/shared/ai/openai';
 import * as photoService from '../src/services/photo';
-import * as utils from '@photobank/shared/';
 import { i18n } from '../src/i18n';
 
 describe('parseAiPrompt', () => {
@@ -39,15 +38,12 @@ describe('aiCommand', () => {
       dateFrom: new Date('2020-01-01T00:00:00Z'),
       dateTo: null,
     });
-    vi.spyOn(utils, 'getFilterHash').mockReturnValue('hash');
     const searchSpy = vi
       .spyOn(photoService, 'searchPhotos')
       .mockResolvedValue({ count: 0, photos: [] } as any);
-    aiFilters.clear();
 
     await aiCommand(ctx);
 
-    expect(aiFilters.has('hash')).toBe(true);
     expect(searchSpy).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({
@@ -69,13 +65,9 @@ describe('aiCommand', () => {
       dateFrom: null,
       dateTo: null,
     });
-    const hashSpy = vi.spyOn(utils, 'getFilterHash');
-    aiFilters.clear();
 
     await aiCommand(ctx);
 
-    expect(hashSpy).not.toHaveBeenCalled();
-    expect(aiFilters.size).toBe(0);
     expect(ctx.reply).toHaveBeenCalledWith(i18n.t('en', 'ai-filter-empty'));
   });
 
@@ -89,12 +81,10 @@ describe('aiCommand', () => {
         dateFrom: null,
         dateTo: null,
       });
-    vi.spyOn(utils, 'getFilterHash').mockResolvedValue('hash');
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
       count: 0,
       photos: [],
     } as any);
-    aiFilters.clear();
 
     await aiCommand(ctx, 'cats');
 

--- a/frontend/packages/telegram-bot/test/aiPage.test.skip.ts
+++ b/frontend/packages/telegram-bot/test/aiPage.test.skip.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { sendAiPage, aiFilters } from '../src/commands/ai';
+import { sendAiPage } from '../src/commands/ai';
 import * as photoService from '../src/services/photo';
 import * as photo from '../src/photo';
 import { i18n } from '../src/i18n';
@@ -19,7 +19,6 @@ const basePhoto = {
 beforeEach(() => {
   vi.restoreAllMocks();
   photo.currentPagePhotos.clear();
-  aiFilters.clear();
 });
 
 describe('sendAiPage', () => {
@@ -30,7 +29,6 @@ describe('sendAiPage', () => {
       editMessageText: vi.fn().mockResolvedValue(undefined),
       t: (k: string, p?: any) => i18n.t('en', k, p),
     } as any;
-    aiFilters.set('hash', {} as any);
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
@@ -38,7 +36,7 @@ describe('sendAiPage', () => {
       photos: [basePhoto],
     } as any);
 
-    await sendAiPage(ctx, 'hash', 2, true);
+    await sendAiPage(ctx, {} as any, 2, true);
 
     expect(photo.deletePhotoMessage).toHaveBeenCalled();
   });
@@ -50,7 +48,6 @@ describe('sendAiPage', () => {
       editMessageText: vi.fn().mockResolvedValue(undefined),
       t: (k: string, p?: any) => i18n.t('en', k, p),
     } as any;
-    aiFilters.set('hash', {} as any);
     photo.currentPagePhotos.set(1, { page: 1, ids: [1] });
     vi.spyOn(photo, 'deletePhotoMessage').mockResolvedValue();
     vi.spyOn(photoService, 'searchPhotos').mockResolvedValue({
@@ -58,7 +55,7 @@ describe('sendAiPage', () => {
       photos: [basePhoto],
     } as any);
 
-    await sendAiPage(ctx, 'hash', 1, true);
+    await sendAiPage(ctx, {} as any, 1, true);
 
     expect(photo.deletePhotoMessage).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- extract a reusable filter paging helper that registers tokens and enforces the Telegram callback limit
- update the search and ai commands to reuse the helper and share callback decoding logic
- add unit coverage to ensure ai filters survive callback round-trips and update legacy tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d95aaeaccc832890b9aa29d261cbea