### PR TITLE
fix: tighten partial person name matching

### DIFF
--- a/backend/PhotoBank.UnitTests/Services/SearchFilterNormalizerTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/SearchFilterNormalizerTests.cs
@@ -120,4 +120,41 @@ public class SearchFilterNormalizerTests
         translator.Verify(t => t.TranslateAsync(It.IsAny<TranslateRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Test]
+    public async Task NormalizeAsync_PrefersSingleIdForAmbiguousPartialMatches()
+    {
+        var translator = new Mock<ITranslatorService>();
+        translator
+            .Setup(t => t.TranslateAsync(It.IsAny<TranslateRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TranslateResponse(Array.Empty<string>()));
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        var persons = new[]
+        {
+            new PersonDto { Id = 11, Name = "Саша" },
+            new PersonDto { Id = 12, Name = "Саша (мама)" }
+        };
+
+        var referenceDataService = new Mock<ISearchReferenceDataService>();
+        referenceDataService
+            .Setup(s => s.GetPersonsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(persons);
+        referenceDataService
+            .Setup(s => s.GetTagsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<TagDto>());
+
+        var normalizer = new SearchFilterNormalizer(translator.Object, cache, referenceDataService.Object);
+
+        var filter = new FilterDto
+        {
+            PersonNames = new[] { "@Саша" }
+        };
+
+        var normalized = await normalizer.NormalizeAsync(filter);
+
+        normalized.Persons.Should().ContainSingle().Which.Should().Be(11);
+        translator.Verify(t => t.TranslateAsync(It.IsAny<TranslateRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
 }


### PR DESCRIPTION
## Summary
- prefer exact matches when resolving person IDs from normalized search tokens
- select a single closest candidate for partial matches and cover the scenario with a new unit test

## Testing
- dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --filter SearchFilterNormalizerTests

------
https://chatgpt.com/codex/tasks/task_e_68d996a5a45c83288a80fd6e09898a7b