### PR TITLE
test: guard calendar day selection in edit profile dialog

### DIFF
--- a/frontend/packages/frontend/src/components/admin/EditProfileDialog.test.tsx
+++ b/frontend/packages/frontend/src/components/admin/EditProfileDialog.test.tsx
@@ -98,10 +98,16 @@ describe('EditProfileDialog', () => {
         throw new Error('No calendar day buttons available');
       }
 
-      targetButton =
+      const nextTarget =
         dayButtons.find((button) => button.dataset.day?.includes('/15/')) ??
         dayButtons[0];
-      targetDateValue = targetButton.dataset.day ?? '';
+
+      if (!nextTarget) {
+        throw new Error('Calendar day button not found');
+      }
+
+      targetButton = nextTarget;
+      targetDateValue = nextTarget.dataset.day ?? '';
 
       if (!targetDateValue) {
         throw new Error('Calendar day value not found');


### PR DESCRIPTION
## Summary
- ensure the calendar day lookup guards against missing buttons in the edit profile dialog test
- derive the selected date value from the guarded button reference to satisfy TypeScript narrowing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e106d20ef88328b58dbbdd1b84f3ed