### PR TITLE
fix: add logging for presigned photo urls

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -17,6 +17,7 @@ public static partial class ServiceCollectionExtensions
 {
     public static IServiceCollection AddPhotobankCore(this IServiceCollection services, IConfiguration? configuration = null)
     {
+        services.AddLogging();
         services.AddMemoryCache();
         services.AddSingleton<IMinioClient>(sp =>
         {

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 using Minio;
 using Moq;
 using NUnit.Framework;
@@ -60,6 +61,7 @@ public class PersonGroupServiceTests
             _provider.GetRequiredService<IRepository<PersonGroup>>(),
             _provider.GetRequiredService<IMapper>(),
             _provider.GetRequiredService<IMemoryCache>(),
+            NullLogger<PhotoService>.Instance,
             _provider.GetRequiredService<ICurrentUser>(),
             _provider.GetRequiredService<ISearchReferenceDataService>(),
             normalizer.Object,

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 using Minio;
 using Moq;
 using NetTopologySuite.Geometries;
@@ -94,6 +95,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<PersonGroup>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
+                NullLogger<PhotoService>.Instance,
                 new DummyCurrentUser(),
                 referenceDataService.Object,
                 normalizerMock.Object,

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 using Minio;
 using Minio.DataModel.Args;
 using Moq;
@@ -160,6 +161,7 @@ public class PhotoServiceGetFacesPageAsyncTests
             new Repository<PersonGroup>(provider),
             _mapper,
             new MemoryCache(new MemoryCacheOptions()),
+            NullLogger<PhotoService>.Instance,
             new DummyCurrentUser(),
             referenceDataService.Object,
             normalizer.Object,

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Logging.Abstractions;
 using Minio;
 using Moq;
 using NUnit.Framework;
@@ -63,6 +64,7 @@ namespace PhotoBank.UnitTests.Services
                 new Repository<PersonGroup>(provider),
                 _mapper,
                 new MemoryCache(new MemoryCacheOptions()),
+                NullLogger<PhotoService>.Instance,
                 new DummyCurrentUser(),
                 referenceDataService.Object,
                 normalizer.Object,


### PR DESCRIPTION
## Summary
- inject ILogger into PhotoService and log presigned URL generation failures with the photo key/id
- pass identifiers to the presigned URL helper so callers can include them in log context
- register logging in AddPhotobankCore and update unit tests to provide a logger instance

## Testing
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e15098b1b48328b621f500889ad6cd