### PR TITLE
fix: normalize face identity statuses

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/FacesPage.test.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.test.tsx
@@ -86,6 +86,41 @@ describe('FacesPage', () => {
     expect(screen.getByText('#123')).toBeInTheDocument();
   });
 
+  test('normalises numeric identity statuses before rendering', async () => {
+    const face = {
+      id: 7,
+      faceId: 7,
+      identityStatus: 3,
+    };
+
+    mockUseFacesGet.mockReturnValue({
+      data: { data: [face] },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+
+    mockUsePersonsGetAll.mockReturnValue({
+      data: { data: [] },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    mockUseFacesUpdate.mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+
+    const { Wrapper } = createWrapper();
+
+    render(<FacesPage />, { wrapper: Wrapper });
+
+    expect(await screen.findByText('Identified')).toBeInTheDocument();
+    expect(screen.getByText('#7')).toBeInTheDocument();
+  });
+
   test('allows editing and unassigning a face without a person', async () => {
     const mutateAsync = vi.fn().mockResolvedValue({});
     const face = {


### PR DESCRIPTION
## Summary
- normalize face identity status values returned by the API before filtering and rendering
- update the Faces admin page to rely on the normalized status labels and colors
- cover numeric identity statuses in the FacesPage tests

## Testing
- pnpm test FacesPage

------
https://chatgpt.com/codex/tasks/task_e_68dd8b6e18d48328a41655cd38abdd94