### PR TITLE
feat: include roles in admin user responses

### DIFF
--- a/backend/PhotoBank.ViewModel.Dto/UserDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/UserDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace PhotoBank.ViewModel.Dto;
 
@@ -9,4 +10,5 @@ public class UserDto : IHasId<string>
     public string? PhoneNumber { get; set; }
     public long? TelegramUserId { get; set; }
     public TimeSpan? TelegramSendTimeUtc { get; set; }
+    public IReadOnlyCollection<string> Roles { get; init; } = Array.Empty<string>();
 }


### PR DESCRIPTION
## Summary
- add the roles collection to `UserDto` so admin responses can expose user roles
- load role memberships when listing or creating users in the admin controller
- extend the admin users integration tests to seed roles and assert they are returned

## Testing
- `dotnet test backend/PhotoBank.IntegrationTests/PhotoBank.IntegrationTests.csproj` *(fails: Docker endpoint unavailable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dacb211aec83289d57991a5afddb5e