### PR TITLE
Expose user roles through auth user endpoint

### DIFF
--- a/backend/PhotoBank.Api/Controllers/AuthController.cs
+++ b/backend/PhotoBank.Api/Controllers/AuthController.cs
@@ -71,13 +71,16 @@ public class AuthController(
         if (user == null)
             return NotFound();
 
+        var roles = await userManager.GetRolesAsync(user);
+
         return Ok(new UserDto
         {
             Id = user.Id,
             Email = user.Email ?? string.Empty,
             PhoneNumber = user.PhoneNumber,
             TelegramUserId = user.TelegramUserId,
-            TelegramSendTimeUtc = user.TelegramSendTimeUtc
+            TelegramSendTimeUtc = user.TelegramSendTimeUtc,
+            Roles = roles.ToArray()
         });
     }
 

--- a/frontend/packages/shared/src/api/photobank/photoBankApi.schemas.ts
+++ b/frontend/packages/shared/src/api/photobank/photoBankApi.schemas.ts
@@ -51,8 +51,7 @@ export interface CreateUserDto {
   password: string | null;
   /** @nullable */
   phoneNumber?: string | null;
-  /** @nullable */
-  roles?: string[] | null;
+  roles?: string[];
 }
 
 export interface FaceBoxDto {
@@ -259,8 +258,7 @@ export interface ResetPasswordDto {
 }
 
 export interface SetRolesDto {
-  /** @nullable */
-  roles?: string[] | null;
+  roles?: string[];
 }
 
 export interface StorageDto {
@@ -328,8 +326,7 @@ export interface UserDto {
   telegramUserId?: number | null;
   /** @nullable */
   telegramSendTimeUtc?: string | null;
-  /** @nullable */
-  roles?: string[] | null;
+  roles?: string[];
 }
 
 export type FacesGetParams = {

--- a/frontend/packages/shared/src/hooks/useIsAdmin.test.ts
+++ b/frontend/packages/shared/src/hooks/useIsAdmin.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasAdminRole } from './useIsAdmin';
+
+describe('hasAdminRole', () => {
+  it('returns true when Administrator role is present', () => {
+    expect(hasAdminRole(['User', 'Administrator'])).toBe(true);
+  });
+
+  it('returns false when Administrator role is missing', () => {
+    expect(hasAdminRole(['User'])).toBe(false);
+  });
+
+  it('returns false when roles are undefined', () => {
+    expect(hasAdminRole(undefined)).toBe(false);
+  });
+
+  it('returns false when roles are null', () => {
+    expect(hasAdminRole(null)).toBe(false);
+  });
+});

--- a/frontend/packages/shared/src/hooks/useIsAdmin.ts
+++ b/frontend/packages/shared/src/hooks/useIsAdmin.ts
@@ -7,10 +7,19 @@ const ROLE_CLAIM_TYPES = [
   'http://schemas.microsoft.com/ws/2008/06/identity/claims/role',
 ];
 
+export const hasAdminRole = (
+  roles?: readonly string[] | null,
+): boolean => roles?.includes(ADMIN_ROLE) ?? false;
+
 export const useIsAdmin = (): boolean | null => {
   const { data: userResp, isLoading, isError } = useAuthGetUser();
   if (isLoading) return null;
   if (isError) return false;
+
+  if (hasAdminRole(userResp?.data?.roles)) {
+    return true;
+  }
+
   const claims = (userResp?.data as UserWithClaims | undefined)?.claims ?? [];
   return claims.some(
     (c: Claim) =>

--- a/frontend/packages/telegram-bot/src/api/photobank/photoBankApi.schemas.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/photoBankApi.schemas.ts
@@ -51,8 +51,7 @@ export interface CreateUserDto {
   password: string | null;
   /** @nullable */
   phoneNumber?: string | null;
-  /** @nullable */
-  roles?: string[] | null;
+  roles?: string[];
 }
 
 export interface FaceBoxDto {
@@ -259,8 +258,7 @@ export interface ResetPasswordDto {
 }
 
 export interface SetRolesDto {
-  /** @nullable */
-  roles?: string[] | null;
+  roles?: string[];
 }
 
 export interface StorageDto {
@@ -328,8 +326,7 @@ export interface UserDto {
   telegramUserId?: number | null;
   /** @nullable */
   telegramSendTimeUtc?: string | null;
-  /** @nullable */
-  roles?: string[] | null;
+  roles?: string[];
 }
 
 export type FacesGetParams = {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1287,7 +1287,6 @@ components:
           type: array
           items:
             type: string
-          nullable: true
       additionalProperties: false
     FaceBoxDto:
       required:
@@ -1704,7 +1703,6 @@ components:
           type: array
           items:
             type: string
-          nullable: true
       additionalProperties: false
     StorageDto:
       required:
@@ -1842,5 +1840,4 @@ components:
           type: array
           items:
             type: string
-          nullable: true
       additionalProperties: false


### PR DESCRIPTION
## Summary
- load the authenticated user's roles in `AuthController` and map them onto `UserDto`
- mark role collections as non-nullable in the OpenAPI spec and regenerate Orval clients for shared and bot packages
- update `useIsAdmin` to check the roles array and cover the helper logic with unit tests

## Testing
- pnpm --dir frontend --filter @photobank/shared test

------
https://chatgpt.com/codex/tasks/task_e_68dc42fd9f9883289733c95e838ad9c3