### PR TITLE
fix(frontend): use FaceDto id when updating faces

### DIFF
--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -433,16 +433,16 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                                         persons={persons}
                                                         disabled={!showFaceBoxes || !isAdmin}
                                                       onChange={(personId) => {
-                                                              void updateFace({
-                                                                  data: {
-                                                                      faceId: face.id!,
-                                                                      personId: personId ?? null,
-                                                                      identityStatus:
-                                                                          personId == null
-                                                                              ? IdentityStatus.StopProcessing
-                                                                              : IdentityStatus.Identified,
-                                                                  },
-                                                              });
+                                                          void updateFace({
+                                                              data: {
+                                                                  id: face.id!,
+                                                                  personId: personId ?? null,
+                                                                  identityStatus:
+                                                                      personId == null
+                                                                          ? IdentityStatus.StopProcessing
+                                                                          : IdentityStatus.Identified,
+                                                              },
+                                                          });
                                                           }}
                                                       />
                                                   );


### PR DESCRIPTION
## Summary
- ensure face updates send the schema-compliant `id` field instead of the removed `faceId`

## Testing
- pnpm --filter @photobank/frontend build *(fails: existing TypeScript errors in admin faces components and face box calculations)*

------
https://chatgpt.com/codex/tasks/task_e_68e02722b0308328838430ff83ecc5be