### PR TITLE
fix: add query key to person group query

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/EditPersonGroupPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/EditPersonGroupPage.tsx
@@ -35,6 +35,7 @@ export default function EditPersonGroupPage() {
     refetch: refetchGroups,
   } = usePersonGroupsGetAll<PersonGroupDto | undefined>({
     query: {
+      queryKey: getPersonGroupsGetAllQueryKey(),
       enabled: isValidGroupId,
       select: (response) => response.data.find((g) => g.id === groupId),
     },


### PR DESCRIPTION
## Summary
- add the generated query key to the person group lookup query so it satisfies the orval hook options

## Testing
- pnpm --filter @photobank/frontend build

------
https://chatgpt.com/codex/tasks/task_e_68dd5e919dc083289da71c245a28b127