### PR TITLE
feat: add editable date ranges to access profile dialog

### DIFF
--- a/frontend/packages/frontend/src/components/admin/EditProfileDialog.test.tsx
+++ b/frontend/packages/frontend/src/components/admin/EditProfileDialog.test.tsx
@@ -1,0 +1,119 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { format } from 'date-fns';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AccessProfileDto } from '@photobank/shared';
+
+import { EditProfileDialog } from './EditProfileDialog';
+
+const mutateAsyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@photobank/shared/api/photobank/admin-access-profiles/admin-access-profiles', () => ({
+  getAdminAccessProfilesListQueryKey: () => ['admin-access-profiles'],
+  useAdminAccessProfilesUpdate: () => ({
+    mutateAsync: mutateAsyncMock,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@photobank/shared/api/photobank/storages/storages', () => ({
+  useGetStorages: () => ({
+    data: { data: [] },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@photobank/shared/api/photobank/person-groups/person-groups', () => ({
+  usePersonGroupsGetAll: () => ({
+    data: { data: [] },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+describe('EditProfileDialog', () => {
+  beforeEach(() => {
+    mutateAsyncMock.mockReset();
+  });
+
+  const renderComponent = (profile: AccessProfileDto) => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <EditProfileDialog open onOpenChange={() => {}} profile={profile} />
+      </QueryClientProvider>
+    );
+  };
+
+  it('updates the displayed date when a new value is selected from the calendar', async () => {
+    const user = userEvent.setup();
+
+    const profile: AccessProfileDto = {
+      id: 1,
+      name: 'Editors',
+      description: 'Editorial team',
+      flags_CanSeeNsfw: false,
+      storages: [],
+      personGroups: [],
+      dateRanges: [
+        {
+          profileId: 1,
+          fromDate: new Date('2024-01-01'),
+          toDate: new Date('2024-01-10'),
+        },
+      ],
+      assignedUsersCount: 0,
+    };
+
+    renderComponent(profile);
+
+    const fromButton = await screen.findByRole('button', {
+      name: /select from date for range 1/i,
+    });
+    expect(fromButton).toHaveTextContent('2024-01-01');
+
+    await user.click(fromButton);
+
+    let targetButton: HTMLButtonElement | null = null;
+    let targetDateValue = '';
+
+    await waitFor(() => {
+      const dayButtons = Array.from(
+        document.querySelectorAll<HTMLButtonElement>('button[data-day]')
+      );
+
+      if (dayButtons.length === 0) {
+        throw new Error('No calendar day buttons available');
+      }
+
+      targetButton =
+        dayButtons.find((button) => button.dataset.day?.includes('/15/')) ??
+        dayButtons[0];
+      targetDateValue = targetButton.dataset.day ?? '';
+
+      if (!targetDateValue) {
+        throw new Error('Calendar day value not found');
+      }
+    });
+
+    await user.click(targetButton!);
+
+    const expectedDisplay = format(new Date(targetDateValue), 'yyyy-MM-dd');
+
+    await waitFor(() => {
+      expect(fromButton).toHaveTextContent(expectedDisplay);
+    });
+  });
+});

--- a/frontend/packages/frontend/src/components/admin/accessProfileFormSchema.ts
+++ b/frontend/packages/frontend/src/components/admin/accessProfileFormSchema.ts
@@ -15,8 +15,8 @@ export const accessProfileFormSchema = z.object({
   dateRanges: z
     .array(
       z.object({
-        fromDate: z.string().optional(),
-        toDate: z.string().optional(),
+        fromDate: z.date({ required_error: 'From date is required' }),
+        toDate: z.date({ required_error: 'To date is required' }),
       })
     )
     .optional(),


### PR DESCRIPTION
## Summary
- replace the access profile date range badges with editable popover calendars for each From/To value
- store form date ranges as Date objects and format them to `yyyy-MM-dd` before sending the update payload
- cover the new behaviour with a component test that selects a date from the calendar

## Testing
- pnpm vitest run src/components/admin/EditProfileDialog.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0db973cb4832894ad4164c41ed6a7