### PR TITLE
ci: perform full clone for api pipeline

### DIFF
--- a/.woodpecker/api.yml
+++ b/.woodpecker/api.yml
@@ -3,7 +3,7 @@ clone:
     image: woodpeckerci/plugin-git
     settings:
       partial: false   # отключаем partial clone
-      depth: 200         # полный клон
+      depth: 0         # полный клон
       tags: true       # нужны теги для NBGV
 
 steps:


### PR DESCRIPTION
## Summary
- ensure the Woodpecker API pipeline performs a full git clone by setting the depth to 0 while keeping partial clone disabled and tags enabled for Nerdbank compatibility

## Testing
- dotnet build PhotoBank.Backend.sln *(fails: dotnet CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2e63f2c4832891b9ac2a2fa2abbe