### PR TITLE
fix: invalidate person group cache on membership change

### DIFF
--- a/backend/PhotoBank.Services/Api/PhotoService.cs
+++ b/backend/PhotoBank.Services/Api/PhotoService.cs
@@ -354,6 +354,7 @@ public class PhotoService : IPhotoService
         {
             person.PersonGroups.Add(group);
             await _db.SaveChangesAsync();
+            _cache.Remove(CacheKeys.PersonGroups);
         }
     }
 
@@ -366,6 +367,7 @@ public class PhotoService : IPhotoService
         {
             person.PersonGroups.Remove(group);
             await _db.SaveChangesAsync();
+            _cache.Remove(CacheKeys.PersonGroups);
         }
     }
 

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -99,5 +99,32 @@ public class PersonGroupServiceTests
         var groups = await _service.GetAllPersonGroupsAsync();
         groups.Should().ContainSingle(g => g.Name == "Family");
     }
+
+    [Test]
+    public async Task AddPersonToGroupAsync_InvalidatesPersonGroupsCache()
+    {
+        var cache = _provider.GetRequiredService<IMemoryCache>();
+
+        await _service.GetAllPersonGroupsAsync();
+        cache.TryGetValue(CacheKeys.PersonGroups, out _).Should().BeTrue();
+
+        await _service.AddPersonToGroupAsync(1, 1);
+
+        cache.TryGetValue(CacheKeys.PersonGroups, out _).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task RemovePersonFromGroupAsync_InvalidatesPersonGroupsCache()
+    {
+        var cache = _provider.GetRequiredService<IMemoryCache>();
+
+        await _service.AddPersonToGroupAsync(1, 1);
+        await _service.GetAllPersonGroupsAsync();
+        cache.TryGetValue(CacheKeys.PersonGroups, out _).Should().BeTrue();
+
+        await _service.RemovePersonFromGroupAsync(1, 1);
+
+        cache.TryGetValue(CacheKeys.PersonGroups, out _).Should().BeFalse();
+    }
 }
 


### PR DESCRIPTION
## Summary
- invalidate the person group cache after adding or removing people from a group so cached data stays current
- extend person group service unit tests to cover cache invalidation on membership changes

## Testing
- dotnet test backend/PhotoBank.UnitTests --nologo

------
https://chatgpt.com/codex/tasks/task_e_68dd52a56f148328aaf1b349ec874cd1