### PR TITLE
feat: add access profile dto mapping and controller updates

### DIFF
--- a/backend/PhotoBank.Api/Controllers/Admin/AdminAccessProfilesController.cs
+++ b/backend/PhotoBank.Api/Controllers/Admin/AdminAccessProfilesController.cs
@@ -1,7 +1,13 @@
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using PhotoBank.AccessControl;
+using PhotoBank.ViewModel.Dto;
+using System;
+using System.Linq;
 
 namespace PhotoBank.Api.Controllers.Admin;
 
@@ -12,47 +18,172 @@ public class AdminAccessProfilesController : ControllerBase
 {
     private readonly AccessControlDbContext _db;
     private readonly IEffectiveAccessProvider _eff;
+    private readonly IMapper _mapper;
 
-    public AdminAccessProfilesController(AccessControlDbContext db, IEffectiveAccessProvider eff)
+    public AdminAccessProfilesController(AccessControlDbContext db, IEffectiveAccessProvider eff, IMapper mapper)
     {
-        _db = db; _eff = eff;
+        _db = db;
+        _eff = eff;
+        _mapper = mapper;
     }
 
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<AccessProfile>>> List(CancellationToken ct)
-        => Ok(await _db.AccessProfiles
-            .Include(p => p.Storages)
-            .Include(p => p.PersonGroups)
-            .Include(p => p.DateRanges)
+    [ProducesResponseType(typeof(IEnumerable<AccessProfileDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<AccessProfileDto>>> List(CancellationToken ct)
+    {
+        var profiles = await _db.AccessProfiles
+            .AsNoTracking()
+            .ProjectTo<AccessProfileDto>(_mapper.ConfigurationProvider)
             .OrderBy(p => p.Name)
-            .ToListAsync(ct));
+            .ToListAsync(ct);
+
+        return Ok(profiles);
+    }
 
     [HttpPost]
-    public async Task<ActionResult> Create([FromBody] AccessProfile profile, CancellationToken ct)
+    [ProducesResponseType(typeof(AccessProfileDto), StatusCodes.Status201Created)]
+    public async Task<ActionResult<AccessProfileDto>> Create([FromBody] AccessProfileDto profile, CancellationToken ct)
     {
-        _db.AccessProfiles.Add(profile);
+        var entity = _mapper.Map<AccessProfile>(profile);
+        _db.AccessProfiles.Add(entity);
         await _db.SaveChangesAsync(ct);
-        return CreatedAtAction(nameof(Get), new { id = profile.Id }, profile);
+
+        var created = await _db.AccessProfiles
+            .AsNoTracking()
+            .Where(x => x.Id == entity.Id)
+            .ProjectTo<AccessProfileDto>(_mapper.ConfigurationProvider)
+            .FirstAsync(ct);
+
+        return CreatedAtAction(nameof(Get), new { id = created.Id }, created);
     }
 
     [HttpGet("{id:int}")]
-    public async Task<ActionResult<AccessProfile>> Get(int id, CancellationToken ct)
+    [ProducesResponseType(typeof(AccessProfileDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<AccessProfileDto>> Get(int id, CancellationToken ct)
     {
-        var p = await _db.AccessProfiles
+        var profile = await _db.AccessProfiles
+            .AsNoTracking()
+            .Where(x => x.Id == id)
+            .ProjectTo<AccessProfileDto>(_mapper.ConfigurationProvider)
+            .FirstOrDefaultAsync(ct);
+
+        return profile is null ? NotFound() : Ok(profile);
+    }
+
+    [HttpPut("{id:int}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> Update(int id, [FromBody] AccessProfileDto dto, CancellationToken ct)
+    {
+        if (id != dto.Id) return BadRequest();
+        var entity = await _db.AccessProfiles
             .Include(x => x.Storages)
             .Include(x => x.PersonGroups)
             .Include(x => x.DateRanges)
             .FirstOrDefaultAsync(x => x.Id == id, ct);
-        return p is null ? NotFound() : Ok(p);
-    }
 
-    [HttpPut("{id:int}")]
-    public async Task<ActionResult> Update(int id, [FromBody] AccessProfile dto, CancellationToken ct)
-    {
-        if (id != dto.Id) return BadRequest();
-        _db.Entry(dto).State = EntityState.Modified;
+        if (entity is null) return NotFound();
+
+        entity.Name = dto.Name;
+        entity.Description = dto.Description;
+        entity.Flags_CanSeeNsfw = dto.Flags_CanSeeNsfw;
+
+        UpdateStorages(entity, dto);
+        UpdatePersonGroups(entity, dto);
+        UpdateDateRanges(entity, dto);
+
         await _db.SaveChangesAsync(ct);
         return NoContent();
+    }
+
+    private void UpdateStorages(AccessProfile entity, AccessProfileDto dto)
+    {
+        var desired = (dto.Storages ?? Array.Empty<AccessProfileStorageAllowDto>())
+            .Select(s => s.StorageId)
+            .ToHashSet();
+
+        var toRemove = entity.Storages
+            .Where(s => !desired.Contains(s.StorageId))
+            .ToList();
+
+        foreach (var remove in toRemove)
+        {
+            _db.AccessProfileStorages.Remove(remove);
+            entity.Storages.Remove(remove);
+        }
+
+        foreach (var storageId in desired)
+        {
+            if (entity.Storages.All(s => s.StorageId != storageId))
+            {
+                entity.Storages.Add(new AccessProfileStorageAllow
+                {
+                    ProfileId = entity.Id,
+                    StorageId = storageId
+                });
+            }
+        }
+    }
+
+    private void UpdatePersonGroups(AccessProfile entity, AccessProfileDto dto)
+    {
+        var desired = (dto.PersonGroups ?? Array.Empty<AccessProfilePersonGroupAllowDto>())
+            .Select(pg => pg.PersonGroupId)
+            .ToHashSet();
+
+        var toRemove = entity.PersonGroups
+            .Where(pg => !desired.Contains(pg.PersonGroupId))
+            .ToList();
+
+        foreach (var remove in toRemove)
+        {
+            _db.AccessProfilePersonGroups.Remove(remove);
+            entity.PersonGroups.Remove(remove);
+        }
+
+        foreach (var personGroupId in desired)
+        {
+            if (entity.PersonGroups.All(pg => pg.PersonGroupId != personGroupId))
+            {
+                entity.PersonGroups.Add(new AccessProfilePersonGroupAllow
+                {
+                    ProfileId = entity.Id,
+                    PersonGroupId = personGroupId
+                });
+            }
+        }
+    }
+
+    private void UpdateDateRanges(AccessProfile entity, AccessProfileDto dto)
+    {
+        var desired = (dto.DateRanges ?? Array.Empty<AccessProfileDateRangeAllowDto>())
+            .Select(r => (r.FromDate, r.ToDate))
+            .ToHashSet();
+
+        var toRemove = entity.DateRanges
+            .Where(r => !desired.Contains((r.FromDate, r.ToDate)))
+            .ToList();
+
+        foreach (var remove in toRemove)
+        {
+            _db.AccessProfileDateRanges.Remove(remove);
+            entity.DateRanges.Remove(remove);
+        }
+
+        foreach (var range in dto.DateRanges ?? Array.Empty<AccessProfileDateRangeAllowDto>())
+        {
+            if (entity.DateRanges.All(r => r.FromDate != range.FromDate || r.ToDate != range.ToDate))
+            {
+                entity.DateRanges.Add(new AccessProfileDateRangeAllow
+                {
+                    ProfileId = entity.Id,
+                    FromDate = range.FromDate,
+                    ToDate = range.ToDate
+                });
+            }
+        }
     }
 
     [HttpDelete("{id:int}")]

--- a/backend/PhotoBank.Services/MappingProfile.cs
+++ b/backend/PhotoBank.Services/MappingProfile.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using AutoMapper;
+using PhotoBank.AccessControl;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Services.Models;
 using PhotoBank.ViewModel.Dto;
@@ -84,6 +85,42 @@ namespace PhotoBank.Services
                 .ForMember(dest => dest.PersonId, opt => opt.MapFrom(src => src.PersonFace.PersonId))
                 .ForMember(dest => dest.PersonDateOfBirth, opt => opt.MapFrom(src => src.Person.DateOfBirth))
                 .ForMember(dest => dest.PhotoTakenDate, opt => opt.MapFrom(src => src.Photo.TakenDate))
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
+            CreateMap<AccessProfileStorageAllow, AccessProfileStorageAllowDto>()
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
+            CreateMap<AccessProfileStorageAllowDto, AccessProfileStorageAllow>()
+                .ForMember(dest => dest.Profile, opt => opt.Ignore())
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
+            CreateMap<AccessProfilePersonGroupAllow, AccessProfilePersonGroupAllowDto>()
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
+            CreateMap<AccessProfilePersonGroupAllowDto, AccessProfilePersonGroupAllow>()
+                .ForMember(dest => dest.Profile, opt => opt.Ignore())
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
+            CreateMap<AccessProfileDateRangeAllow, AccessProfileDateRangeAllowDto>()
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
+            CreateMap<AccessProfileDateRangeAllowDto, AccessProfileDateRangeAllow>()
+                .ForMember(dest => dest.Profile, opt => opt.Ignore())
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
+            CreateMap<AccessProfile, AccessProfileDto>()
+                .ForMember(dest => dest.Storages, opt => opt.MapFrom(src => src.Storages))
+                .ForMember(dest => dest.PersonGroups, opt => opt.MapFrom(src => src.PersonGroups))
+                .ForMember(dest => dest.DateRanges, opt => opt.MapFrom(src => src.DateRanges))
+                .IgnoreAllPropertiesWithAnInaccessibleSetter();
+
+            CreateMap<AccessProfileDto, AccessProfile>()
+                .ForMember(dest => dest.Storages,
+                    opt => opt.MapFrom(src => src.Storages ?? Array.Empty<AccessProfileStorageAllowDto>()))
+                .ForMember(dest => dest.PersonGroups,
+                    opt => opt.MapFrom(src => src.PersonGroups ?? Array.Empty<AccessProfilePersonGroupAllowDto>()))
+                .ForMember(dest => dest.DateRanges,
+                    opt => opt.MapFrom(src => src.DateRanges ?? Array.Empty<AccessProfileDateRangeAllowDto>()))
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
         }
     }

--- a/backend/PhotoBank.ViewModel.Dto/AccessProfileDateRangeAllowDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/AccessProfileDateRangeAllowDto.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace PhotoBank.ViewModel.Dto
+{
+    public class AccessProfileDateRangeAllowDto
+    {
+        [Required]
+        public int ProfileId { get; set; }
+
+        [Required]
+        public DateOnly FromDate { get; set; }
+
+        [Required]
+        public DateOnly ToDate { get; set; }
+    }
+}

--- a/backend/PhotoBank.ViewModel.Dto/AccessProfileDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/AccessProfileDto.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace PhotoBank.ViewModel.Dto
+{
+    public class AccessProfileDto : IHasId<int>
+    {
+        [Required]
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(128)]
+        public string Name { get; set; } = default!;
+
+        [MaxLength(512)]
+        public string? Description { get; set; }
+
+        public bool Flags_CanSeeNsfw { get; set; }
+
+        public ICollection<AccessProfileStorageAllowDto> Storages { get; set; } = new List<AccessProfileStorageAllowDto>();
+
+        public ICollection<AccessProfilePersonGroupAllowDto> PersonGroups { get; set; } = new List<AccessProfilePersonGroupAllowDto>();
+
+        public ICollection<AccessProfileDateRangeAllowDto> DateRanges { get; set; } = new List<AccessProfileDateRangeAllowDto>();
+    }
+}

--- a/backend/PhotoBank.ViewModel.Dto/AccessProfilePersonGroupAllowDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/AccessProfilePersonGroupAllowDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PhotoBank.ViewModel.Dto
+{
+    public class AccessProfilePersonGroupAllowDto
+    {
+        [Required]
+        public int ProfileId { get; set; }
+
+        [Required]
+        public int PersonGroupId { get; set; }
+    }
+}

--- a/backend/PhotoBank.ViewModel.Dto/AccessProfileStorageAllowDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/AccessProfileStorageAllowDto.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PhotoBank.ViewModel.Dto
+{
+    public class AccessProfileStorageAllowDto
+    {
+        [Required]
+        public int ProfileId { get; set; }
+
+        [Required]
+        public int StorageId { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated access profile DTO types for storages, person groups, and date ranges
- extend the AutoMapper profile with conversions between access profile entities and the new DTOs
- refactor the admin access profile controller to use the DTOs and mapper for reads and writes while syncing nested collections

## Testing
- dotnet build backend/PhotoBank.Backend.sln *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd10f3e4b08328bdb60ff07c7b1f0f