### PR TITLE
fix: add admin navbar translations

### DIFF
--- a/frontend/packages/frontend/src/shared/config/locales/en.json
+++ b/frontend/packages/frontend/src/shared/config/locales/en.json
@@ -52,6 +52,7 @@
   "navbarPersonsLabel": "Persons",
   "navbarFacesLabel": "Faces",
   "navbarOpenAiLabel": "OpenAI",
+  "navbarAdminLabel": "Admin",
   "faceDetailsTitle": "Face Details",
   "ageLabel": "Age",
   "genderLabel": "Gender",

--- a/frontend/packages/frontend/src/shared/config/locales/ru.json
+++ b/frontend/packages/frontend/src/shared/config/locales/ru.json
@@ -52,6 +52,7 @@
   "navbarPersonsLabel": "Персоны",
   "navbarFacesLabel": "Лица",
   "navbarOpenAiLabel": "OpenAI",
+  "navbarAdminLabel": "Админ",
   "faceDetailsTitle": "Детали лица",
   "ageLabel": "Возраст",
   "genderLabel": "Пол",


### PR DESCRIPTION
## Summary
- add missing Admin label to the English and Russian navbar locale files so the dropdown renders a friendly name

## Testing
- pnpm --filter @photobank/frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dc400c8c348328ade5a0bba3022f91