### PR TITLE
fix: guard faces api data on admin page

### DIFF
--- a/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
@@ -99,7 +99,7 @@ export default function FacesPage() {
   );
 
   const faceRows = useMemo<FaceRow[]>(() => {
-    const rawFaces = data?.data ?? [];
+    const rawFaces: FaceDto[] = Array.isArray(data?.data) ? data.data : [];
 
     return rawFaces.map((face) => {
       const id = face.id ?? 0;


### PR DESCRIPTION
## Summary
- ensure FacesPage only processes face rows when the API payload is an array
- keep existing normalization logic while benefitting from typed FaceDto entries

## Testing
- pnpm -w build *(fails: @photobank/telegram-bot build command exits with code 1)*
- pnpm --filter @photobank/frontend run build


------
https://chatgpt.com/codex/tasks/task_e_68e02afdbcd08328a0612139f6f805a6