### PR TITLE
fix: widen identity status typing

### DIFF
--- a/frontend/packages/frontend/src/components/admin/EditFaceDialog.tsx
+++ b/frontend/packages/frontend/src/components/admin/EditFaceDialog.tsx
@@ -77,8 +77,8 @@ export function EditFaceDialog({ open, onOpenChange, face }: EditFaceDialogProps
     [personsResponse]
   );
 
-  const identityStatuses = useMemo(() => {
-    const base = [...Object.values(IdentityStatus)];
+  const identityStatuses = useMemo<string[]>(() => {
+    const base: string[] = [...Object.values(IdentityStatus)];
 
     if (face?.identityStatus) {
       const alreadyPresent = base.some(


### PR DESCRIPTION
## Summary
- ensure the identity status memo in the admin face editor is typed as a string array so fallback values can be added safely

## Testing
- pnpm --filter frontend build *(fails: existing TypeScript errors in FacesPage.tsx and PhotoDetailsPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68e028fc05e08328930cdd74766e7527