### PR TITLE
fix: align photo date column identifiers

### DIFF
--- a/frontend/packages/frontend/src/features/photos/components/PhotoTable.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/PhotoTable.tsx
@@ -29,7 +29,7 @@ const DEFAULT_COLUMN_FLEX_STYLE: CSSProperties = CONTENT_BASE_FLEX_STYLE;
 const COLUMN_FLEX_STYLES: Record<string, CSSProperties> = {
   thumbnail: { flexBasis: '80px', flexShrink: 0 },
   flags: { flexBasis: '100px', flexShrink: 0 },
-  takenDate: { flexBasis: '150px', flexShrink: 0 },
+  date: { flexBasis: '150px', flexShrink: 0 },
   path: CONTENT_BASE_FLEX_STYLE,
   caption: { ...CONTENT_BASE_FLEX_STYLE, flexGrow: 1.5 },
 };

--- a/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
@@ -72,7 +72,7 @@ export function usePhotoColumns(): ColumnDef<PhotoItemDto>[] {
       },
       {
         accessorKey: 'takenDate',
-        id: 'takenDate',
+        id: 'date',
         header: 'Date',
         accessorFn: (p) => {
           const date = toDate(p.takenDate);


### PR DESCRIPTION
## Summary
- rename the photo date column id to `date` while keeping its accessor bound to takenDate
- update the column flex sizing map to reference the renamed date column key

## Testing
- pnpm vitest run src/features/photos/components/photoColumns.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e030f080d483288aa6038d644c87a2