### PR TITLE
fix: align sonner imports with verbatim module syntax

### DIFF
--- a/frontend/packages/frontend/src/hooks/use-toast.ts
+++ b/frontend/packages/frontend/src/hooks/use-toast.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { ToasterProps } from "@/shared/ui/sonner";
+import type { ToasterProps } from "@/shared/ui/sonner";
 
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;

--- a/frontend/packages/frontend/src/shared/ui/sonner.tsx
+++ b/frontend/packages/frontend/src/shared/ui/sonner.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import type { ToasterProps } from "sonner"
+import { Toaster as Sonner } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
@@ -21,3 +22,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
 }
 
 export { Toaster }
+export type { ToasterProps }


### PR DESCRIPTION
## Summary
- split the Sonner import to use a type-only import for ToasterProps and re-export the type
- update the toast hook to consume the type from the shared Sonner wrapper so verbatimModuleSyntax is satisfied

## Testing
- pnpm --filter @photobank/frontend build *(fails: existing TypeScript errors for identity status and missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1d0623288328935b922ab3e3c3fd