### PR TITLE
test: adapt photo service unit tests to new constructor

### DIFF
--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
@@ -18,6 +18,9 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Photos.Admin;
+using PhotoBank.Services.Photos.Faces;
+using PhotoBank.Services.Photos.Queries;
 using PhotoBank.Services.Search;
 using PhotoBank.ViewModel.Dto;
 using System;
@@ -152,20 +155,56 @@ public class PhotoServiceGetFacesPageAsyncTests
             .Setup(n => n.NormalizeAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((FilterDto f, CancellationToken _) => f);
 
-        return new PhotoService(
+        var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var photoRepository = new Repository<Photo>(provider);
+        var personRepository = new Repository<Person>(provider);
+        var faceRepository = new Repository<Face>(provider);
+        var storageRepository = new Repository<Storage>(provider);
+        var personGroupRepository = new Repository<PersonGroup>(provider);
+        var s3Options = Options.Create(new S3Options { Bucket = "bucket", UrlExpirySeconds = 60 });
+
+        var photoQueryService = new PhotoQueryService(
             context,
-            new Repository<Photo>(provider),
-            new Repository<Person>(provider),
-            new Repository<Face>(provider),
-            new Repository<Storage>(provider),
-            new Repository<PersonGroup>(provider),
+            photoRepository,
+            storageRepository,
             _mapper,
-            new MemoryCache(new MemoryCacheOptions()),
-            NullLogger<PhotoService>.Instance,
+            memoryCache,
+            NullLogger<PhotoQueryService>.Instance,
             new DummyCurrentUser(),
             referenceDataService.Object,
             normalizer.Object,
             minioClient,
-            Options.Create(new S3Options { Bucket = "bucket", UrlExpirySeconds = 60 }));
+            s3Options);
+
+        var personDirectoryService = new PersonDirectoryService(
+            personRepository,
+            _mapper,
+            referenceDataService.Object,
+            NullLogger<PersonDirectoryService>.Instance);
+
+        var personGroupService = new PersonGroupService(
+            context,
+            personGroupRepository,
+            _mapper,
+            memoryCache,
+            NullLogger<PersonGroupService>.Instance);
+
+        var faceCatalogService = new FaceCatalogService(
+            faceRepository,
+            _mapper,
+            minioClient,
+            NullLogger<FaceCatalogService>.Instance,
+            s3Options);
+
+        var photoAdminService = new PhotoAdminService(
+            storageRepository,
+            NullLogger<PhotoAdminService>.Instance);
+
+        return new PhotoService(
+            photoQueryService,
+            personDirectoryService,
+            personGroupService,
+            faceCatalogService,
+            photoAdminService);
     }
 }

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
@@ -16,6 +16,9 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Photos.Admin;
+using PhotoBank.Services.Photos.Faces;
+using PhotoBank.Services.Photos.Queries;
 using PhotoBank.Services.Search;
 using PhotoBank.ViewModel.Dto;
 using System;
@@ -107,21 +110,57 @@ namespace PhotoBank.UnitTests.Services
 
             var filterNormalizer = new Mock<ISearchFilterNormalizer>();
 
-            var service = new PhotoService(
+            var memoryCache = new MemoryCache(new MemoryCacheOptions());
+            var photoRepository = new Repository<Photo>(provider);
+            var personRepository = new Repository<Person>(provider);
+            var faceRepository = new Repository<Face>(provider);
+            var storageRepository = new Repository<Storage>(provider);
+            var personGroupRepository = new Repository<PersonGroup>(provider);
+            var s3Options = Options.Create(new S3Options());
+
+            var photoQueryService = new PhotoQueryService(
                 context,
-                new Repository<Photo>(provider),
-                new Repository<Person>(provider),
-                new Repository<Face>(provider),
-                new Repository<Storage>(provider),
-                new Repository<PersonGroup>(provider),
+                photoRepository,
+                storageRepository,
                 _mapper,
-                new MemoryCache(new MemoryCacheOptions()),
-                NullLogger<PhotoService>.Instance,
+                memoryCache,
+                NullLogger<PhotoQueryService>.Instance,
                 currentUser,
                 referenceDataService.Object,
                 filterNormalizer.Object,
                 minioClient.Object,
-                Options.Create(new S3Options()));
+                s3Options);
+
+            var personDirectoryService = new PersonDirectoryService(
+                personRepository,
+                _mapper,
+                referenceDataService.Object,
+                NullLogger<PersonDirectoryService>.Instance);
+
+            var personGroupService = new PersonGroupService(
+                context,
+                personGroupRepository,
+                _mapper,
+                memoryCache,
+                NullLogger<PersonGroupService>.Instance);
+
+            var faceCatalogService = new FaceCatalogService(
+                faceRepository,
+                _mapper,
+                minioClient.Object,
+                NullLogger<FaceCatalogService>.Instance,
+                s3Options);
+
+            var photoAdminService = new PhotoAdminService(
+                storageRepository,
+                NullLogger<PhotoAdminService>.Instance);
+
+            var service = new PhotoService(
+                photoQueryService,
+                personDirectoryService,
+                personGroupService,
+                faceCatalogService,
+                photoAdminService);
 
             // Act
             var result = await service.GetPhotoAsync(photo.Id);

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -16,6 +16,9 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Photos.Admin;
+using PhotoBank.Services.Photos.Faces;
+using PhotoBank.Services.Photos.Queries;
 using PhotoBank.Services.Search;
 using System;
 using System.IO;
@@ -55,21 +58,60 @@ namespace PhotoBank.UnitTests.Services
                 .Setup(n => n.NormalizeAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((FilterDto f, CancellationToken _) => f);
 
-            return new PhotoService(
+            var memoryCache = new MemoryCache(new MemoryCacheOptions());
+            var minioClient = new Mock<IMinioClient>();
+            var s3Options = new Mock<IOptions<S3Options>>();
+            s3Options.Setup(o => o.Value).Returns(new S3Options());
+
+            var photoRepository = new Repository<Photo>(provider);
+            var personRepository = new Repository<Person>(provider);
+            var faceRepository = new Repository<Face>(provider);
+            var storageRepository = new Repository<Storage>(provider);
+            var personGroupRepository = new Repository<PersonGroup>(provider);
+
+            var photoQueryService = new PhotoQueryService(
                 context,
-                new Repository<Photo>(provider),
-                new Repository<Person>(provider),
-                new Repository<Face>(provider),
-                new Repository<Storage>(provider),
-                new Repository<PersonGroup>(provider),
+                photoRepository,
+                storageRepository,
                 _mapper,
-                new MemoryCache(new MemoryCacheOptions()),
-                NullLogger<PhotoService>.Instance,
+                memoryCache,
+                NullLogger<PhotoQueryService>.Instance,
                 new DummyCurrentUser(),
                 referenceDataService.Object,
                 normalizer.Object,
-                new Mock<IMinioClient>().Object,
-                new Mock<IOptions<S3Options>>().Object);
+                minioClient.Object,
+                s3Options.Object);
+
+            var personDirectoryService = new PersonDirectoryService(
+                personRepository,
+                _mapper,
+                referenceDataService.Object,
+                NullLogger<PersonDirectoryService>.Instance);
+
+            var personGroupService = new PersonGroupService(
+                context,
+                personGroupRepository,
+                _mapper,
+                memoryCache,
+                NullLogger<PersonGroupService>.Instance);
+
+            var faceCatalogService = new FaceCatalogService(
+                faceRepository,
+                _mapper,
+                minioClient.Object,
+                NullLogger<FaceCatalogService>.Instance,
+                s3Options.Object);
+
+            var photoAdminService = new PhotoAdminService(
+                storageRepository,
+                NullLogger<PhotoAdminService>.Instance);
+
+            return new PhotoService(
+                photoQueryService,
+                personDirectoryService,
+                personGroupService,
+                faceCatalogService,
+                photoAdminService);
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- build the new PhotoQueryService, PersonDirectoryService, PersonGroupService, FaceCatalogService, and PhotoAdminService inside the PhotoService unit tests so they target the updated five-parameter constructor
- update the PersonGroupService unit tests to reuse the registered dependencies when composing PhotoService for assertions

## Testing
- dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e22116f5ac8328b13bcebd2c90ee88