### PR TITLE
fix: delay photo table pagination fetch

### DIFF
--- a/frontend/packages/frontend/src/features/photos/components/PhotoTable.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/PhotoTable.tsx
@@ -54,14 +54,24 @@ export function PhotoTable({
   });
 
   React.useEffect(() => {
+    const scrollEl = tableContainerRef.current;
+    if (!scrollEl || !hasNextPage || isFetchingNextPage || !fetchNextPage) {
+      return;
+    }
+
     const lastItem = rowVirtualizer.getVirtualItems().at(-1);
-    if (
-      lastItem &&
-      lastItem.index >= rows.length - 10 &&
-      hasNextPage &&
-      !isFetchingNextPage &&
-      fetchNextPage
-    ) {
+    if (!lastItem) {
+      return;
+    }
+
+    const distanceToBottom = Math.max(
+      0,
+      rowVirtualizer.getTotalSize() - (scrollEl.scrollTop + scrollEl.clientHeight)
+    );
+
+    const triggerThreshold = lastItem.size ?? 150;
+
+    if (distanceToBottom <= triggerThreshold) {
       fetchNextPage();
     }
   }, [rows.length, hasNextPage, isFetchingNextPage, fetchNextPage, rowVirtualizer]);


### PR DESCRIPTION
## Summary
- update the photo table infinite scroll to trigger loading when the user nears the bottom of the list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dadc68d8588328a2c9fd65f530d6db