### PR TITLE
fix: refresh person group lists after membership changes

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/EditPersonGroupPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/EditPersonGroupPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Search, UserPlus, UserMinus, Users } from 'lucide-react';
 import type { PersonDto, PersonGroupDto } from '@photobank/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import {
+  getPersonGroupsGetAllQueryKey,
   usePersonGroupsAddPerson,
   usePersonGroupsGetAll,
   usePersonGroupsRemovePerson,
@@ -30,7 +31,6 @@ export default function EditPersonGroupPage() {
     isError: isGroupError,
     isFetching: isGroupFetching,
     refetch: refetchGroups,
-    queryKey: personGroupsQueryKey,
   } = usePersonGroupsGetAll<PersonGroupDto | undefined>({
     query: {
       enabled: isValidGroupId,
@@ -77,7 +77,7 @@ export default function EditPersonGroupPage() {
   const addPersonMutation = usePersonGroupsAddPerson({
     mutation: {
       onSuccess: async (_, variables) => {
-        await queryClient.invalidateQueries({ queryKey: personGroupsQueryKey });
+        await queryClient.invalidateQueries({ queryKey: getPersonGroupsGetAllQueryKey() });
 
         const personName = persons.find((person) => person.id === variables.personId)?.name;
 
@@ -101,7 +101,7 @@ export default function EditPersonGroupPage() {
   const removePersonMutation = usePersonGroupsRemovePerson({
     mutation: {
       onSuccess: async (_, variables) => {
-        await queryClient.invalidateQueries({ queryKey: personGroupsQueryKey });
+        await queryClient.invalidateQueries({ queryKey: getPersonGroupsGetAllQueryKey() });
 
         const personName = persons.find((person) => person.id === variables.personId)?.name;
 


### PR DESCRIPTION
## Summary
- use the shared person groups query key when mutating group membership
- stop relying on the hook's exposed query key and invalidate via helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4910cae88328af58d37771591f88