### PR TITLE
test: type identity status badge mapping

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/FacesPage.test.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.test.tsx
@@ -277,7 +277,7 @@ describe('FacesPage', () => {
 
     render(<FacesPage />, { wrapper: Wrapper });
 
-    const expectedClasses: Record<string, string> = {
+    const expectedClasses: Record<IdentityStatus, string> = {
       [IdentityStatus.Identified]: 'bg-success text-success-foreground',
       [IdentityStatus.ForReprocessing]: 'bg-warning text-warning-foreground',
       [IdentityStatus.NotDetected]: 'bg-warning text-warning-foreground',


### PR DESCRIPTION
## Summary
- type the FacesPage badge expectations as a Record keyed by IdentityStatus

## Testing
- pnpm --filter @photobank/frontend... build
- pnpm --filter @photobank/frontend test --run src/pages/admin/FacesPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de16389a2483289f9e81201a7d0570