### PR TITLE
test: add NavBar admin dropdown coverage

### DIFF
--- a/frontend/packages/frontend/src/components/NavBar.test.tsx
+++ b/frontend/packages/frontend/src/components/NavBar.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, beforeEach, vi, expect } from 'vitest';
+
+import NavBar from './NavBar';
+import { getAuthToken } from '@photobank/shared/auth';
+import { useIsAdmin } from '@photobank/shared';
+
+const changeLanguageMock = vi.fn();
+const i18nMock = {
+  language: 'en',
+  changeLanguage: changeLanguageMock,
+};
+
+vi.mock('@photobank/shared/auth', () => ({
+  getAuthToken: vi.fn(),
+}));
+
+vi.mock('@photobank/shared', () => ({
+  useIsAdmin: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: i18nMock,
+  }),
+}));
+
+const renderNavBar = () =>
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <NavBar />
+    </MemoryRouter>
+  );
+
+describe('NavBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    i18nMock.language = 'en';
+    changeLanguageMock.mockClear();
+  });
+
+  it('does not render admin dropdown trigger for non-admin users', () => {
+    vi.mocked(getAuthToken).mockReturnValue('token');
+    vi.mocked(useIsAdmin).mockReturnValue(false);
+
+    renderNavBar();
+
+    expect(
+      screen.queryByRole('button', { name: 'navbarAdminLabel' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders admin dropdown with admin links for admin users', async () => {
+    const user = userEvent.setup();
+    vi.mocked(getAuthToken).mockReturnValue('token');
+    vi.mocked(useIsAdmin).mockReturnValue(true);
+
+    renderNavBar();
+
+    const adminTrigger = screen.getByRole('button', {
+      name: 'navbarAdminLabel',
+    });
+
+    await user.click(adminTrigger);
+
+    const adminLinkLabels = [
+      'navbarUsersLabel',
+      'navbarAccessProfilesLabel',
+      'navbarPersonGroupsLabel',
+      'navbarPersonsLabel',
+      'navbarFacesLabel',
+    ];
+
+    for (const label of adminLinkLabels) {
+      expect(await screen.findByText(label)).toBeInTheDocument();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest and React Testing Library coverage for the NavBar component across admin and non-admin states
- mock translation, auth, and router dependencies so the admin dropdown and links render reliably in tests

## Testing
- pnpm --filter @photobank/frontend test --run src/components/NavBar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dcb54a6580832895c65433079d8c81