### PR TITLE
refactor: align admin access profile UI with DTO types

### DIFF
--- a/frontend/packages/frontend/src/components/admin/AccessProfilesGrid.tsx
+++ b/frontend/packages/frontend/src/components/admin/AccessProfilesGrid.tsx
@@ -8,10 +8,10 @@ import {
   MoreHorizontal,
 } from 'lucide-react';
 import type {
-  AccessProfile,
-  AccessProfileDateRangeAllow,
-  AccessProfilePersonGroupAllow,
-  AccessProfileStorageAllow,
+  AccessProfileDto,
+  AccessProfileDateRangeAllowDto,
+  AccessProfilePersonGroupAllowDto,
+  AccessProfileStorageAllowDto,
 } from '@photobank/shared';
 import { format } from 'date-fns';
 
@@ -27,18 +27,18 @@ import {
 import { useToast } from '@/hooks/use-toast';
 
 interface AccessProfilesGridProps {
-  profiles: AccessProfile[];
-  onEditProfile: (profile: AccessProfile) => void;
+  profiles: AccessProfileDto[];
+  onEditProfile: (profile: AccessProfileDto) => void;
 }
 
 export function AccessProfilesGrid({ profiles, onEditProfile }: AccessProfilesGridProps) {
   const { toast } = useToast();
 
-  const handleEdit = (profile: AccessProfile) => {
+  const handleEdit = (profile: AccessProfileDto) => {
     onEditProfile(profile);
   };
 
-  const handleDelete = (profile: AccessProfile) => {
+  const handleDelete = (profile: AccessProfileDto) => {
     toast({
       title: 'Profile Deleted',
       description: `${profile.name} has been removed`,
@@ -58,7 +58,7 @@ export function AccessProfilesGrid({ profiles, onEditProfile }: AccessProfilesGr
     );
   }
 
-  const getStorageLabel = (storage: AccessProfileStorageAllow, index: number) => {
+  const getStorageLabel = (storage: AccessProfileStorageAllowDto, index: number) => {
     if (storage.profileId !== undefined) {
       return `#${storage.storageId ?? storage.profileId}`;
     }
@@ -70,7 +70,7 @@ export function AccessProfilesGrid({ profiles, onEditProfile }: AccessProfilesGr
     return `Storage ${index + 1}`;
   };
 
-  const getPersonGroupLabel = (group: AccessProfilePersonGroupAllow, index: number) => {
+  const getPersonGroupLabel = (group: AccessProfilePersonGroupAllowDto, index: number) => {
     if (group.personGroupId !== undefined) {
       return `Group #${group.personGroupId}`;
     }
@@ -82,7 +82,7 @@ export function AccessProfilesGrid({ profiles, onEditProfile }: AccessProfilesGr
     return `Group ${index + 1}`;
   };
 
-  const getDateRangeLabel = (range: AccessProfileDateRangeAllow | undefined) => {
+  const getDateRangeLabel = (range: AccessProfileDateRangeAllowDto | undefined) => {
     if (!range) {
       return 'No range';
     }

--- a/frontend/packages/frontend/src/components/admin/EditProfileDialog.tsx
+++ b/frontend/packages/frontend/src/components/admin/EditProfileDialog.tsx
@@ -4,7 +4,12 @@ import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 import { format } from 'date-fns';
 import { Save, X, Plus, Trash2 } from 'lucide-react';
-import type { AccessProfile } from '@photobank/shared';
+import type {
+  AccessProfileDateRangeAllowDto,
+  AccessProfileDto,
+  AccessProfilePersonGroupAllowDto,
+  AccessProfileStorageAllowDto,
+} from '@photobank/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   getAdminAccessProfilesListQueryKey,
@@ -52,7 +57,7 @@ const formSchema = z.object({
 interface EditProfileDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  profile: AccessProfile | null;
+  profile: AccessProfileDto | null;
 }
 
 export function EditProfileDialog({ open, onOpenChange, profile }: EditProfileDialogProps) {
@@ -149,7 +154,7 @@ export function EditProfileDialog({ open, onOpenChange, profile }: EditProfileDi
       return;
     }
 
-    const payload: AccessProfile = {
+    const payload = {
       id: profile.id,
       name: values.name,
       description: values.description,
@@ -164,9 +169,13 @@ export function EditProfileDialog({ open, onOpenChange, profile }: EditProfileDi
       })),
       dateRanges: values.dateRanges.map((range) => ({
         profileId: profile.id,
-        fromDate: range.fromDate ? new Date(range.fromDate) : undefined,
-        toDate: range.toDate ? new Date(range.toDate) : undefined,
+        fromDate: new Date(range.fromDate),
+        toDate: new Date(range.toDate),
       })),
+    } satisfies AccessProfileDto & {
+      storages: AccessProfileStorageAllowDto[];
+      personGroups: AccessProfilePersonGroupAllowDto[];
+      dateRanges: AccessProfileDateRangeAllowDto[];
     };
 
     try {

--- a/frontend/packages/frontend/src/components/admin/UserDetailsDrawer.tsx
+++ b/frontend/packages/frontend/src/components/admin/UserDetailsDrawer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { User as UserIcon, Key, UserX, Loader2 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
-import type { AccessProfile, UserDto } from '@photobank/shared';
+import type { AccessProfileDto, UserDto } from '@photobank/shared';
 import {
   getAdminAccessProfilesListQueryKey,
   useAdminAccessProfilesAssignUser,
@@ -48,7 +48,7 @@ export function UserDetailsDrawer({ user, open, onOpenChange }: UserDetailsDrawe
     refetch: refetchAccessProfiles,
   } = useAdminAccessProfilesList();
 
-  const accessProfiles = useMemo<AccessProfile[]>(
+  const accessProfiles = useMemo<AccessProfileDto[]>(
     () => accessProfilesData?.data ?? [],
     [accessProfilesData]
   );
@@ -86,7 +86,7 @@ export function UserDetailsDrawer({ user, open, onOpenChange }: UserDetailsDrawe
   const showAccessProfilesLoading = isAccessProfilesLoading && accessProfiles.length === 0;
   const showAccessProfilesError = isAccessProfilesError && accessProfiles.length === 0;
 
-  const handleAssignProfile = async (profile: AccessProfile) => {
+  const handleAssignProfile = async (profile: AccessProfileDto) => {
     const profileId = profile.id;
 
     if (typeof profileId !== 'number') {
@@ -135,7 +135,7 @@ export function UserDetailsDrawer({ user, open, onOpenChange }: UserDetailsDrawe
     }
   };
 
-  const handleUnassignProfile = async (profile: AccessProfile) => {
+  const handleUnassignProfile = async (profile: AccessProfileDto) => {
     const profileId = profile.id;
 
     if (typeof profileId !== 'number') {

--- a/frontend/packages/frontend/src/pages/admin/AccessProfilesPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/AccessProfilesPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Plus, Search } from 'lucide-react';
-import type { AccessProfile } from '@photobank/shared';
+import type { AccessProfileDto } from '@photobank/shared';
 import { useAdminAccessProfilesList } from '@photobank/shared/api/photobank/admin-access-profiles/admin-access-profiles';
 
 import { Button } from '@/shared/ui/button';
@@ -16,7 +16,7 @@ export default function AccessProfilesPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-  const [selectedProfile, setSelectedProfile] = useState<AccessProfile | null>(null);
+  const [selectedProfile, setSelectedProfile] = useState<AccessProfileDto | null>(null);
 
   const {
     data,
@@ -26,7 +26,7 @@ export default function AccessProfilesPage() {
     refetch,
   } = useAdminAccessProfilesList();
 
-  const profiles = useMemo<AccessProfile[]>(() => data?.data ?? [], [data]);
+  const profiles = useMemo<AccessProfileDto[]>(() => data?.data ?? [], [data]);
 
   const filteredProfiles = useMemo(() => {
     const normalizedQuery = searchQuery.trim().toLowerCase();
@@ -47,7 +47,7 @@ export default function AccessProfilesPage() {
   const showError = isError && profiles.length === 0;
   const isRefreshing = isFetching && profiles.length > 0;
 
-  const handleEditProfile = (profile: AccessProfile) => {
+  const handleEditProfile = (profile: AccessProfileDto) => {
     if (!profile.id) {
       toast({
         title: 'Unable to edit profile',


### PR DESCRIPTION
## Summary
- update admin access profile views to consume AccessProfileDto-based types from the shared API client
- adjust create and edit dialogs to build DTO-shaped payloads for API mutations

## Testing
- pnpm --filter frontend test -- --runInBand *(fails: known vitest environment gaps such as missing IntersectionObserver and i18next setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1cf6c6748328b55359b1776271bf