### PR TITLE
fix: align face identity statuses with backend

### DIFF
--- a/frontend/packages/frontend/src/components/admin/EditFaceDialog.tsx
+++ b/frontend/packages/frontend/src/components/admin/EditFaceDialog.tsx
@@ -5,6 +5,8 @@ import type { FaceIdentityDto, PersonDto } from '@photobank/shared/api/photobank
 import {
   getFacesGetQueryKey,
   type FacesUpdateMutationBody,
+  IdentityStatus,
+  type IdentityStatus as IdentityStatusType,
   useFacesUpdate,
   usePersonsGetAll,
 } from '@photobank/shared/api/photobank';
@@ -82,23 +84,18 @@ export function EditFaceDialog({ open, onOpenChange, face }: EditFaceDialogProps
   });
 
   const identityStatusOptions = useMemo(() => {
-    const baseStatuses = [
-      'Undefined',
-      'Pending',
-      'Verified',
-      'Rejected',
-      'Identified',
-      'NotIdentified',
-      'NotDetected',
-      'ForReprocessing',
-      'StopProcessing',
+    const baseStatuses: Array<IdentityStatusType | string> = [
+      ...Object.values(IdentityStatus),
     ];
 
-    if (face?.identityStatus && !baseStatuses.includes(face.identityStatus)) {
+    if (
+      face?.identityStatus &&
+      !baseStatuses.includes(face.identityStatus as IdentityStatusType)
+    ) {
       baseStatuses.push(face.identityStatus);
     }
 
-    return Array.from(new Set(baseStatuses));
+    return baseStatuses;
   }, [face?.identityStatus]);
 
   if (!face) return null;

--- a/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
@@ -183,19 +183,17 @@ export default function FacesPage() {
     }
   };
 
-  const getStatusColor = (status?: string | null) => {
+  const getStatusColor = (status?: IdentityStatusType | null) => {
     switch (status) {
-      case 'Verified':
-      case 'Identified':
+      case IdentityStatusEnum.Identified:
         return 'bg-success text-success-foreground';
-      case 'Pending':
-      case 'NotDetected':
-      case 'NotIdentified':
-      case 'ForReprocessing':
+      case IdentityStatusEnum.ForReprocessing:
+      case IdentityStatusEnum.NotDetected:
+      case IdentityStatusEnum.NotIdentified:
         return 'bg-warning text-warning-foreground';
-      case 'Rejected':
-      case 'StopProcessing':
+      case IdentityStatusEnum.StopProcessing:
         return 'bg-destructive text-destructive-foreground';
+      case IdentityStatusEnum.Undefined:
       default:
         return 'bg-muted text-muted-foreground';
     }
@@ -312,7 +310,9 @@ export default function FacesPage() {
                         face.personName ??
                         (face.person ? face.person.name ?? null : null) ??
                         (personId != null ? `Person #${personId}` : null);
-                      const status = statusLabel(face.normalizedIdentityStatus);
+                      const rawStatus = face.identityStatus ?? face.normalizedIdentityStatus;
+                      const canonicalStatus = normalizeIdentityStatus(rawStatus);
+                      const status = statusLabel(rawStatus);
                       const faceIdentifier = face.id ?? face.faceId;
 
                       return (
@@ -337,7 +337,7 @@ export default function FacesPage() {
                             )}
                           </TableCell>
                           <TableCell>
-                            <Badge className={getStatusColor(status)}>{status}</Badge>
+                            <Badge className={getStatusColor(canonicalStatus)}>{status}</Badge>
                           </TableCell>
                           <TableCell>
                             {createdAt ? (


### PR DESCRIPTION
## Summary
- use the backend `IdentityStatus` enum for the admin face edit dialog options
- update admin face badge styling to derive from canonical identity statuses
- cover the supported statuses with new dropdown and badge colour tests

## Testing
- pnpm --filter @photobank/frontend test --run FacesPage

------
https://chatgpt.com/codex/tasks/task_e_68dd8d8ffea883289fb26b383902afca