### PR TITLE
fix: allow nullable admin access profile date ranges

### DIFF
--- a/frontend/packages/frontend/src/components/admin/accessProfileFormSchema.ts
+++ b/frontend/packages/frontend/src/components/admin/accessProfileFormSchema.ts
@@ -1,5 +1,7 @@
 import * as z from 'zod';
 
+const nullableDate = z.coerce.date({ error: 'Date must be a valid date' }).nullish();
+
 export const accessProfileFormSchema = z.object({
   name: z
     .string()
@@ -15,11 +17,12 @@ export const accessProfileFormSchema = z.object({
   dateRanges: z
     .array(
       z.object({
-        fromDate: z.date({ required_error: 'From date is required' }),
-        toDate: z.date({ required_error: 'To date is required' }),
+        fromDate: nullableDate,
+        toDate: nullableDate,
       })
     )
     .optional(),
 });
 
 export type AccessProfileFormValues = z.infer<typeof accessProfileFormSchema>;
+export type AccessProfileFormInput = z.input<typeof accessProfileFormSchema>;


### PR DESCRIPTION
## Summary
- reuse a shared nullable date schema for access profile range fields
- align create and edit dialogs with the nullable date types and guards

## Testing
- pnpm --filter frontend build

------
https://chatgpt.com/codex/tasks/task_e_68e10959b8448328ba94a77fc2a684be