### PR TITLE
test: fix Minio mock in PhotoService face tests

### DIFF
--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllFacesAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllFacesAsyncTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Minio;
+using Minio.DataModel.Args;
 using Moq;
 using NetTopologySuite.Geometries;
 using NUnit.Framework;
@@ -90,7 +91,7 @@ public class PhotoServiceGetAllFacesAsyncTests
 
         var minioClient = new Mock<IMinioClient>();
         minioClient
-            .Setup(m => m.PresignedGetObjectAsync(It.IsAny<PresignedGetObjectArgs>(), It.IsAny<CancellationToken>()))
+            .Setup(m => m.PresignedGetObjectAsync(It.IsAny<PresignedGetObjectArgs>()))
             .ReturnsAsync("https://example.com/face.jpg");
 
         var service = CreateService(dbName, minioClient.Object);


### PR DESCRIPTION
## Summary
- add the Minio data model args namespace to the face service unit test
- update the mock setup to match the current PresignedGetObjectAsync signature

## Testing
- DOTNET_DISABLE_TERMINAL_LOGGER=1 dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build *(fails with terminal logger exception after tests execute)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c8b8358883288fed926f79c82246