### PR TITLE
Fix caption wrapping in photo columns

### DIFF
--- a/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
@@ -58,7 +58,7 @@ export function usePhotoColumns(): ColumnDef<PhotoItemDto>[] {
         id: 'caption',
         header: 'Caption',
         cell: ({ row }) => (
-          <div className="text-sm text-foreground truncate">
+          <div className="text-sm text-foreground whitespace-pre-wrap break-words">
             {row.original.captions ? (
               row.original.captions[0]
             ) : (


### PR DESCRIPTION
## Summary
- allow photo captions in the photo table to wrap instead of truncating so long text stays readable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae6cc8b3c8328ad9582b7e07fda81