### PR TITLE
feat: expose assigned user counts for access profiles

### DIFF
--- a/backend/PhotoBank.DbContext/AccessControl/AccessControlDbContext.cs
+++ b/backend/PhotoBank.DbContext/AccessControl/AccessControlDbContext.cs
@@ -39,6 +39,8 @@ public class AccessControlDbContext : Microsoft.EntityFrameworkCore.DbContext
             .HasOne(x => x.Profile).WithMany(p => p.PersonGroups).HasForeignKey(x => x.ProfileId);
         b.Entity<AccessProfileDateRangeAllow>()
             .HasOne(x => x.Profile).WithMany(p => p.DateRanges).HasForeignKey(x => x.ProfileId);
+        b.Entity<UserAccessProfile>()
+            .HasOne(x => x.Profile).WithMany(p => p.UserAssignments).HasForeignKey(x => x.ProfileId);
 
         // DateOnly -> date
         var dConv = new ValueConverter<DateOnly, DateTime>(

--- a/backend/PhotoBank.DbContext/AccessControl/AccessProfileEntities.cs
+++ b/backend/PhotoBank.DbContext/AccessControl/AccessProfileEntities.cs
@@ -19,6 +19,7 @@ public class AccessProfile
     public ICollection<AccessProfileStorageAllow> Storages { get; set; } = [];
     public ICollection<AccessProfilePersonGroupAllow> PersonGroups { get; set; } = [];
     public ICollection<AccessProfileDateRangeAllow> DateRanges { get; set; } = [];
+    public ICollection<UserAccessProfile> UserAssignments { get; set; } = [];
 }
 
 public class AccessProfileStorageAllow
@@ -53,4 +54,5 @@ public class UserAccessProfile
 {
     public string UserId { get; set; } = default!;
     public int ProfileId { get; set; }
+    public AccessProfile Profile { get; set; } = default!;
 }

--- a/backend/PhotoBank.Services/MappingProfile.cs
+++ b/backend/PhotoBank.Services/MappingProfile.cs
@@ -112,6 +112,7 @@ namespace PhotoBank.Services
                 .ForMember(dest => dest.Storages, opt => opt.MapFrom(src => src.Storages))
                 .ForMember(dest => dest.PersonGroups, opt => opt.MapFrom(src => src.PersonGroups))
                 .ForMember(dest => dest.DateRanges, opt => opt.MapFrom(src => src.DateRanges))
+                .ForMember(dest => dest.AssignedUsersCount, opt => opt.MapFrom(src => src.UserAssignments.Count))
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
             CreateMap<AccessProfileDto, AccessProfile>()

--- a/backend/PhotoBank.ViewModel.Dto/AccessProfileDto.cs
+++ b/backend/PhotoBank.ViewModel.Dto/AccessProfileDto.cs
@@ -17,6 +17,9 @@ namespace PhotoBank.ViewModel.Dto
 
         public bool Flags_CanSeeNsfw { get; set; }
 
+        [Range(0, int.MaxValue)]
+        public int AssignedUsersCount { get; set; }
+
         public ICollection<AccessProfileStorageAllowDto> Storages { get; set; } = new List<AccessProfileStorageAllowDto>();
 
         public ICollection<AccessProfilePersonGroupAllowDto> PersonGroups { get; set; } = new List<AccessProfilePersonGroupAllowDto>();

--- a/frontend/packages/frontend/src/components/admin/AccessProfilesGrid.test.tsx
+++ b/frontend/packages/frontend/src/components/admin/AccessProfilesGrid.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { AccessProfileDto } from '@photobank/shared';
+
+import { AccessProfilesGrid } from './AccessProfilesGrid';
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+describe('AccessProfilesGrid', () => {
+  it('renders assigned user count for each profile', () => {
+    const profiles: AccessProfileDto[] = [
+      {
+        id: 1,
+        name: 'Moderators',
+        description: 'Moderation team',
+        flags_CanSeeNsfw: false,
+        storages: [],
+        personGroups: [],
+        dateRanges: [],
+        assignedUsersCount: 3,
+      },
+    ];
+
+    render(<AccessProfilesGrid profiles={profiles} onEditProfile={vi.fn()} />);
+
+    expect(screen.getByText('3 users')).toBeInTheDocument();
+  });
+});

--- a/frontend/packages/frontend/src/components/admin/AccessProfilesGrid.tsx
+++ b/frontend/packages/frontend/src/components/admin/AccessProfilesGrid.tsx
@@ -199,10 +199,7 @@ export function AccessProfilesGrid({ profiles, onEditProfile }: AccessProfilesGr
                 <span className="text-muted-foreground">Assigned to:</span>
                 <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                   <span className="font-medium">
-                    {typeof (profile as { assignedUsersCount?: number }).assignedUsersCount === 'number'
-                      ? (profile as { assignedUsersCount?: number }).assignedUsersCount
-                      : 0}{' '}
-                    users
+                    {(profile.assignedUsersCount ?? 0).toLocaleString()} users
                   </span>
                   <div className="flex flex-wrap gap-1">
                     {((profile as { assignedRoles?: string[] }).assignedRoles ?? []).map(

--- a/frontend/packages/shared/src/api/photobank/photoBankApi.schemas.ts
+++ b/frontend/packages/shared/src/api/photobank/photoBankApi.schemas.ts
@@ -23,6 +23,8 @@ export interface AccessProfileDto {
    */
   description?: string | null;
   flags_CanSeeNsfw?: boolean;
+  /** @minimum 0 */
+  assignedUsersCount: number;
   /** @nullable */
   storages?: AccessProfileStorageAllowDto[] | null;
   /** @nullable */

--- a/frontend/packages/telegram-bot/src/api/photobank/photoBankApi.schemas.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/photoBankApi.schemas.ts
@@ -23,6 +23,8 @@ export interface AccessProfileDto {
    */
   description?: string | null;
   flags_CanSeeNsfw?: boolean;
+  /** @minimum 0 */
+  assignedUsersCount: number;
   /** @nullable */
   storages?: AccessProfileStorageAllowDto[] | null;
   /** @nullable */

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1252,6 +1252,7 @@ components:
       required:
         - id
         - name
+        - assignedUsersCount
       type: object
       properties:
         id:
@@ -1267,6 +1268,10 @@ components:
           nullable: true
         flags_CanSeeNsfw:
           type: boolean
+        assignedUsersCount:
+          type: integer
+          format: int32
+          minimum: 0
         storages:
           type: array
           items:


### PR DESCRIPTION
## Summary
- add assignedUsersCount to access profile DTOs and map the value from EF user assignment links
- update the OpenAPI contract and regenerate shared API clients to surface the new count
- use the strongly typed assignedUsersCount in the admin access profiles grid and cover it with a Vitest check

## Testing
- pnpm --filter @photobank/frontend test -- --run AccessProfilesGrid *(fails: existing suite requires additional setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6b1742e48328bdc995ecb035d9b4