### PR TITLE
fix: align photo table column flex behavior

### DIFF
--- a/frontend/packages/frontend/src/features/photos/components/PhotoTable.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/PhotoTable.tsx
@@ -18,13 +18,20 @@ type Props = {
   onRowClick?: (photoId: number) => void;
 };
 
-const DEFAULT_COLUMN_FLEX_STYLE: CSSProperties = { flex: '1.5 1 0%' };
+const CONTENT_BASE_FLEX_STYLE: CSSProperties = {
+  flexGrow: 1,
+  flexShrink: 1,
+  flexBasis: 'auto',
+  minWidth: 'fit-content',
+};
+
+const DEFAULT_COLUMN_FLEX_STYLE: CSSProperties = CONTENT_BASE_FLEX_STYLE;
 const COLUMN_FLEX_STYLES: Record<string, CSSProperties> = {
   thumbnail: { flexBasis: '80px', flexShrink: 0 },
   flags: { flexBasis: '100px', flexShrink: 0 },
   takenDate: { flexBasis: '150px', flexShrink: 0 },
-  path: { flex: '1 1 0%' },
-  caption: { flex: '1.5 1 0%' },
+  path: CONTENT_BASE_FLEX_STYLE,
+  caption: { ...CONTENT_BASE_FLEX_STYLE, flexGrow: 1.5 },
 };
 
 function getColumnFlexStyle(columnId: string): CSSProperties {


### PR DESCRIPTION
## Summary
- adjust the default column flex style to use content-based sizing with a fit-content minimum
- apply the same content-based flex configuration to the path and caption columns so headers and cells stay aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae5a5e4848328a794c10b4b1ea86b