### PR TITLE
feat: extract photo filter specification

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -34,6 +34,7 @@ public static partial class ServiceCollectionExtensions
         services.AddScoped<IFaceStorageService, FaceStorageService>();
         services.AddScoped<MinioObjectService>();
         services.AddScoped<ISearchFilterNormalizer, SearchFilterNormalizer>();
+        services.AddScoped<PhotoFilterSpecification>();
         services.AddScoped<IPhotoQueryService, PhotoQueryService>();
         services.AddScoped<IPersonDirectoryService, PersonDirectoryService>();
         services.AddScoped<IPersonGroupService, PersonGroupService>();

--- a/backend/PhotoBank.Services/Search/PhotoFilterSpecification.cs
+++ b/backend/PhotoBank.Services/Search/PhotoFilterSpecification.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using PhotoBank.AccessControl;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Services.Search;
+
+public class PhotoFilterSpecification
+{
+    private readonly PhotoBankDbContext _dbContext;
+
+    public PhotoFilterSpecification(PhotoBankDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public IQueryable<Photo> Build(FilterDto filter, ICurrentUser currentUser)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentNullException.ThrowIfNull(currentUser);
+
+        var query = _dbContext.Photos.AsNoTracking();
+
+        if (filter.IsBW is true)
+        {
+            query = query.Where(p => p.IsBW);
+        }
+
+        if (filter.IsAdultContent is true)
+        {
+            query = query.Where(p => p.IsAdultContent);
+        }
+
+        if (filter.IsRacyContent is true)
+        {
+            query = query.Where(p => p.IsRacyContent);
+        }
+
+        if (filter.TakenDateFrom.HasValue)
+        {
+            var from = filter.TakenDateFrom.Value.Date;
+            query = query.Where(p => p.TakenDate.HasValue && p.TakenDate >= from);
+        }
+
+        if (filter.TakenDateTo.HasValue)
+        {
+            var toExclusive = filter.TakenDateTo.Value.Date.AddDays(1);
+            query = query.Where(p => p.TakenDate.HasValue && p.TakenDate < toExclusive);
+        }
+
+        if (filter.ThisDay != null)
+        {
+            query = query.Where(p => p.TakenDate.HasValue &&
+                                     p.TakenDate.Value.Day == filter.ThisDay.Day &&
+                                     p.TakenDate.Value.Month == filter.ThisDay.Month);
+        }
+
+        if (filter.Storages?.Any() == true)
+        {
+            var storages = filter.Storages.ToList();
+            query = query.Where(p => storages.Contains(p.StorageId));
+
+            if (!string.IsNullOrEmpty(filter.RelativePath))
+            {
+                query = query.Where(p => p.RelativePath == filter.RelativePath);
+            }
+        }
+
+        if (!string.IsNullOrEmpty(filter.Caption))
+        {
+            query = query.Where(p => p.Captions.Any(c => EF.Functions.FreeText(c.Text, filter.Caption!)));
+        }
+
+        if (filter.Persons?.Any() == true)
+        {
+            var personIds = filter.Persons.Distinct().ToArray();
+            var requiredPersons = personIds.Length;
+
+            if (requiredPersons > 0)
+            {
+                query = query.Where(p =>
+                    _dbContext.Faces
+                        .Where(f => f.PhotoId == p.Id && f.PersonId != null && personIds.Contains(f.PersonId.Value))
+                        .Select(f => f.PersonId!.Value)
+                        .Distinct()
+                        .Count() == requiredPersons);
+            }
+        }
+
+        if (filter.Tags?.Any() == true)
+        {
+            var tagIds = filter.Tags.Distinct().ToArray();
+            var requiredTags = tagIds.Length;
+
+            if (requiredTags > 0)
+            {
+                query = query.Where(p =>
+                    _dbContext.PhotoTags
+                        .Where(pt => pt.PhotoId == p.Id && tagIds.Contains(pt.TagId))
+                        .Select(pt => pt.TagId)
+                        .Distinct()
+                        .Count() == requiredTags);
+            }
+        }
+
+        return query.MaybeApplyAcl(currentUser);
+    }
+}

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -67,6 +67,8 @@ public class PersonGroupServiceTests
         var minioClient = new Mock<IMinioClient>();
         var s3Options = Options.Create(new S3Options());
 
+        var photoFilterSpecification = new PhotoFilterSpecification(db);
+
         var photoQueryService = new PhotoQueryService(
             db,
             photoRepository,
@@ -77,6 +79,7 @@ public class PersonGroupServiceTests
             currentUser,
             referenceDataService,
             normalizer.Object,
+            photoFilterSpecification,
             minioClient.Object,
             s3Options);
 

--- a/backend/PhotoBank.UnitTests/Search/PhotoFilterSpecificationTests.cs
+++ b/backend/PhotoBank.UnitTests/Search/PhotoFilterSpecificationTests.cs
@@ -1,0 +1,306 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Geometries;
+using NUnit.Framework;
+using PhotoBank.AccessControl;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Search;
+using PhotoBank.UnitTests;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.UnitTests.Search;
+
+[TestFixture]
+public class PhotoFilterSpecificationTests
+{
+    private PhotoBankDbContext _context = null!;
+    private PhotoFilterSpecification _sut = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _context = TestDbFactory.CreateInMemory();
+        _sut = new PhotoFilterSpecification(_context);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _context.Dispose();
+    }
+
+    [Test]
+    public async Task Build_WithFlagsAndDateFilters_ReturnsMatchingPhoto()
+    {
+        var storage = new Storage { Id = 1, Name = "s1", Folder = "f1" };
+        var matching = CreatePhoto(1, storage, "match", new DateTime(2024, 1, 1));
+        matching.IsBW = true;
+        matching.IsAdultContent = true;
+        matching.IsRacyContent = true;
+
+        var other = CreatePhoto(2, storage, "other", new DateTime(2024, 2, 1));
+        other.IsBW = false;
+        other.IsAdultContent = false;
+        other.IsRacyContent = false;
+
+        _context.Storages.Add(storage);
+        _context.Photos.AddRange(matching, other);
+        await _context.SaveChangesAsync();
+
+        var filter = new FilterDto
+        {
+            IsBW = true,
+            IsAdultContent = true,
+            IsRacyContent = true,
+            TakenDateFrom = new DateTime(2024, 1, 1),
+            TakenDateTo = new DateTime(2024, 1, 1)
+        };
+
+        var result = await _sut.Build(filter, new DummyCurrentUser())
+            .OrderBy(p => p.Id)
+            .ToListAsync();
+
+        result.Should().ContainSingle()
+            .Which.Id.Should().Be(matching.Id);
+    }
+
+    [Test]
+    public async Task Build_WithThisDayFilter_ReturnsPhotosFromSameDay()
+    {
+        var storage = new Storage { Id = 10, Name = "s2", Folder = "f2" };
+        var sameDay = CreatePhoto(11, storage, "same", new DateTime(2023, 5, 10));
+        var differentDay = CreatePhoto(12, storage, "different", new DateTime(2023, 6, 10));
+
+        _context.Storages.Add(storage);
+        _context.Photos.AddRange(sameDay, differentDay);
+        await _context.SaveChangesAsync();
+
+        var filter = new FilterDto
+        {
+            ThisDay = new ThisDayDto { Day = 10, Month = 5 }
+        };
+
+        var result = await _sut.Build(filter, new DummyCurrentUser())
+            .OrderBy(p => p.Id)
+            .Select(p => p.Id)
+            .ToListAsync();
+
+        result.Should().Equal(sameDay.Id);
+    }
+
+    [Test]
+    public async Task Build_WithStoragesAndRelativePath_FiltersByBoth()
+    {
+        var storage1 = new Storage { Id = 100, Name = "s100", Folder = "f100" };
+        var storage2 = new Storage { Id = 200, Name = "s200", Folder = "f200" };
+        var matching = CreatePhoto(101, storage1, "match");
+        matching.RelativePath = "album/2024";
+
+        var samePathDifferentStorage = CreatePhoto(102, storage2, "different-storage");
+        samePathDifferentStorage.RelativePath = "album/2024";
+
+        var otherPath = CreatePhoto(103, storage1, "other-path");
+        otherPath.RelativePath = "album/2023";
+
+        _context.Storages.AddRange(storage1, storage2);
+        _context.Photos.AddRange(matching, samePathDifferentStorage, otherPath);
+        await _context.SaveChangesAsync();
+
+        var filter = new FilterDto
+        {
+            Storages = new[] { storage1.Id },
+            RelativePath = "album/2024"
+        };
+
+        var result = await _sut.Build(filter, new DummyCurrentUser())
+            .Select(p => p.Id)
+            .ToListAsync();
+
+        result.Should().Equal(matching.Id);
+    }
+
+    [Test]
+    public async Task Build_WithPersonsAndTags_ReturnsPhotosContainingAll()
+    {
+        var storage = new Storage { Id = 300, Name = "s300", Folder = "f300" };
+        var person1 = new Person { Id = 1, Name = "Alice" };
+        var person2 = new Person { Id = 2, Name = "Bob" };
+        var tag1 = new Tag { Id = 10, Name = "Nature", Hint = string.Empty, PhotoTags = new List<PhotoTag>() };
+        var tag2 = new Tag { Id = 20, Name = "Family", Hint = string.Empty, PhotoTags = new List<PhotoTag>() };
+
+        var matching = CreatePhoto(301, storage, "match");
+        var other = CreatePhoto(302, storage, "other");
+
+        _context.Storages.Add(storage);
+        _context.Persons.AddRange(person1, person2);
+        _context.Tags.AddRange(tag1, tag2);
+        _context.Photos.AddRange(matching, other);
+        await _context.SaveChangesAsync();
+
+        var matchingFaces = new[]
+        {
+            new Face
+            {
+                Id = 1,
+                Photo = matching,
+                PhotoId = matching.Id,
+                Person = person1,
+                PersonId = person1.Id,
+                Rectangle = new Point(0, 0),
+                S3Key_Image = "k1",
+                S3ETag_Image = "e1",
+                Sha256_Image = "s1",
+                FaceAttributes = "{}"
+            },
+            new Face
+            {
+                Id = 2,
+                Photo = matching,
+                PhotoId = matching.Id,
+                Person = person2,
+                PersonId = person2.Id,
+                Rectangle = new Point(0, 0),
+                S3Key_Image = "k2",
+                S3ETag_Image = "e2",
+                Sha256_Image = "s2",
+                FaceAttributes = "{}"
+            }
+        };
+
+        var otherFace = new Face
+        {
+            Id = 3,
+            Photo = other,
+            PhotoId = other.Id,
+            Person = person1,
+            PersonId = person1.Id,
+            Rectangle = new Point(0, 0),
+            S3Key_Image = "k3",
+            S3ETag_Image = "e3",
+            Sha256_Image = "s3",
+            FaceAttributes = "{}"
+        };
+
+        _context.Faces.AddRange(matchingFaces);
+        _context.Faces.Add(otherFace);
+
+        var matchingTags = new[]
+        {
+            new PhotoTag { Photo = matching, PhotoId = matching.Id, Tag = tag1, TagId = tag1.Id },
+            new PhotoTag { Photo = matching, PhotoId = matching.Id, Tag = tag2, TagId = tag2.Id }
+        };
+        var otherTag = new PhotoTag { Photo = other, PhotoId = other.Id, Tag = tag1, TagId = tag1.Id };
+
+        _context.PhotoTags.AddRange(matchingTags);
+        _context.PhotoTags.Add(otherTag);
+        await _context.SaveChangesAsync();
+
+        var filter = new FilterDto
+        {
+            Persons = new[] { person1.Id, person2.Id },
+            Tags = new[] { tag1.Id, tag2.Id }
+        };
+
+        var result = await _sut.Build(filter, new DummyCurrentUser())
+            .Select(p => p.Id)
+            .ToListAsync();
+
+        result.Should().Equal(matching.Id);
+    }
+
+    [Test]
+    public async Task Build_AppliesAclForNonAdminUsers()
+    {
+        var storageAllowed = new Storage { Id = 400, Name = "allowed", Folder = "fa" };
+        var storageDenied = new Storage { Id = 401, Name = "denied", Folder = "fd" };
+
+        var allowedPhoto = CreatePhoto(401, storageAllowed, "allowed-photo");
+
+        var deniedPhoto = CreatePhoto(402, storageDenied, "denied-photo");
+
+        _context.Storages.AddRange(storageAllowed, storageDenied);
+        _context.Photos.AddRange(allowedPhoto, deniedPhoto);
+        await _context.SaveChangesAsync();
+
+        var user = new TestCurrentUser(storageAllowed.Id);
+
+        var result = await _sut.Build(new FilterDto(), user)
+            .Select(p => p.Id)
+            .ToListAsync();
+
+        result.Should().Equal(allowedPhoto.Id);
+    }
+
+    [Test]
+    public void Build_WithCaption_AddsFreeTextExpression()
+    {
+        var storage = new Storage { Id = 500, Name = "s500", Folder = "f500" };
+        var photo = CreatePhoto(501, storage, "captioned");
+        photo.Captions.Add(new Caption { Id = 1, Text = "Sunset" });
+
+        _context.Storages.Add(storage);
+        _context.Photos.Add(photo);
+        _context.SaveChanges();
+
+        var filter = new FilterDto { Caption = "sun" };
+
+        var query = _sut.Build(filter, new DummyCurrentUser());
+
+        query.Expression.ToString().Should().Contain("FreeText");
+    }
+
+    private static Photo CreatePhoto(int id, Storage storage, string name, DateTime? takenDate = null)
+    {
+        return new Photo
+        {
+            Id = id,
+            Storage = storage,
+            StorageId = storage.Id,
+            Name = name,
+            TakenDate = takenDate,
+            AccentColor = string.Empty,
+            DominantColorBackground = string.Empty,
+            DominantColorForeground = string.Empty,
+            DominantColors = string.Empty,
+            ImageHash = string.Empty,
+            RelativePath = string.Empty,
+            S3Key_Preview = string.Empty,
+            S3ETag_Preview = string.Empty,
+            Sha256_Preview = string.Empty,
+            S3Key_Thumbnail = string.Empty,
+            S3ETag_Thumbnail = string.Empty,
+            Sha256_Thumbnail = string.Empty,
+            Captions = new List<Caption>(),
+            PhotoTags = new List<PhotoTag>(),
+            Faces = new List<Face>(),
+            Files = new List<File>()
+        };
+    }
+
+    private sealed class TestCurrentUser : ICurrentUser
+    {
+        public TestCurrentUser(int storageId)
+        {
+            AllowedStorageIds = new HashSet<int> { storageId };
+            AllowedPersonGroupIds = new HashSet<int>();
+            AllowedDateRanges = Array.Empty<(DateOnly From, DateOnly To)>();
+        }
+
+        public string UserId => "user";
+
+        public bool IsAdmin => false;
+
+        public IReadOnlySet<int> AllowedStorageIds { get; }
+
+        public IReadOnlySet<int> AllowedPersonGroupIds { get; }
+
+        public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; }
+
+        public bool CanSeeNsfw => true;
+    }
+}

--- a/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -192,6 +192,7 @@ public class ServiceCollectionExtensionsTests
         AssertScopedRegistration<IFaceStorageService, FaceStorageService>(services);
         AssertScopedRegistration<MinioObjectService, MinioObjectService>(services);
         AssertScopedRegistration<ISearchFilterNormalizer, SearchFilterNormalizer>(services);
+        AssertScopedRegistration<PhotoFilterSpecification, PhotoFilterSpecification>(services);
         AssertScopedRegistration<IPhotoService, PhotoService>(services);
         AssertScopedRegistration<ISearchReferenceDataService, SearchReferenceDataService>(services);
         AssertHttpClientRegistration<ITranslatorService, TranslatorService>(services);
@@ -205,6 +206,7 @@ public class ServiceCollectionExtensionsTests
             typeof(IFaceStorageService),
             typeof(MinioObjectService),
             typeof(ISearchFilterNormalizer),
+            typeof(PhotoFilterSpecification),
             typeof(IPhotoService),
             typeof(ISearchReferenceDataService));
 

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -100,6 +100,8 @@ namespace PhotoBank.UnitTests.Services
             var storageRepository = new Repository<Storage>(provider);
             var personGroupRepository = new Repository<PersonGroup>(provider);
 
+            var photoFilterSpecification = new PhotoFilterSpecification(context);
+
             var photoQueryService = new PhotoQueryService(
                 context,
                 photoRepository,
@@ -110,6 +112,7 @@ namespace PhotoBank.UnitTests.Services
                 new DummyCurrentUser(),
                 referenceDataService.Object,
                 normalizerMock.Object,
+                photoFilterSpecification,
                 minioClient.Object,
                 s3Options.Object);
 

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
@@ -163,6 +163,8 @@ public class PhotoServiceGetFacesPageAsyncTests
         var personGroupRepository = new Repository<PersonGroup>(provider);
         var s3Options = Options.Create(new S3Options { Bucket = "bucket", UrlExpirySeconds = 60 });
 
+        var photoFilterSpecification = new PhotoFilterSpecification(context);
+
         var photoQueryService = new PhotoQueryService(
             context,
             photoRepository,
@@ -173,6 +175,7 @@ public class PhotoServiceGetFacesPageAsyncTests
             new DummyCurrentUser(),
             referenceDataService.Object,
             normalizer.Object,
+            photoFilterSpecification,
             minioClient,
             s3Options);
 

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
@@ -118,6 +118,8 @@ namespace PhotoBank.UnitTests.Services
             var personGroupRepository = new Repository<PersonGroup>(provider);
             var s3Options = Options.Create(new S3Options());
 
+            var photoFilterSpecification = new PhotoFilterSpecification(context);
+
             var photoQueryService = new PhotoQueryService(
                 context,
                 photoRepository,
@@ -128,6 +130,7 @@ namespace PhotoBank.UnitTests.Services
                 currentUser,
                 referenceDataService.Object,
                 filterNormalizer.Object,
+                photoFilterSpecification,
                 minioClient.Object,
                 s3Options);
 

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -69,6 +69,8 @@ namespace PhotoBank.UnitTests.Services
             var storageRepository = new Repository<Storage>(provider);
             var personGroupRepository = new Repository<PersonGroup>(provider);
 
+            var photoFilterSpecification = new PhotoFilterSpecification(context);
+
             var photoQueryService = new PhotoQueryService(
                 context,
                 photoRepository,
@@ -79,6 +81,7 @@ namespace PhotoBank.UnitTests.Services
                 new DummyCurrentUser(),
                 referenceDataService.Object,
                 normalizer.Object,
+                photoFilterSpecification,
                 minioClient.Object,
                 s3Options.Object);
 


### PR DESCRIPTION
## Summary
- extract photo filtering logic into a dedicated PhotoFilterSpecification that handles ACL, faces, tags, and caption predicates
- inject the specification into PhotoQueryService and register it in DI while updating unit tests to use the new dependency
- add targeted unit coverage for the specification to ensure filtering combinations continue to work as expected

## Testing
- DOTNET_CLI_DISABLE_TERMINAL_LOGGER=1 dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --logger "console;verbosity=minimal" --filter PhotoFilterSpecificationTests

------
https://chatgpt.com/codex/tasks/task_e_68e22301f14483289b170fe5a335236e