### PR TITLE
fix: use query hook key for person group updates

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/EditPersonGroupPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/EditPersonGroupPage.tsx
@@ -4,7 +4,6 @@ import { ArrowLeft, Search, UserPlus, UserMinus, Users } from 'lucide-react';
 import type { PersonDto, PersonGroupDto } from '@photobank/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import {
-  getPersonGroupsGetAllQueryKey,
   usePersonGroupsAddPerson,
   usePersonGroupsGetAll,
   usePersonGroupsRemovePerson,
@@ -25,18 +24,17 @@ export default function EditPersonGroupPage() {
   const queryClient = useQueryClient();
   const groupId = id ? Number(id) : NaN;
   const isValidGroupId = Number.isFinite(groupId);
-  const personGroupsQueryKey = useMemo(() => getPersonGroupsGetAllQueryKey(), []);
   const {
     data: group,
     isLoading: isGroupLoading,
     isError: isGroupError,
     isFetching: isGroupFetching,
     refetch: refetchGroups,
+    queryKey: personGroupsQueryKey,
   } = usePersonGroupsGetAll<PersonGroupDto | undefined>({
     query: {
       enabled: isValidGroupId,
       select: (response) => response.data.find((g) => g.id === groupId),
-      queryKey: [],
     },
   });
   const {


### PR DESCRIPTION
## Summary
- use the query key returned by usePersonGroupsGetAll so cache invalidation matches the hook's generated key
- keep invalidation on add/remove mutations to refresh group membership lists

## Testing
- not run (manual verification required with running app/backend)


------
https://chatgpt.com/codex/tasks/task_e_68dd360611b48328b5895b335c958fef