### PR TITLE
fix: pass correct metadata ids to photo badges

### DIFF
--- a/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
@@ -102,7 +102,7 @@ export function usePhotoColumns(): ColumnDef<PhotoItemDto>[] {
         cell: ({ row }) => (
           <MetadataBadgeList
             items={
-              metaLoaded ? (row.original.tags?.map((t) => t.tagId) ?? []) : []
+              metaLoaded ? (row.original.tags ?? []) : []
             }
             map={tagsMap}
             maxVisible={8}
@@ -119,9 +119,7 @@ export function usePhotoColumns(): ColumnDef<PhotoItemDto>[] {
         cell: ({ row }) => (
           <MetadataBadgeList
             items={
-              metaLoaded
-                ? (row.original.persons?.map((p) => p.personId) ?? [])
-                : []
+              metaLoaded ? (row.original.persons ?? []) : []
             }
             map={personsMap}
             maxVisible={6}


### PR DESCRIPTION
## Summary
- ensure the photo list passes tag and person id arrays directly into MetadataBadgeList

## Testing
- pnpm --filter @photobank/frontend build *(fails: existing TS errors in admin faces components)*

------
https://chatgpt.com/codex/tasks/task_e_68e0258efb84832881fa451755997b30