### PR TITLE
refactor: share access profile form schema

### DIFF
--- a/frontend/packages/frontend/src/components/admin/accessProfileFormSchema.ts
+++ b/frontend/packages/frontend/src/components/admin/accessProfileFormSchema.ts
@@ -1,0 +1,25 @@
+import * as z from 'zod';
+
+export const accessProfileFormSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Profile name is required')
+    .max(128, 'Name must be 128 characters or less'),
+  description: z
+    .string()
+    .max(512, 'Description must be 512 characters or less')
+    .optional(),
+  flags_CanSeeNsfw: z.boolean(),
+  storages: z.array(z.number()).optional(),
+  personGroups: z.array(z.number()).optional(),
+  dateRanges: z
+    .array(
+      z.object({
+        fromDate: z.string().optional(),
+        toDate: z.string().optional(),
+      })
+    )
+    .optional(),
+});
+
+export type AccessProfileFormValues = z.infer<typeof accessProfileFormSchema>;


### PR DESCRIPTION
## Summary
- extract the access profile form schema into a shared module for admin dialogs
- update create and edit dialogs to consume the shared schema and normalize optional fields
- align the edit dialog submission flow with the create dialog by filtering undefined date ranges and optional associations

## Testing
- pnpm --filter @photobank/frontend build

------
https://chatgpt.com/codex/tasks/task_e_68dd31b819708328a9d41be74ea0b777