### PR TITLE
feat: enable photo table row interaction

### DIFF
--- a/frontend/packages/frontend/src/features/photos/components/PhotoTable.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/PhotoTable.tsx
@@ -15,6 +15,7 @@ type Props = {
   fetchNextPage?: () => void;
   hasNextPage?: boolean;
   isFetchingNextPage?: boolean;
+  onRowClick?: (photoId: number) => void;
 };
 
 const DEFAULT_COLUMN_FLEX_STYLE: CSSProperties = { flex: '1.5 1 0%' };
@@ -35,6 +36,7 @@ export function PhotoTable({
                              fetchNextPage,
                              hasNextPage,
                              isFetchingNextPage,
+                             onRowClick,
                            }: Props) {
   const tableContainerRef = useRef<HTMLDivElement>(null);
 
@@ -130,7 +132,16 @@ export function PhotoTable({
               return (
                 <div
                   key={rowKey}
-                  className="absolute top-0 left-0 w-full flex items-center border-b border-border hover:bg-gallery-hover transition-colors duration-150"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => onRowClick?.(row.original.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault();
+                      onRowClick?.(row.original.id);
+                    }
+                  }}
+                  className="absolute top-0 left-0 w-full flex items-center border-b border-border hover:bg-gallery-hover transition-colors duration-150 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-primary"
                   style={{
                     height: `${virtualRow.size}px`,
                     transform: `translateY(${virtualRow.start}px)`,

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -167,12 +167,13 @@ const PhotoListPage = () => {
         <div className="p-6">
           {/* Desktop/Tablet View */}
           <div className="h-screen w-screen overflow-hidden">
-              <PhotoTable
-                photos={photos}
-                isFetchingNextPage={isFetchingNextPage}
-                hasNextPage={hasNextPage}
-                fetchNextPage={() => void fetchNextPage()}
-              />
+            <PhotoTable
+              photos={photos}
+              isFetchingNextPage={isFetchingNextPage}
+              hasNextPage={hasNextPage}
+              fetchNextPage={() => void fetchNextPage()}
+              onRowClick={handleOpenDetails}
+            />
           </div>
 
           {/* Mobile View */}


### PR DESCRIPTION
## Summary
- add an optional onRowClick handler to PhotoTable rows with accessible keyboard support
- pass the existing detail modal opener through PhotoListPage so table rows open the modal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dade1e3ed883288425ff1ba0dbf7aa