### PR TITLE
fix: restore default person group query key

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/EditPersonGroupPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/EditPersonGroupPage.tsx
@@ -36,7 +36,6 @@ export default function EditPersonGroupPage() {
     query: {
       enabled: isValidGroupId,
       select: (response) => response.data.find((g) => g.id === groupId),
-      queryKey: [],
     },
   });
   const {


### PR DESCRIPTION
## Summary
- allow the generated person group query key to be used by removing the manual override in the edit page
- keep cache invalidation targeting the shared query key so add/remove mutations refresh correctly

## Testing
- not run (manual verification required with running app/backend)


------
https://chatgpt.com/codex/tasks/task_e_68dd360611b48328b5895b335c958fef