### PR TITLE
fix: normalize identity status labels

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/FacesPage.test.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.test.tsx
@@ -288,7 +288,13 @@ describe('FacesPage', () => {
 
     for (const status of statuses) {
       const badge = await screen.findByText(status);
-      expect(badge).toHaveClass(expectedClasses[status]);
+      const expectedClass = expectedClasses[status];
+
+      if (!expectedClass) {
+        throw new Error(`Missing expected class for status: ${status}`);
+      }
+
+      expect(badge).toHaveClass(expectedClass);
     }
   });
 });

--- a/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
@@ -99,10 +99,12 @@ export default function FacesPage() {
         extendedFace.personName ?? (extendedFace.person ? extendedFace.person.name ?? null : null);
       const normalizedFaceId = extendedFace.faceId ?? extendedFace.id ?? null;
       const normalizedIdentityStatus = normalizeIdentityStatus(extendedFace.identityStatus);
+      const identityStatusString =
+        typeof extendedFace.identityStatus === 'string'
+          ? extendedFace.identityStatus.trim() || undefined
+          : undefined;
       const normalizedIdentityStatusLabel =
-        normalizedIdentityStatus ??
-        (typeof extendedFace.identityStatus === 'string' && extendedFace.identityStatus.trim()) ??
-        'Unknown';
+        normalizedIdentityStatus ?? identityStatusString ?? 'Unknown';
 
       return {
         ...extendedFace,
@@ -112,9 +114,7 @@ export default function FacesPage() {
         personName: normalizedPersonName,
         identityStatus:
           normalizedIdentityStatus ??
-          (typeof extendedFace.identityStatus === 'string'
-            ? (extendedFace.identityStatus.trim() as FaceListItem['identityStatus'])
-            : undefined),
+          (identityStatusString as FaceListItem['identityStatus'] | undefined),
         normalizedIdentityStatus: normalizedIdentityStatusLabel,
       };
     });


### PR DESCRIPTION
## Summary
- derive a trimmed identity status string fallback so labels always render as strings
- reuse the derived status string when populating the face identity status field
- harden the FacesPage status badge test to assert the expected class lookup exists

## Testing
- pnpm --filter @photobank/frontend... build

------
https://chatgpt.com/codex/tasks/task_e_68de10d7196c8328addf2253b3f3e24f