### PR TITLE
fix: normalize optional telegram user id parsing

### DIFF
--- a/frontend/packages/frontend/src/components/admin/CreateUserDialog.tsx
+++ b/frontend/packages/frontend/src/components/admin/CreateUserDialog.tsx
@@ -40,19 +40,12 @@ const formSchema = z.object({
   roles: z.array(z.enum(roles)).min(1, 'At least one role is required'),
   telegramUserId: z
     .string()
-    .optional()
-    .transform((value) => {
-      if (value === undefined) {
-        return value;
-      }
-
-      const trimmed = value.trim();
-      return trimmed.length === 0 ? '' : trimmed;
+    .trim()
+    .transform((value) => (value.length === 0 ? '' : value))
+    .refine((value) => value === '' || /^\d+$/.test(value), {
+      message: 'Telegram ID must contain only digits',
     })
-    .refine(
-      (value) => value === undefined || value === '' || /^\d+$/.test(value),
-      { message: 'Telegram ID must contain only digits' }
-    ),
+    .optional(),
   telegramSendTimeUtc: z.string().optional(),
 });
 

--- a/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
+++ b/frontend/packages/frontend/src/pages/profile/MyProfilePage.tsx
@@ -18,19 +18,12 @@ const formSchema = z.object({
   phoneNumber: z.string().optional(),
   telegramUserId: z
     .string()
-    .optional()
-    .transform((value) => {
-      if (value === undefined) {
-        return value;
-      }
-
-      const trimmed = value.trim();
-      return trimmed.length === 0 ? '' : trimmed;
+    .trim()
+    .transform((value) => (value.length === 0 ? '' : value))
+    .refine((value) => value === '' || /^\d+$/.test(value), {
+      message: 'Telegram ID must contain only digits',
     })
-    .refine(
-      (value) => value === undefined || value === '' || /^\d+$/.test(value),
-      { message: 'Telegram ID must contain only digits' }
-    ),
+    .optional(),
 });
 
 type FormData = z.infer<typeof formSchema>;


### PR DESCRIPTION
## Summary
- normalize telegram user ID parsing in the admin create user dialog so trimming and digit checks happen before optional handling
- align the profile page form schema with the same optional-friendly normalization to keep the resolver types consistent

## Testing
- pnpm --filter frontend build *(fails: missing type definitions for object-hash in shared package, but TS2322 no longer appears)*

------
https://chatgpt.com/codex/tasks/task_e_68e13f904660832891d4717ceb10c66f