### PR TITLE
fix: use IdentityStatus enum when updating faces

### DIFF
--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -4,7 +4,7 @@ import { formatDate, getOrientation, getPlaceByGeoPoint, useIsAdmin } from '@pho
 import { logger } from '@photobank/shared/utils/logger';
 import type { FaceBoxDto, FaceDto } from '@photobank/shared/api/photobank';
 import * as PhotosApi from '@photobank/shared/api/photobank';
-import { useFacesUpdate } from '@photobank/shared/api/photobank';
+import { IdentityStatus, useFacesUpdate } from '@photobank/shared/api/photobank';
 import { Maximize2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -437,7 +437,10 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                                                   data: {
                                                                       faceId: face.id!,
                                                                       personId: personId ?? null,
-                                                                      identityStatus: personId == null ? 5 : 3,
+                                                                      identityStatus:
+                                                                          personId == null
+                                                                              ? IdentityStatus.StopProcessing
+                                                                              : IdentityStatus.Identified,
                                                                   },
                                                               });
                                                           }}


### PR DESCRIPTION
## Summary
- import the generated IdentityStatus enum in the photo details page
- use the enum members instead of numeric literals when updating face identity assignments

## Testing
- pnpm --filter @photobank/frontend build *(fails: existing toast typings reject `variant` / `open` props in toast payloads)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1f589a508328b7492800b0984167