### PR TITLE
fix: align faces page with updated api hook

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/FacesPage.test.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.test.tsx
@@ -22,8 +22,8 @@ beforeAll(() => {
   }
 });
 
-const { mockUseFacesGet, mockUsePersonsGetAll, mockUseFacesUpdate, mockToast } = vi.hoisted(() => ({
-  mockUseFacesGet: vi.fn(),
+const { mockUseFacesGetAll, mockUsePersonsGetAll, mockUseFacesUpdate, mockToast } = vi.hoisted(() => ({
+  mockUseFacesGetAll: vi.fn(),
   mockUsePersonsGetAll: vi.fn(),
   mockUseFacesUpdate: vi.fn(),
   mockToast: vi.fn(),
@@ -37,7 +37,7 @@ vi.mock('@photobank/shared/api/photobank', async () => {
   return {
     ...actual,
     IdentityStatus: (actual as { IdentityStatus?: unknown; IdentityStatusDto?: unknown }).IdentityStatus ?? (actual as { IdentityStatusDto?: unknown }).IdentityStatusDto,
-    useFacesGet: mockUseFacesGet,
+    useFacesGetAll: mockUseFacesGetAll,
     usePersonsGetAll: mockUsePersonsGetAll,
     useFacesUpdate: mockUseFacesUpdate,
   };
@@ -76,7 +76,7 @@ describe('FacesPage', () => {
       imageUrl: null,
     };
 
-    mockUseFacesGet.mockReturnValue({
+    mockUseFacesGetAll.mockReturnValue({
       data: { data: [face] },
       isLoading: false,
       isError: false,
@@ -111,7 +111,7 @@ describe('FacesPage', () => {
       identityStatus: 3,
     };
 
-    mockUseFacesGet.mockReturnValue({
+    mockUseFacesGetAll.mockReturnValue({
       data: { data: [face] },
       isLoading: false,
       isError: false,
@@ -147,7 +147,7 @@ describe('FacesPage', () => {
       identityStatus: 'NotIdentified',
     };
 
-    mockUseFacesGet.mockReturnValue({
+    mockUseFacesGetAll.mockReturnValue({
       data: { data: [face] },
       isLoading: false,
       isError: false,
@@ -202,7 +202,7 @@ describe('FacesPage', () => {
       identityStatus: IdentityStatus.Identified,
     };
 
-    mockUseFacesGet.mockReturnValue({
+    mockUseFacesGetAll.mockReturnValue({
       data: { data: [face] },
       isLoading: false,
       isError: false,
@@ -257,7 +257,7 @@ describe('FacesPage', () => {
       identityStatus: status,
     }));
 
-    mockUseFacesGet.mockReturnValue({
+    mockUseFacesGetAll.mockReturnValue({
       data: { data: faces },
       isLoading: false,
       isError: false,

--- a/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Search, User, Eye, Loader2 } from 'lucide-react';
 import {
   IdentityStatusDto as IdentityStatusEnum,
-  useFacesGet,
+  useFacesGetAll,
   usePersonsGetAll,
   type FaceDto,
   type IdentityStatusDto as IdentityStatusType,
@@ -90,7 +90,7 @@ export default function FacesPage() {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [selectedFace, setSelectedFace] = useState<FaceDto | null>(null);
 
-  const { data, isLoading, isError, isFetching, refetch } = useFacesGet();
+  const { data, isLoading, isError, isFetching, refetch } = useFacesGetAll();
   const { data: personsResponse } = usePersonsGetAll();
 
   const personLookup = useMemo(
@@ -200,7 +200,14 @@ export default function FacesPage() {
           {showError ? (
             <div className="flex flex-col items-center justify-center gap-4 py-12 text-center">
               <p className="text-sm text-muted-foreground">We couldn't load the faces list. Please try again.</p>
-              <Button variant="outline" onClick={refetch}>Retry loading faces</Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  void refetch();
+                }}
+              >
+                Retry loading faces
+              </Button>
             </div>
           ) : showLoading ? (
             <div className="flex items-center justify-center py-12" role="status">

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -257,7 +257,11 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                               key={face.id}
                                               face={face}
                                               index={index}
-                                              style={calculateFacePosition(face.faceBox)}
+                                              style={
+                                                  face.faceBox
+                                                      ? calculateFacePosition(face.faceBox)
+                                                      : undefined
+                                              }
                                           />
                                     ))}
                             </div>


### PR DESCRIPTION
## Summary
- switch the admin Faces page to use the new `useFacesGetAll` hook and adjust the retry handler
- update the Faces page test suite mocks to match the new hook name
- guard face overlay positioning against missing face boxes to satisfy stricter typing

## Testing
- pnpm --filter frontend build

------
https://chatgpt.com/codex/tasks/task_e_68e029ae6f1083288cb10898e0400ca1