### PR TITLE
fix: adjust photo table responsiveness

### DIFF
--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -166,7 +166,7 @@ const PhotoListPage = () => {
       >
         <div className="p-6">
           {/* Desktop/Tablet View */}
-          <div className="h-screen w-screen overflow-hidden">
+          <div className="hidden h-screen w-full overflow-hidden lg:block">
             <PhotoTable
               photos={photos}
               isFetchingNextPage={isFetchingNextPage}
@@ -177,7 +177,7 @@ const PhotoListPage = () => {
           </div>
 
           {/* Mobile View */}
-          <div className="lg:hidden">
+          <div className="block lg:hidden">
             <div className="grid gap-4 sm:grid-cols-2">
               {loading
                 ? skeletonPhotos.slice(0, 6).map((p: PhotoItemDto) => (


### PR DESCRIPTION
## Summary
- hide the photo table on mobile widths while preserving desktop layout
- explicitly show the mobile grid only on small viewports for complementary responsiveness

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc38d2230c832883d379f55074bf6f