### PR TITLE
fix: surface profile update errors

### DIFF
--- a/frontend/packages/frontend/src/pages/profile/MyProfilePage.test.tsx
+++ b/frontend/packages/frontend/src/pages/profile/MyProfilePage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { ProblemDetailsError } from '@photobank/shared/types/problem';
+
+import MyProfilePage from './MyProfilePage';
+import { I18nProvider } from '@/app/providers/I18nProvider';
+import { useAuthGetUser, useAuthUpdateUser } from '@photobank/shared/api/photobank';
+import { toast } from '@/shared/ui/sonner';
+import { logger } from '@photobank/shared/utils/logger';
+
+vi.mock('@photobank/shared/api/photobank', () => ({
+  useAuthGetUser: vi.fn(),
+  useAuthUpdateUser: vi.fn(),
+}));
+
+vi.mock('@/shared/ui/sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+const useAuthGetUserMock = useAuthGetUser as unknown as Mock;
+const useAuthUpdateUserMock = useAuthUpdateUser as unknown as Mock;
+
+const renderPage = () =>
+  render(
+    <I18nProvider>
+      <MemoryRouter>
+        <MyProfilePage />
+      </MemoryRouter>
+    </I18nProvider>
+  );
+
+describe('MyProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows toast with problem details when profile update fails', async () => {
+    const problem = new ProblemDetailsError({
+      title: 'Profile update failed',
+      status: 400,
+      detail: 'Phone number is invalid',
+    });
+
+    useAuthGetUserMock.mockReturnValue({
+      data: {
+        data: {
+          email: 'user@example.com',
+          phoneNumber: '',
+          telegramUserId: null,
+        },
+      },
+    });
+
+    const mutateAsync = vi.fn().mockRejectedValue(problem);
+    useAuthUpdateUserMock.mockReturnValue({ mutateAsync });
+
+    const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    renderPage();
+
+    const user = userEvent.setup();
+    const saveButton = await screen.findByRole('button', { name: /save/i });
+    await user.click(saveButton);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(problem.problem.title, {
+        description: problem.problem.detail,
+      })
+    );
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith(problem.problem);
+    loggerErrorSpy.mockRestore();
+  });
+});

--- a/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
+++ b/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
@@ -12,6 +12,7 @@ import { ProblemDetailsError } from '@photobank/shared/types/problem';
 import {Button} from '@/shared/ui/button';
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/shared/ui/form';
 import {Input} from '@/shared/ui/input';
+import { toast } from '@/shared/ui/sonner';
 
 const formSchema = z.object({
   phoneNumber: z.string().optional(),
@@ -53,8 +54,20 @@ export default function MyProfilePage() {
       });
       navigate('/filter');
     } catch (e: unknown) {
-      if (e instanceof ProblemDetailsError) logger.error(e.problem);
-      else logger.error(e);
+      const fallbackMessage = t('profileSaveFailed');
+
+      if (e instanceof ProblemDetailsError) {
+        const { title, detail } = e.problem;
+        const message = title ?? detail ?? fallbackMessage;
+        const description =
+          detail && detail !== message ? detail : undefined;
+
+        toast.error(message, description ? { description } : undefined);
+        logger.error(e.problem);
+      } else {
+        toast.error(fallbackMessage);
+        logger.error(e);
+      }
     }
   };
 

--- a/frontend/packages/frontend/src/shared/config/locales/en.json
+++ b/frontend/packages/frontend/src/shared/config/locales/en.json
@@ -33,6 +33,7 @@
   "phoneNumberLabel": "Phone number",
   "telegramLabel": "Telegram",
   "saveButtonText": "Save",
+  "profileSaveFailed": "Failed to save profile. Please try again.",
   "rolesTitle": "Roles",
   "logoutButtonText": "Logout",
   "unassignedLabel": "Unassigned",

--- a/frontend/packages/frontend/src/shared/config/locales/ru.json
+++ b/frontend/packages/frontend/src/shared/config/locales/ru.json
@@ -33,6 +33,7 @@
   "phoneNumberLabel": "Номер телефона",
   "telegramLabel": "Telegram",
   "saveButtonText": "Сохранить",
+  "profileSaveFailed": "Не удалось сохранить профиль. Повторите попытку.",
   "rolesTitle": "Роли",
   "logoutButtonText": "Выйти",
   "unassignedLabel": "Не назначено",

--- a/frontend/packages/frontend/src/shared/ui/sonner.tsx
+++ b/frontend/packages/frontend/src/shared/ui/sonner.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from "next-themes"
 import type { ToasterProps } from "sonner"
-import { Toaster as Sonner } from "sonner"
+import { Toaster as Sonner, toast as sonnerToast } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
@@ -21,5 +21,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster }
+const toast = sonnerToast
+
+export { Toaster, toast }
 export type { ToasterProps }


### PR DESCRIPTION
## Summary
- show API problem details on the profile form by surfacing them via toast with a localized fallback message
- add the `profileSaveFailed` locale key in English and Russian and expose the toast helper from the sonner wrapper
- cover the failure scenario with a Vitest + RTL test for `MyProfilePage`

## Testing
- pnpm --filter @photobank/frontend exec vitest run src/pages/profile/MyProfilePage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e1238813708328ba3824da1d0621fd