### PR TITLE
test: refresh EditFaceDialog fixtures

### DIFF
--- a/frontend/packages/frontend/src/components/admin/EditFaceDialog.test.tsx
+++ b/frontend/packages/frontend/src/components/admin/EditFaceDialog.test.tsx
@@ -22,7 +22,12 @@ vi.mock('@photobank/shared/api/photobank', async () => {
       isPending: false,
     }),
     usePersonsGetAll: () => ({
-      data: { data: [] },
+      data: {
+        data: [
+          { id: 42, name: 'Jane Doe' },
+          { id: 30, name: 'John Smith' },
+        ],
+      },
       isLoading: false,
       isError: false,
       refetch: vi.fn(),
@@ -56,7 +61,6 @@ describe('EditFaceDialog', () => {
   it('renders the face preview image when an image URL is available', () => {
     const face: FaceDto = {
       id: 12,
-      faceId: 12,
       personId: 42,
       personName: 'Jane Doe',
       imageUrl: 'https://example.com/face.jpg',
@@ -81,7 +85,6 @@ describe('EditFaceDialog', () => {
 
     const face: FaceDto = {
       id: 15,
-      faceId: 15,
       personId: 30,
       personName: 'John Smith',
       identityStatus: 'Identified',


### PR DESCRIPTION
## Summary
- update the EditFaceDialog test fixtures to rely on the canonical id field
- provide mocked person entries so the preview alt text continues to assert on person names

## Testing
- pnpm --filter frontend test -- EditFaceDialog *(fails: existing PhotoDetailsPage, PhotoTable, and photoColumns tests due to missing i18next setup, IntersectionObserver, and undefined date column)*

------
https://chatgpt.com/codex/tasks/task_e_68e020c032d483289e3e15e726b69347