### PR TITLE
fix: localize photo preview column header

### DIFF
--- a/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
+++ b/frontend/packages/frontend/src/features/photos/components/photoColumns.tsx
@@ -8,6 +8,7 @@ import MetadataBadgeList from '@/components/MetadataBadgeList';
 import { Badge } from '@/shared/ui/badge';
 import { buildThumbnailUrl } from '@/shared/utils/buildThumbnailUrl';
 import { useAppSelector } from '@/app/hook';
+import { useTranslation } from 'react-i18next';
 import {
   selectMetadataLoaded,
   selectPersonsMap,
@@ -15,6 +16,7 @@ import {
 } from '@/features/metadata/selectors';
 
 export function usePhotoColumns(): ColumnDef<PhotoItemDto>[] {
+  const { t } = useTranslation();
   const personsMap = useAppSelector(selectPersonsMap);
   const tagsMap = useAppSelector(selectTagsMap);
   const metaLoaded = useAppSelector(selectMetadataLoaded);
@@ -24,7 +26,7 @@ export function usePhotoColumns(): ColumnDef<PhotoItemDto>[] {
       {
         accessorKey: 'thumbnail',
         id: 'thumbnail',
-        header: 'Thumb',
+        header: t('colPreviewLabel'),
         cell: ({ row }) => (
           <div className="flex items-center justify-center">
             <img
@@ -149,6 +151,6 @@ export function usePhotoColumns(): ColumnDef<PhotoItemDto>[] {
         enableResizing: true,
       },
     ],
-    [metaLoaded, personsMap, tagsMap]
+    [metaLoaded, personsMap, tagsMap, t]
   );
 }


### PR DESCRIPTION
## Summary
- use the translated `colPreviewLabel` for the photo preview column header
- update the PhotoTable integration test to load the i18n provider and stub `IntersectionObserver`

## Testing
- pnpm --filter frontend test PhotoTable.integration.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0337b446c8328a19d78d1185d65fa