### PR TITLE
fix: skip face overlay without bounding box

### DIFF
--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -251,19 +251,23 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
                                     alt={photoData.name ?? ''}
                                     className="max-h-full max-w-full object-contain"
                                 />
-                                  {showFaceBoxes &&
-                                      photoData.faces?.map((face, index) => (
-                                          <FaceOverlay
-                                              key={face.id}
-                                              face={face}
-                                              index={index}
-                                              style={
-                                                  face.faceBox
-                                                      ? calculateFacePosition(face.faceBox)
-                                                      : undefined
-                                              }
-                                          />
-                                    ))}
+                                {showFaceBoxes &&
+                                    photoData.faces?.map((face, index) => {
+                                        if (!face.faceBox) {
+                                            return null;
+                                        }
+
+                                        const facePosition = calculateFacePosition(face.faceBox);
+
+                                        return (
+                                            <FaceOverlay
+                                                key={face.id}
+                                                face={face}
+                                                index={index}
+                                                style={facePosition}
+                                            />
+                                        );
+                                    })}
                             </div>
                         </CardContent>
                     </Card>


### PR DESCRIPTION
## Summary
- avoid rendering FaceOverlay when a face lacks a faceBox in the photo details page
- calculate overlay positioning only after confirming a bounding box is present

## Testing
- pnpm -w build *(fails: @photobank/telegram-bot build script exits with code 1)*
- pnpm --filter @photobank/frontend build

------
https://chatgpt.com/codex/tasks/task_e_68e02c0a1ffc8328bbd8027b3a760265