### PR TITLE
Refactor face provider sync to use flattened face metadata

### DIFF
--- a/backend/PhotoBank.UnitTests/FaceServiceErrorHandlingTests.cs
+++ b/backend/PhotoBank.UnitTests/FaceServiceErrorHandlingTests.cs
@@ -20,7 +20,6 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using DbFace = PhotoBank.DbContext.Models.Face;
 using DbPerson = PhotoBank.DbContext.Models.Person;
-using DbPersonFace = PhotoBank.DbContext.Models.PersonFace;
 using DbPhoto = PhotoBank.DbContext.Models.Photo;
 
 namespace PhotoBank.UnitTests;
@@ -30,7 +29,6 @@ public class FaceServiceErrorHandlingTests
 {
     private Mock<IRepository<DbFace>> _faceRepository = null!;
     private Mock<IRepository<DbPerson>> _personRepository = null!;
-    private Mock<IRepository<DbPersonFace>> _personFaceRepository = null!;
     private Mock<IRepository<DbPhoto>> _photoRepository = null!;
     private Mock<IMinioClient> _minioClient = null!;
     private Mock<IFaceClient> _faceClient = null!;
@@ -44,7 +42,6 @@ public class FaceServiceErrorHandlingTests
     {
         _faceRepository = new Mock<IRepository<DbFace>>();
         _personRepository = new Mock<IRepository<DbPerson>>();
-        _personFaceRepository = new Mock<IRepository<DbPersonFace>>();
         _photoRepository = new Mock<IRepository<DbPhoto>>();
         _minioClient = new Mock<IMinioClient>();
         _faceOperations = new Mock<IFaceOperations>();
@@ -57,7 +54,6 @@ public class FaceServiceErrorHandlingTests
             _faceClient.Object,
             _faceRepository.Object,
             _personRepository.Object,
-            _personFaceRepository.Object,
             _photoRepository.Object,
             _minioClient.Object,
             _mapper.Object,

--- a/backend/PhotoBank.UnitTests/FaceServiceIdentifyTests.cs
+++ b/backend/PhotoBank.UnitTests/FaceServiceIdentifyTests.cs
@@ -21,7 +21,6 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using DbFace = PhotoBank.DbContext.Models.Face;
 using DbPerson = PhotoBank.DbContext.Models.Person;
-using DbPersonFace = PhotoBank.DbContext.Models.PersonFace;
 using DbPhoto = PhotoBank.DbContext.Models.Photo;
 using DbStorage = PhotoBank.DbContext.Models.Storage;
 using IdentityStatus = PhotoBank.DbContext.Models.IdentityStatus;
@@ -36,7 +35,6 @@ public class FaceServiceIdentifyTests
     private ServiceProvider _provider = null!;
     private Repository<DbFace> _faceRepository = null!;
     private Repository<DbPerson> _personRepository = null!;
-    private Mock<IRepository<DbPersonFace>> _personFaceRepository = null!;
     private Mock<IRepository<DbPhoto>> _photoRepository = null!;
     private Mock<IMinioClient> _minioClient = null!;
     private Mock<IFaceOperations> _faceOperations = null!;
@@ -54,7 +52,6 @@ public class FaceServiceIdentifyTests
 
         _faceRepository = new Repository<DbFace>(_provider);
         _personRepository = new Repository<DbPerson>(_provider);
-        _personFaceRepository = new Mock<IRepository<DbPersonFace>>();
         _photoRepository = new Mock<IRepository<DbPhoto>>();
         _minioClient = new Mock<IMinioClient>();
         _faceOperations = new Mock<IFaceOperations>();
@@ -153,7 +150,6 @@ public class FaceServiceIdentifyTests
             _faceClient.Object,
             _faceRepository,
             _personRepository,
-            _personFaceRepository.Object,
             _photoRepository.Object,
             _minioClient.Object,
             _mapper.Object,


### PR DESCRIPTION
## Summary
- switch Azure face sync to query Face rows and persist provider metadata on the face itself
- update AWS face sync and the unified provider bridge to reuse the flattened face columns
- remove PersonFace repository dependencies and refresh the affected unit tests

## Testing
- `dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --logger "console;verbosity=minimal"` *(fails due to Microsoft.Build terminal logger bug in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dea6e03ac08328b09f253e5d57520b