### PR TITLE
feat: integrate admin faces page with person faces api

### DIFF
--- a/frontend/packages/frontend/src/components/admin/EditFaceDialog.tsx
+++ b/frontend/packages/frontend/src/components/admin/EditFaceDialog.tsx
@@ -1,100 +1,264 @@
-import { useState, useEffect } from 'react';
-import type { FaceDto, PersonDto } from '@photobank/shared';
+import { useEffect, useMemo, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+import type { PersonDto, PersonFaceDto, PersonFacesUpdateMutationBody } from '@photobank/shared/api/photobank';
+import {
+  getPersonFacesGetAllQueryKey,
+  usePersonFacesDelete,
+  usePersonFacesUpdate,
+  usePersonsGetAll,
+} from '@photobank/shared/api/photobank';
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
 import { Button } from '@/shared/ui/button';
 import { Label } from '@/shared/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/shared/ui/select';
-
-import { mockPersons } from '@/data/mockData';
+import { useToast } from '@/hooks/use-toast';
 
 interface EditFaceDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  face: FaceDto | null;
-  onSave: (face: FaceDto) => void;
+  face: (PersonFaceDto & {
+    identityStatus?: string | null;
+    personName?: string | null;
+  }) | null;
 }
 
-export function EditFaceDialog({ open, onOpenChange, face, onSave }: EditFaceDialogProps) {
-  const [formData, setFormData] = useState<Partial<FaceDto>>({});
-  const [availablePersons] = useState<PersonDto[]>(mockPersons);
+type FormState = Partial<PersonFaceDto> & {
+  identityStatus?: string | null;
+};
+
+export function EditFaceDialog({ open, onOpenChange, face }: EditFaceDialogProps) {
+  const [formData, setFormData] = useState<FormState>({});
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const facesQueryKey = useMemo(() => getPersonFacesGetAllQueryKey(), []);
+
+  const {
+    data: personsResponse,
+    isLoading: arePersonsLoading,
+    isError: hasPersonsError,
+    refetch: refetchPersons,
+  } = usePersonsGetAll();
+
+  const persons = useMemo<PersonDto[]>(() => personsResponse?.data ?? [], [personsResponse]);
 
   useEffect(() => {
     if (face) {
       setFormData({
-        ...face,
+        personId: face.personId ?? undefined,
+        identityStatus: face.identityStatus ?? undefined,
       });
     } else {
       setFormData({});
     }
   }, [face]);
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (face && formData) {
-      const updatedFace: FaceDto = {
-        ...face,
-        ...formData,
-        personId: formData.personId,
-      };
-      onSave(updatedFace);
+  const updateFaceMutation = usePersonFacesUpdate({
+    mutation: {
+      onError: () => {
+        toast({
+          title: 'Failed to update face',
+          description: 'Something went wrong while saving the changes. Please try again.',
+          variant: 'destructive',
+        });
+      },
+    },
+  });
+
+  const deleteFaceMutation = usePersonFacesDelete({
+    mutation: {
+      onError: () => {
+        toast({
+          title: 'Failed to unassign face',
+          description: 'We could not unassign this face. Please try again.',
+          variant: 'destructive',
+        });
+      },
+    },
+  });
+
+  if (!face) return null;
+
+  const identityStatusOptions = useMemo(() => {
+    const baseStatuses = [
+      'Pending',
+      'Verified',
+      'Rejected',
+      'Identified',
+      'NotIdentified',
+      'NotDetected',
+      'ForReprocessing',
+      'StopProcessing',
+    ];
+
+    if (face.identityStatus && !baseStatuses.includes(face.identityStatus)) {
+      baseStatuses.push(face.identityStatus);
+    }
+
+    return Array.from(new Set(baseStatuses));
+  }, [face.identityStatus]);
+
+  const currentIdentityStatus =
+    formData.identityStatus ?? face.identityStatus ?? identityStatusOptions[0];
+
+  const pendingPersonSelection = formData.personId ?? face.personId ?? null;
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!face) return;
+
+    const resolvedPersonId = formData.personId ?? face.personId ?? undefined;
+
+    const targetId = face.id ?? face.faceId;
+    const faceIdentifier = face.faceId ?? face.id;
+
+    if (targetId == null || faceIdentifier == null) {
+      toast({
+        title: 'Face information incomplete',
+        description: 'Cannot update the selected face because it is missing identifiers.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      if (resolvedPersonId == null) {
+        await deleteFaceMutation.mutateAsync({ id: targetId });
+        toast({
+          title: 'Face unassigned',
+          description: `Face #${faceIdentifier} has been unassigned from any person.`,
+        });
+      } else {
+        const payload: PersonFacesUpdateMutationBody = {
+          id: targetId,
+          faceId: faceIdentifier,
+          personId: resolvedPersonId,
+          provider: formData.provider ?? face.provider,
+          externalId: formData.externalId ?? face.externalId,
+          externalGuid: formData.externalGuid ?? face.externalGuid,
+        } as PersonFacesUpdateMutationBody;
+
+        const extendedPayload = {
+          ...payload,
+          identityStatus: currentIdentityStatus,
+        } as unknown as PersonFacesUpdateMutationBody;
+
+        await updateFaceMutation.mutateAsync({
+          id: targetId,
+          data: extendedPayload,
+        });
+
+        toast({
+          title: 'Face updated',
+          description: `Face #${faceIdentifier} has been updated successfully.`,
+        });
+      }
+
+      await queryClient.invalidateQueries({ queryKey: facesQueryKey });
+      setFormData({});
       onOpenChange(false);
+    } catch {
+      // handled in mutation hooks
     }
   };
 
-  if (!face) return null;
+  const isSaving = updateFaceMutation.isPending || deleteFaceMutation.isPending;
+  const isSubmitDisabled =
+    isSaving || (arePersonsLoading && persons.length === 0 && pendingPersonSelection !== null);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>Edit Face #{face.id}</DialogTitle>
+          <DialogTitle>Edit Face #{face.id ?? face.faceId}</DialogTitle>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="person">Assign to Person</Label>
             <Select
-              value={formData.personId?.toString() || ''}
-              onValueChange={(value) => setFormData({ ...formData, personId: value ? parseInt(value) : undefined })}
+              value={
+                formData.personId != null
+                  ? formData.personId.toString()
+                  : face.personId != null
+                    ? face.personId.toString()
+                    : ''
+              }
+              onValueChange={(value) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  personId: value ? Number.parseInt(value, 10) : undefined,
+                }))
+              }
+              disabled={arePersonsLoading && persons.length === 0}
             >
               <SelectTrigger>
-                <SelectValue placeholder="Select a person or leave unassigned" />
+                <SelectValue
+                  placeholder={
+                    arePersonsLoading
+                      ? 'Loading persons…'
+                      : 'Select a person or leave unassigned'
+                  }
+                />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="">Unassigned</SelectItem>
-                {availablePersons.map((person) => (
+                {persons.map((person) => (
                   <SelectItem key={person.id} value={person.id.toString()}>
                     {person.name}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
+            {hasPersonsError && (
+              <Button
+                type="button"
+                variant="link"
+                className="px-0 text-xs text-muted-foreground"
+                onClick={() => refetchPersons()}
+              >
+                Retry loading persons
+              </Button>
+            )}
           </div>
 
           <div className="space-y-2">
             <Label htmlFor="status">Identity Status</Label>
             <Select
-              value={formData.identityStatus || face.identityStatus}
-              onValueChange={(value: 'Pending' | 'Verified' | 'Rejected') => 
-                setFormData({ ...formData, identityStatus: value })
+              value={currentIdentityStatus ?? ''}
+              onValueChange={(value) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  identityStatus: value,
+                }))
               }
             >
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="Pending">Pending</SelectItem>
-                <SelectItem value="Verified">Verified</SelectItem>
-                <SelectItem value="Rejected">Rejected</SelectItem>
+                {identityStatusOptions.map((status) => (
+                  <SelectItem key={status} value={status}>
+                    {status}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>
 
           <div className="flex justify-end gap-2 pt-4">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+            >
               Cancel
             </Button>
-            <Button type="submit">Save Changes</Button>
+            <Button type="submit" disabled={isSubmitDisabled}>
+              {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
+              Save Changes
+            </Button>
           </div>
         </form>
       </DialogContent>

--- a/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
-import { Search, User, Calendar, Eye } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Search, User, Calendar, Eye, Loader2 } from 'lucide-react';
+import type { PersonFacesGetAllQueryResult } from '@photobank/shared/api/photobank';
+import { usePersonFacesGetAll } from '@photobank/shared/api/photobank';
 
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
@@ -9,61 +11,134 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { EditFaceDialog } from '@/components/admin/EditFaceDialog';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar';
-import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from '@/shared/ui/pagination';
-import { Face } from '@/types/admin';
-import { mockFaces } from '@/data/mockData';
-import { useToast } from '@/hooks/use-toast';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/shared/ui/pagination';
 
 const ITEMS_PER_PAGE = 20;
 
+type PersonFaceListItem =
+  PersonFacesGetAllQueryResult['data'][number] &
+    Partial<{
+      identityStatus: string | null;
+      personName: string | null;
+      imageUrl: string | null;
+      createdAt: string | null;
+      updatedAt: string | null;
+    }>;
+
 export default function FacesPage() {
-  const [faces, setFaces] = useState<Face[]>(mockFaces);
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
-  const [selectedFace, setSelectedFace] = useState<Face | null>(null);
-  const { toast } = useToast();
+  const [selectedFace, setSelectedFace] = useState<PersonFaceListItem | null>(null);
 
-  const filteredFaces = faces.filter(face =>
-    face.personName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    face.id.toString().includes(searchTerm) ||
-    face.identityStatus.toLowerCase().includes(searchTerm.toLowerCase())
-  );
+  const { data, isLoading, isError, isFetching, refetch } = usePersonFacesGetAll();
+
+  const faces = useMemo<PersonFaceListItem[]>(() => {
+    const rawFaces = data?.data ?? [];
+
+    return rawFaces.map((face) => ({
+      ...face,
+      id: face.id ?? face.faceId,
+    }));
+  }, [data]);
+
+  const hasFacesLoaded = faces.length > 0;
+  const showLoading = isLoading && !hasFacesLoaded;
+  const showError = isError && !hasFacesLoaded;
+  const isRefreshing = isFetching && !showLoading;
+
+  const normalizedSearch = searchTerm.trim().toLowerCase();
+  const filteredFaces = useMemo(() => {
+    if (!normalizedSearch) {
+      return faces;
+    }
+
+    return faces.filter((face) => {
+      const id = (face.id ?? face.faceId).toString();
+      const faceId = face.faceId?.toString() ?? '';
+      const personId = face.personId?.toString() ?? '';
+      const personName = face.personName?.toLowerCase() ?? '';
+      const identityStatus = face.identityStatus?.toLowerCase() ?? '';
+      const provider = face.provider?.toLowerCase() ?? '';
+      const externalId = face.externalId?.toLowerCase() ?? '';
+
+      return (
+        id.includes(normalizedSearch) ||
+        faceId.includes(normalizedSearch) ||
+        personId.includes(normalizedSearch) ||
+        personName.includes(normalizedSearch) ||
+        identityStatus.includes(normalizedSearch) ||
+        provider.includes(normalizedSearch) ||
+        externalId.includes(normalizedSearch)
+      );
+    });
+  }, [faces, normalizedSearch]);
 
   const totalPages = Math.ceil(filteredFaces.length / ITEMS_PER_PAGE);
-  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
-  const currentFaces = filteredFaces.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+  const effectiveCurrentPage = totalPages === 0 ? 1 : Math.min(currentPage, totalPages);
+  const startIndex = (effectiveCurrentPage - 1) * ITEMS_PER_PAGE;
+  const endIndex = startIndex + ITEMS_PER_PAGE;
 
-  const getStatusColor = (status: Face['identityStatus']) => {
+  const currentFaces = useMemo(
+    () => filteredFaces.slice(startIndex, endIndex),
+    [filteredFaces, startIndex, endIndex]
+  );
+
+  useEffect(() => {
+    if (currentPage !== effectiveCurrentPage) {
+      setCurrentPage(effectiveCurrentPage);
+    }
+  }, [currentPage, effectiveCurrentPage]);
+
+  const handleEditFace = (face: PersonFaceListItem) => {
+    setSelectedFace(face);
+    setEditDialogOpen(true);
+  };
+
+  const handleDialogOpenChange = (open: boolean) => {
+    setEditDialogOpen(open);
+    if (!open) {
+      setSelectedFace(null);
+    }
+  };
+
+  const getStatusColor = (status?: string | null) => {
     switch (status) {
       case 'Verified':
+      case 'Identified':
         return 'bg-success text-success-foreground';
       case 'Pending':
+      case 'NotDetected':
+      case 'NotIdentified':
+      case 'ForReprocessing':
         return 'bg-warning text-warning-foreground';
       case 'Rejected':
+      case 'StopProcessing':
         return 'bg-destructive text-destructive-foreground';
       default:
         return 'bg-muted text-muted-foreground';
     }
   };
 
-  const handleEditFace = (face: Face) => {
-    setSelectedFace(face);
-    setEditDialogOpen(true);
-  };
+  const formatDate = (dateInput?: string | Date | null) => {
+    if (!dateInput) {
+      return null;
+    }
 
-  const handleUpdateFace = (updatedFace: Face) => {
-    setFaces(faces.map(face => 
-      face.id === updatedFace.id ? updatedFace : face
-    ));
-    toast({
-      title: 'Face Updated',
-      description: `Face #${updatedFace.id} has been updated successfully.`,
-    });
-  };
+    const date = typeof dateInput === 'string' ? new Date(dateInput) : new Date(dateInput);
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return date.toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
@@ -71,6 +146,17 @@ export default function FacesPage() {
       minute: '2-digit',
     });
   };
+
+  const statusLabel = (status?: string | null) => {
+    if (!status) {
+      return 'Unknown';
+    }
+
+    return status;
+  };
+
+  const displayedFacesCount = showLoading ? '—' : filteredFaces.length;
+  const totalFacesCount = showLoading ? '—' : faces.length;
 
   return (
     <div className="space-y-6">
@@ -96,14 +182,32 @@ export default function FacesPage() {
                   setCurrentPage(1);
                 }}
                 className="pl-10"
+                data-testid="faces-search-input"
               />
             </div>
-            <div className="text-sm text-muted-foreground">
-              {filteredFaces.length} of {faces.length} faces
+            <div className="text-sm text-muted-foreground flex items-center gap-2">
+              {isRefreshing && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+              <span>
+                {displayedFacesCount} of {totalFacesCount} faces
+              </span>
             </div>
           </div>
 
-          {currentFaces.length > 0 ? (
+          {showError ? (
+            <div className="flex flex-col items-center justify-center gap-4 py-12 text-center">
+              <p className="text-sm text-muted-foreground">
+                We couldn't load the faces list. Please try again.
+              </p>
+              <Button variant="outline" onClick={() => refetch()}>
+                Retry loading faces
+              </Button>
+            </div>
+          ) : showLoading ? (
+            <div className="flex items-center justify-center py-12" role="status">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              <span className="sr-only">Loading faces…</span>
+            </div>
+          ) : currentFaces.length > 0 ? (
             <>
               <div className="rounded-lg border border-border overflow-hidden">
                 <Table>
@@ -119,61 +223,71 @@ export default function FacesPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {currentFaces.map((face) => (
-                      <TableRow key={face.id} className="hover:bg-muted/30">
-                        <TableCell className="font-medium">#{face.id}</TableCell>
-                        <TableCell>
-                          <Avatar className="w-10 h-10">
-                            <AvatarImage src={face.imageUrl} />
-                            <AvatarFallback>
-                              <User className="w-4 h-4" />
-                            </AvatarFallback>
-                          </Avatar>
-                        </TableCell>
-                        <TableCell>
-                          {face.personName ? (
-                            <div className="flex items-center gap-2">
-                              <User className="w-4 h-4 text-muted-foreground" />
-                              <span>{face.personName}</span>
-                            </div>
-                          ) : (
-                            <span className="text-muted-foreground italic">Unassigned</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <Badge className={getStatusColor(face.identityStatus)}>
-                            {face.identityStatus}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                            <Calendar className="w-4 h-4" />
-                            {formatDate(face.createdAt)}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {face.updatedAt ? (
-                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                              <Calendar className="w-4 h-4" />
-                              {formatDate(face.updatedAt)}
-                            </div>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleEditFace(face)}
-                            className="gap-2"
-                          >
-                            <Eye className="w-4 h-4" />
-                            Edit
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                    {currentFaces.map((face) => {
+                      const createdAt = formatDate(face.createdAt);
+                      const updatedAt = formatDate(face.updatedAt);
+                      const displayName = face.personName ??
+                        (face.personId != null ? `Person #${face.personId}` : null);
+                      const status = statusLabel(face.identityStatus);
+
+                      return (
+                        <TableRow key={face.id ?? face.faceId} className="hover:bg-muted/30">
+                          <TableCell className="font-medium">#{face.id ?? face.faceId}</TableCell>
+                          <TableCell>
+                            <Avatar className="w-10 h-10">
+                              <AvatarImage src={face.imageUrl ?? undefined} />
+                              <AvatarFallback>
+                                <User className="w-4 h-4" />
+                              </AvatarFallback>
+                            </Avatar>
+                          </TableCell>
+                          <TableCell>
+                            {displayName ? (
+                              <div className="flex items-center gap-2">
+                                <User className="w-4 h-4 text-muted-foreground" />
+                                <span>{displayName}</span>
+                              </div>
+                            ) : (
+                              <span className="text-muted-foreground italic">Unassigned</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            <Badge className={getStatusColor(face.identityStatus)}>{status}</Badge>
+                          </TableCell>
+                          <TableCell>
+                            {createdAt ? (
+                              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                <Calendar className="w-4 h-4" />
+                                {createdAt}
+                              </div>
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {updatedAt ? (
+                              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                <Calendar className="w-4 h-4" />
+                                {updatedAt}
+                              </div>
+                            ) : (
+                              <span className="text-muted-foreground">—</span>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleEditFace(face)}
+                              className="gap-2"
+                            >
+                              <Eye className="w-4 h-4" />
+                              Edit
+                            </Button>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
                   </TableBody>
                 </Table>
               </div>
@@ -183,29 +297,35 @@ export default function FacesPage() {
                   <Pagination>
                     <PaginationContent>
                       <PaginationItem>
-                        <PaginationPrevious 
-                          onClick={() => setCurrentPage(Math.max(1, currentPage - 1))}
-                          className={currentPage === 1 ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                        <PaginationPrevious
+                          onClick={() =>
+                            setCurrentPage((prev) => Math.max(1, prev - 1))
+                          }
+                          className={
+                            effectiveCurrentPage === 1
+                              ? 'pointer-events-none opacity-50'
+                              : 'cursor-pointer'
+                          }
                         />
                       </PaginationItem>
-                      
+
                       {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-                        let pageNum;
+                        let pageNum: number;
                         if (totalPages <= 5) {
                           pageNum = i + 1;
-                        } else if (currentPage <= 3) {
+                        } else if (effectiveCurrentPage <= 3) {
                           pageNum = i + 1;
-                        } else if (currentPage >= totalPages - 2) {
+                        } else if (effectiveCurrentPage >= totalPages - 2) {
                           pageNum = totalPages - 4 + i;
                         } else {
-                          pageNum = currentPage - 2 + i;
+                          pageNum = effectiveCurrentPage - 2 + i;
                         }
-                        
+
                         return (
                           <PaginationItem key={pageNum}>
                             <PaginationLink
                               onClick={() => setCurrentPage(pageNum)}
-                              isActive={currentPage === pageNum}
+                              isActive={pageNum === effectiveCurrentPage}
                               className="cursor-pointer"
                             >
                               {pageNum}
@@ -213,11 +333,17 @@ export default function FacesPage() {
                           </PaginationItem>
                         );
                       })}
-                      
+
                       <PaginationItem>
-                        <PaginationNext 
-                          onClick={() => setCurrentPage(Math.min(totalPages, currentPage + 1))}
-                          className={currentPage === totalPages ? 'pointer-events-none opacity-50' : 'cursor-pointer'}
+                        <PaginationNext
+                          onClick={() =>
+                            setCurrentPage((prev) => Math.min(totalPages, prev + 1))
+                          }
+                          className={
+                            effectiveCurrentPage === totalPages
+                              ? 'pointer-events-none opacity-50'
+                              : 'cursor-pointer'
+                          }
                         />
                       </PaginationItem>
                     </PaginationContent>
@@ -226,12 +352,10 @@ export default function FacesPage() {
               )}
             </>
           ) : (
-            <div className="text-center py-12">
-              <User className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-              <h3 className="text-lg font-medium text-foreground mb-2">No faces found</h3>
-              <p className="text-muted-foreground mb-4">
-                {searchTerm ? 'No faces match your search criteria.' : 'No faces have been uploaded yet.'}
-              </p>
+            <div className="py-12 text-center text-muted-foreground">
+              {normalizedSearch
+                ? 'No faces match your search criteria.'
+                : 'No faces available yet.'}
             </div>
           )}
         </CardContent>
@@ -239,9 +363,8 @@ export default function FacesPage() {
 
       <EditFaceDialog
         open={editDialogOpen}
-        onOpenChange={setEditDialogOpen}
+        onOpenChange={handleDialogOpenChange}
         face={selectedFace}
-        onSave={handleUpdateFace}
       />
     </div>
   );

--- a/frontend/packages/shared/src/api/photobank/index.ts
+++ b/frontend/packages/shared/src/api/photobank/index.ts
@@ -3,6 +3,7 @@ export * from './photoBankApi.schemas';
 export * from './users/users';
 export * from './faces/faces';
 export * from './persons/persons';
+export * from './person-faces/person-faces';
 export * from './paths/paths';
 export * from './storages/storages';
 export * from './tags/tags';


### PR DESCRIPTION
## Summary
- replace the admin faces table mock store with the `usePersonFacesGetAll` query and add loading/error UX
- route edit dialog actions through the `usePersonFacesUpdate`/`usePersonFacesDelete` mutations and fetch people via `usePersonsGetAll`
- export the person-faces client from the shared API index for front-end use

## Testing
- pnpm --filter @photobank/frontend test --runInBand *(fails: vitest binary missing in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf368f01483288c6033b8cecd1f5f