### PR TITLE
feat: add ingestion and duplicate services for photos

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -6,6 +6,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Photos;
 using PhotoBank.Services.Photos.Admin;
 using PhotoBank.Services.Photos.Faces;
 using PhotoBank.Services.Photos.Queries;
@@ -13,6 +14,7 @@ using PhotoBank.Services.Search;
 using PhotoBank.Services.Translator;
 using Polly;
 using System;
+using System.IO.Abstractions;
 
 namespace PhotoBank.DependencyInjection;
 
@@ -22,6 +24,7 @@ public static partial class ServiceCollectionExtensions
     {
         services.AddLogging();
         services.AddMemoryCache();
+        services.AddSingleton<IFileSystem, FileSystem>();
         services.AddSingleton<IMinioClient>(sp =>
         {
             var opts = sp.GetRequiredService<IOptions<MinioOptions>>().Value;
@@ -39,6 +42,8 @@ public static partial class ServiceCollectionExtensions
         services.AddScoped<IPersonDirectoryService, PersonDirectoryService>();
         services.AddScoped<IPersonGroupService, PersonGroupService>();
         services.AddScoped<IFaceCatalogService, FaceCatalogService>();
+        services.AddScoped<IPhotoDuplicateFinder, PhotoDuplicateFinder>();
+        services.AddScoped<IPhotoIngestionService, PhotoIngestionService>();
         services.AddScoped<IPhotoAdminService, PhotoAdminService>();
         services.AddScoped<IPhotoService, PhotoService>();
         services.AddScoped<ISearchReferenceDataService, SearchReferenceDataService>();
@@ -53,6 +58,7 @@ public static partial class ServiceCollectionExtensions
         {
             services.AddOptions<TranslatorOptions>();
             services.AddOptions<MinioOptions>();
+            services.AddOptions<S3Options>();
         }
         services.AddHttpClient<ITranslatorService, TranslatorService>()
             .AddTransientHttpErrorPolicy(p => p.WaitAndRetryAsync(3, attempt => TimeSpan.FromMilliseconds(100 * attempt)));

--- a/backend/PhotoBank.Services/Api/PhotoService.cs
+++ b/backend/PhotoBank.Services/Api/PhotoService.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using PhotoBank.Services.Models;
+using PhotoBank.Services.Photos;
 using PhotoBank.Services.Photos.Admin;
 using PhotoBank.Services.Photos.Faces;
 using PhotoBank.Services.Photos.Queries;
@@ -40,20 +41,23 @@ public class PhotoService : IPhotoService
     private readonly IPersonDirectoryService _personDirectoryService;
     private readonly IPersonGroupService _personGroupService;
     private readonly IFaceCatalogService _faceCatalogService;
-    private readonly IPhotoAdminService _photoAdminService;
+    private readonly IPhotoDuplicateFinder _photoDuplicateFinder;
+    private readonly IPhotoIngestionService _photoIngestionService;
 
     public PhotoService(
         IPhotoQueryService photoQueryService,
         IPersonDirectoryService personDirectoryService,
         IPersonGroupService personGroupService,
         IFaceCatalogService faceCatalogService,
-        IPhotoAdminService photoAdminService)
+        IPhotoDuplicateFinder photoDuplicateFinder,
+        IPhotoIngestionService photoIngestionService)
     {
         _photoQueryService = photoQueryService;
         _personDirectoryService = personDirectoryService;
         _personGroupService = personGroupService;
         _faceCatalogService = faceCatalogService;
-        _photoAdminService = photoAdminService;
+        _photoDuplicateFinder = photoDuplicateFinder;
+        _photoIngestionService = photoIngestionService;
     }
 
     public Task<PageResponse<PhotoItemDto>> GetAllPhotosAsync(FilterDto filter, CancellationToken ct = default) =>
@@ -100,8 +104,8 @@ public class PhotoService : IPhotoService
     public Task UpdateFaceAsync(int faceId, int? personId) => _faceCatalogService.UpdateFaceAsync(faceId, personId);
 
     public Task<IEnumerable<PhotoItemDto>> FindDuplicatesAsync(int? id, string? hash, int threshold) =>
-        _photoQueryService.FindDuplicatesAsync(id, hash, threshold);
+        _photoDuplicateFinder.FindDuplicatesAsync(id, hash, threshold);
 
     public Task UploadPhotosAsync(IEnumerable<IFormFile> files, int storageId, string path) =>
-        _photoAdminService.UploadPhotosAsync(files, storageId, path);
+        _photoIngestionService.UploadAsync(files, storageId, path);
 }

--- a/backend/PhotoBank.Services/PhotoBank.Services.csproj
+++ b/backend/PhotoBank.Services/PhotoBank.Services.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.9" />
     <PackageReference Include="Minio" Version="6.0.5" />
     <PackageReference Include="MediatR" Version="13.0.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="21.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/PhotoBank.Services/Photos/Admin/IPhotoAdminService.cs
+++ b/backend/PhotoBank.Services/Photos/Admin/IPhotoAdminService.cs
@@ -1,12 +1,7 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
-using PhotoBank.DbContext.Models;
-using PhotoBank.Repositories;
+using PhotoBank.Services.Photos;
 
 namespace PhotoBank.Services.Photos.Admin;
 
@@ -17,62 +12,13 @@ public interface IPhotoAdminService
 
 public class PhotoAdminService : IPhotoAdminService
 {
-    private readonly IRepository<Storage> _storageRepository;
-    private readonly ILogger<PhotoAdminService> _logger;
+    private readonly IPhotoIngestionService _photoIngestionService;
 
-    public PhotoAdminService(IRepository<Storage> storageRepository, ILogger<PhotoAdminService> logger)
+    public PhotoAdminService(IPhotoIngestionService photoIngestionService)
     {
-        _storageRepository = storageRepository;
-        _logger = logger;
+        _photoIngestionService = photoIngestionService;
     }
 
-    public async Task UploadPhotosAsync(IEnumerable<IFormFile> files, int storageId, string path)
-    {
-        if (files == null || !files.Any())
-        {
-            _logger.LogDebug("No files provided for upload to storage {StorageId}", storageId);
-            return;
-        }
-
-        var storage = await _storageRepository.GetAsync(storageId);
-        if (storage == null)
-        {
-            throw new ArgumentException($"Storage {storageId} not found", nameof(storageId));
-        }
-
-        var targetPath = Path.Combine(storage.Folder, path ?? string.Empty);
-
-        if (!Directory.Exists(targetPath))
-        {
-            Directory.CreateDirectory(targetPath);
-        }
-
-        foreach (var file in files)
-        {
-            var destination = Path.Combine(targetPath, file.FileName);
-
-            if (System.IO.File.Exists(destination))
-            {
-                var existing = new FileInfo(destination);
-                if (existing.Length == file.Length)
-                {
-                    _logger.LogInformation("Skipping upload for {FileName} - identical file already exists in storage {StorageId}", file.FileName, storageId);
-                    continue;
-                }
-
-                var name = Path.GetFileNameWithoutExtension(file.FileName);
-                var extension = Path.GetExtension(file.FileName);
-                var index = 1;
-                do
-                {
-                    var newFileName = $"{name}_{index}{extension}";
-                    destination = Path.Combine(targetPath, newFileName);
-                    index++;
-                } while (System.IO.File.Exists(destination));
-            }
-
-            await using var stream = new FileStream(destination, FileMode.Create);
-            await file.CopyToAsync(stream);
-        }
-    }
+    public Task UploadPhotosAsync(IEnumerable<IFormFile> files, int storageId, string path) =>
+        _photoIngestionService.UploadAsync(files, storageId, path);
 }

--- a/backend/PhotoBank.Services/Photos/IPhotoDuplicateFinder.cs
+++ b/backend/PhotoBank.Services/Photos/IPhotoDuplicateFinder.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using ImageMagick;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Minio;
+using Minio.DataModel.Args;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services;
+using PhotoBank.Repositories;
+using PhotoBank.Services.Internal;
+using PhotoBank.Services.Models;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.Services.Photos;
+
+public interface IPhotoDuplicateFinder
+{
+    Task<IEnumerable<PhotoItemDto>> FindDuplicatesAsync(int? id, string? hash, int threshold, CancellationToken cancellationToken = default);
+}
+
+public sealed class PhotoDuplicateFinder : IPhotoDuplicateFinder
+{
+    private readonly IRepository<Photo> _photoRepository;
+    private readonly IMapper _mapper;
+    private readonly IMinioClient _minioClient;
+    private readonly S3Options _s3Options;
+    private readonly ILogger<PhotoDuplicateFinder> _logger;
+
+    public PhotoDuplicateFinder(
+        IRepository<Photo> photoRepository,
+        IMapper mapper,
+        IMinioClient minioClient,
+        IOptions<S3Options> s3Options,
+        ILogger<PhotoDuplicateFinder> logger)
+    {
+        _photoRepository = photoRepository;
+        _mapper = mapper;
+        _minioClient = minioClient;
+        _s3Options = s3Options?.Value ?? new S3Options();
+        _logger = logger;
+    }
+
+    public async Task<IEnumerable<PhotoItemDto>> FindDuplicatesAsync(int? id, string? hash, int threshold, CancellationToken cancellationToken = default)
+    {
+        if (id.HasValue)
+        {
+            hash = await _photoRepository.GetByCondition(p => p.Id == id.Value)
+                .AsNoTracking()
+                .Select(p => p.ImageHash)
+                .SingleOrDefaultAsync(cancellationToken);
+        }
+
+        if (string.IsNullOrEmpty(hash))
+        {
+            return Array.Empty<PhotoItemDto>();
+        }
+
+        var referenceHash = new PerceptualHash(hash);
+        var candidateIds = new List<int>();
+
+        await foreach (var photo in _photoRepository.GetAll().AsNoTracking()
+                           .Where(p => !id.HasValue || p.Id != id.Value)
+                           .Select(p => new { p.Id, p.ImageHash })
+                           .AsAsyncEnumerable())
+        {
+            if (ImageHashHelper.HammingDistance(referenceHash, photo.ImageHash) <= threshold)
+            {
+                candidateIds.Add(photo.Id);
+            }
+        }
+
+        var matchedIds = candidateIds.Distinct().ToArray();
+        if (matchedIds.Length == 0)
+        {
+            return Array.Empty<PhotoItemDto>();
+        }
+
+        var entities = await _photoRepository.GetAll().AsNoTracking()
+            .Where(p => matchedIds.Contains(p.Id))
+            .ToListAsync(cancellationToken);
+
+        var items = _mapper.Map<List<PhotoItemDto>>(entities);
+        await FillUrlsAsync(items, cancellationToken);
+
+        return items;
+    }
+
+    private async Task FillUrlsAsync(IEnumerable<PhotoItemDto> items, CancellationToken cancellationToken)
+    {
+        var tasks = items.Select(async dto =>
+        {
+            dto.ThumbnailUrl = await GetPresignedUrlAsync(dto.S3Key_Thumbnail, dto.Id, cancellationToken);
+        });
+
+        await Task.WhenAll(tasks);
+    }
+
+    private async Task<string?> GetPresignedUrlAsync(string? key, int? photoId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return null;
+        }
+
+        try
+        {
+            return await _minioClient.PresignedGetObjectAsync(new PresignedGetObjectArgs()
+                .WithBucket(_s3Options.Bucket)
+                .WithObject(key)
+                .WithExpiry(_s3Options.UrlExpirySeconds));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to generate presigned URL for photo {PhotoId} with key {S3Key}.", photoId, key);
+            return null;
+        }
+    }
+}

--- a/backend/PhotoBank.Services/Photos/IPhotoIngestionService.cs
+++ b/backend/PhotoBank.Services/Photos/IPhotoIngestionService.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Minio;
+using Minio.DataModel;
+using Minio.DataModel.Args;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+using PhotoBank.Services.Internal;
+using System.IO.Abstractions;
+
+namespace PhotoBank.Services.Photos;
+
+public interface IPhotoIngestionService
+{
+    Task UploadAsync(IEnumerable<IFormFile> files, int storageId, string? relativePath, CancellationToken cancellationToken = default);
+}
+
+public class PhotoIngestionService : IPhotoIngestionService
+{
+    private readonly IRepository<Storage> _storageRepository;
+    private readonly IMinioClient _minioClient;
+    private readonly S3Options _s3Options;
+    private readonly IFileSystem _fileSystem;
+    private readonly ILogger<PhotoIngestionService> _logger;
+
+    public PhotoIngestionService(
+        IRepository<Storage> storageRepository,
+        IMinioClient minioClient,
+        IOptions<S3Options> s3Options,
+        IFileSystem fileSystem,
+        ILogger<PhotoIngestionService> logger)
+    {
+        _storageRepository = storageRepository;
+        _minioClient = minioClient;
+        _s3Options = s3Options?.Value ?? new S3Options();
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    public async Task UploadAsync(IEnumerable<IFormFile> files, int storageId, string? relativePath, CancellationToken cancellationToken = default)
+    {
+        if (files == null || !files.Any())
+        {
+            _logger.LogDebug("No files provided for upload to storage {StorageId}", storageId);
+            return;
+        }
+
+        var storage = await _storageRepository.GetAsync(storageId);
+        if (storage == null)
+        {
+            throw new ArgumentException($"Storage {storageId} not found", nameof(storageId));
+        }
+
+        if (IsObjectStorageLocation(storage.Folder, out var bucket, out var prefix))
+        {
+            var resolvedBucket = string.IsNullOrWhiteSpace(bucket) ? _s3Options.Bucket : bucket;
+            await UploadToObjectStorageAsync(storageId, resolvedBucket, prefix, files, relativePath, cancellationToken);
+            return;
+        }
+
+        await UploadToFileSystemAsync(storageId, storage.Folder, files, relativePath, cancellationToken);
+    }
+
+    private async Task UploadToFileSystemAsync(
+        int storageId,
+        string? root,
+        IEnumerable<IFormFile> files,
+        string? relativePath,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            throw new InvalidOperationException($"Storage {storageId} does not have a folder configured.");
+        }
+
+        var targetPath = string.IsNullOrEmpty(relativePath)
+            ? root
+            : _fileSystem.Path.Combine(root, relativePath);
+
+        if (!_fileSystem.Directory.Exists(targetPath))
+        {
+            _fileSystem.Directory.CreateDirectory(targetPath);
+        }
+
+        foreach (var file in files)
+        {
+            var destination = _fileSystem.Path.Combine(targetPath, file.FileName);
+
+            if (_fileSystem.File.Exists(destination))
+            {
+                var existing = _fileSystem.FileInfo.New(destination);
+                if (existing.Length == file.Length)
+                {
+                    _logger.LogInformation(
+                        "Skipping upload for {FileName} - identical file already exists in storage {StorageId}",
+                        file.FileName,
+                        storageId);
+                    continue;
+                }
+
+                var baseName = _fileSystem.Path.GetFileNameWithoutExtension(file.FileName);
+                var extension = _fileSystem.Path.GetExtension(file.FileName);
+                var index = 1;
+                string candidate;
+                do
+                {
+                    candidate = _fileSystem.Path.Combine(targetPath, $"{baseName}_{index}{extension}");
+                    index++;
+                } while (_fileSystem.File.Exists(candidate));
+
+                destination = candidate;
+            }
+
+            await using var stream = _fileSystem.File.Create(destination);
+            await file.CopyToAsync(stream, cancellationToken);
+        }
+    }
+
+    private async Task UploadToObjectStorageAsync(
+        int storageId,
+        string bucket,
+        string? basePrefix,
+        IEnumerable<IFormFile> files,
+        string? relativePath,
+        CancellationToken cancellationToken)
+    {
+        var prefix = CombinePrefixes(basePrefix, relativePath);
+
+        foreach (var file in files)
+        {
+            var key = BuildObjectKey(prefix, file.FileName);
+            var candidateKey = key;
+            var index = 1;
+
+            while (true)
+            {
+                var stat = await TryStatObjectAsync(bucket, candidateKey, cancellationToken);
+                if (stat == null)
+                {
+                    break;
+                }
+
+                if (stat.Size == file.Length)
+                {
+                    _logger.LogInformation(
+                        "Skipping upload for {FileName} - identical object already exists in bucket {Bucket}",
+                        file.FileName,
+                        bucket);
+                    goto ContinueWithNextFile;
+                }
+
+                var baseName = Path.GetFileNameWithoutExtension(file.FileName);
+                var extension = Path.GetExtension(file.FileName);
+                candidateKey = BuildObjectKey(prefix, $"{baseName}_{index}{extension}");
+                index++;
+            }
+
+            await using (var stream = file.OpenReadStream())
+            {
+                await _minioClient.PutObjectAsync(new PutObjectArgs()
+                        .WithBucket(bucket)
+                        .WithObject(candidateKey)
+                        .WithStreamData(stream)
+                        .WithObjectSize(file.Length)
+                        .WithContentType(string.IsNullOrWhiteSpace(file.ContentType)
+                            ? "application/octet-stream"
+                            : file.ContentType),
+                    cancellationToken);
+            }
+
+            _logger.LogInformation(
+                "Uploaded {FileName} to bucket {Bucket} with key {ObjectKey} for storage {StorageId}",
+                file.FileName,
+                bucket,
+                candidateKey,
+                storageId);
+
+        ContinueWithNextFile: ;
+        }
+    }
+
+    private async Task<ObjectStat?> TryStatObjectAsync(string bucket, string objectKey, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _minioClient.StatObjectAsync(new StatObjectArgs()
+                .WithBucket(bucket)
+                .WithObject(objectKey), cancellationToken);
+        }
+        catch (Exception ex) when (IsNotFound(ex))
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to inspect object {ObjectKey} in bucket {Bucket}", objectKey, bucket);
+            return null;
+        }
+    }
+
+    private bool IsObjectStorageLocation(string? folder, out string bucket, out string? prefix)
+    {
+        bucket = string.Empty;
+        prefix = null;
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            bucket = _s3Options.Bucket;
+            return false;
+        }
+
+        if (Uri.TryCreate(folder, UriKind.Absolute, out var uri) &&
+            (string.Equals(uri.Scheme, "s3", StringComparison.OrdinalIgnoreCase) ||
+             string.Equals(uri.Scheme, "minio", StringComparison.OrdinalIgnoreCase)))
+        {
+            bucket = string.IsNullOrWhiteSpace(uri.Host) ? string.Empty : uri.Host;
+            prefix = uri.AbsolutePath.Trim('/');
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsNotFound(Exception ex)
+    {
+        if (ex.GetType().Name.Contains("NotFound", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string CombinePrefixes(string? basePrefix, string? relativePath)
+    {
+        var segments = new List<string>();
+        if (!string.IsNullOrWhiteSpace(basePrefix))
+        {
+            segments.Add(basePrefix.Trim('/'));
+        }
+
+        if (!string.IsNullOrWhiteSpace(relativePath))
+        {
+            segments.Add(relativePath.Replace('\\', '/').Trim('/'));
+        }
+
+        var prefix = string.Join('/', segments.Where(s => !string.IsNullOrWhiteSpace(s)));
+        return prefix;
+    }
+
+    private string BuildObjectKey(string prefix, string fileName)
+    {
+        var normalized = fileName.Replace('\\', '/');
+        if (string.IsNullOrWhiteSpace(prefix))
+        {
+            return normalized;
+        }
+
+        return string.Join('/', new[] { prefix.TrimEnd('/'), normalized.TrimStart('/') });
+    }
+}

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -15,6 +15,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Photos;
 using PhotoBank.Services.Photos.Admin;
 using PhotoBank.Services.Photos.Faces;
 using PhotoBank.Services.Photos.Queries;
@@ -103,16 +104,20 @@ public class PersonGroupServiceTests
             NullLogger<FaceCatalogService>.Instance,
             s3Options);
 
-        var photoAdminService = new PhotoAdminService(
-            storageRepository,
-            NullLogger<PhotoAdminService>.Instance);
+        var duplicateFinder = new Mock<IPhotoDuplicateFinder>();
+        duplicateFinder
+            .Setup(f => f.FindDuplicatesAsync(It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PhotoItemDto>());
+
+        var ingestionService = new Mock<IPhotoIngestionService>();
 
         _service = new PhotoService(
             photoQueryService,
             personDirectoryService,
             personGroupService,
             faceCatalogService,
-            photoAdminService);
+            duplicateFinder.Object,
+            ingestionService.Object);
     }
 
     [TearDown]

--- a/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -42,6 +43,7 @@ using PhotoBank.Services.FaceRecognition.Aws;
 using PhotoBank.Services.FaceRecognition.Azure;
 using PhotoBank.Services.FaceRecognition.Local;
 using PhotoBank.Services.FaceRecognition.Abstractions;
+using PhotoBank.Services.Photos;
 using PhotoBank.Services.Recognition;
 using PhotoBank.Services.Search;
 using PhotoBank.Services.Translator;
@@ -189,10 +191,13 @@ public class ServiceCollectionExtensionsTests
 
         AssertFactoryRegistration<IMinioClient>(services, "Singleton");
         AssertScopedRegistration(typeof(IRepository<>), typeof(Repository<>), services);
+        AssertSingletonRegistration<IFileSystem, FileSystem>(services);
         AssertScopedRegistration<IFaceStorageService, FaceStorageService>(services);
         AssertScopedRegistration<MinioObjectService, MinioObjectService>(services);
         AssertScopedRegistration<ISearchFilterNormalizer, SearchFilterNormalizer>(services);
         AssertScopedRegistration<PhotoFilterSpecification, PhotoFilterSpecification>(services);
+        AssertScopedRegistration<IPhotoDuplicateFinder, PhotoDuplicateFinder>(services);
+        AssertScopedRegistration<IPhotoIngestionService, PhotoIngestionService>(services);
         AssertScopedRegistration<IPhotoService, PhotoService>(services);
         AssertScopedRegistration<ISearchReferenceDataService, SearchReferenceDataService>(services);
         AssertHttpClientRegistration<ITranslatorService, TranslatorService>(services);
@@ -207,11 +212,15 @@ public class ServiceCollectionExtensionsTests
             typeof(MinioObjectService),
             typeof(ISearchFilterNormalizer),
             typeof(PhotoFilterSpecification),
+            typeof(IPhotoDuplicateFinder),
+            typeof(IPhotoIngestionService),
             typeof(IPhotoService),
             typeof(ISearchReferenceDataService));
 
         using var provider = services.BuildServiceProvider();
         provider.GetRequiredService<IMinioClient>().Should().NotBeNull();
+        provider.GetRequiredService<IPhotoDuplicateFinder>().Should().NotBeNull();
+        provider.GetRequiredService<IPhotoIngestionService>().Should().NotBeNull();
         provider.GetRequiredService<IMediator>().Should().NotBeNull();
     }
 

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetAllPhotosAsyncTests.cs
@@ -17,6 +17,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Photos;
 using PhotoBank.Services.Photos.Admin;
 using PhotoBank.Services.Photos.Faces;
 using PhotoBank.Services.Photos.Queries;
@@ -136,16 +137,20 @@ namespace PhotoBank.UnitTests.Services
                 NullLogger<FaceCatalogService>.Instance,
                 s3Options.Object);
 
-            var photoAdminService = new PhotoAdminService(
-                storageRepository,
-                NullLogger<PhotoAdminService>.Instance);
+            var duplicateFinder = new Mock<IPhotoDuplicateFinder>();
+            duplicateFinder
+                .Setup(f => f.FindDuplicatesAsync(It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<PhotoItemDto>());
+
+            var ingestionService = new Mock<IPhotoIngestionService>();
 
             return new PhotoService(
                 photoQueryService,
                 personDirectoryService,
                 personGroupService,
                 faceCatalogService,
-                photoAdminService);
+                duplicateFinder.Object,
+                ingestionService.Object);
         }
 
         [Test]

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
@@ -18,6 +18,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Photos;
 using PhotoBank.Services.Photos.Admin;
 using PhotoBank.Services.Photos.Faces;
 using PhotoBank.Services.Photos.Queries;
@@ -199,15 +200,19 @@ public class PhotoServiceGetFacesPageAsyncTests
             NullLogger<FaceCatalogService>.Instance,
             s3Options);
 
-        var photoAdminService = new PhotoAdminService(
-            storageRepository,
-            NullLogger<PhotoAdminService>.Instance);
+        var duplicateFinder = new Mock<IPhotoDuplicateFinder>();
+        duplicateFinder
+            .Setup(f => f.FindDuplicatesAsync(It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PhotoItemDto>());
+
+        var ingestionService = new Mock<IPhotoIngestionService>();
 
         return new PhotoService(
             photoQueryService,
             personDirectoryService,
             personGroupService,
             faceCatalogService,
-            photoAdminService);
+            duplicateFinder.Object,
+            ingestionService.Object);
     }
 }

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
@@ -16,6 +16,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Photos;
 using PhotoBank.Services.Photos.Admin;
 using PhotoBank.Services.Photos.Faces;
 using PhotoBank.Services.Photos.Queries;
@@ -154,16 +155,20 @@ namespace PhotoBank.UnitTests.Services
                 NullLogger<FaceCatalogService>.Instance,
                 s3Options);
 
-            var photoAdminService = new PhotoAdminService(
-                storageRepository,
-                NullLogger<PhotoAdminService>.Instance);
+            var duplicateFinder = new Mock<IPhotoDuplicateFinder>();
+            duplicateFinder
+                .Setup(f => f.FindDuplicatesAsync(It.IsAny<int?>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<PhotoItemDto>());
+
+            var ingestionService = new Mock<IPhotoIngestionService>();
 
             var service = new PhotoService(
                 photoQueryService,
                 personDirectoryService,
                 personGroupService,
                 faceCatalogService,
-                photoAdminService);
+                duplicateFinder.Object,
+                ingestionService.Object);
 
             // Act
             var result = await service.GetPhotoAsync(photo.Id);


### PR DESCRIPTION
## Summary
- add dedicated photo ingestion service with filesystem and S3 support
- introduce photo duplicate finder service and refactor photo query logic
- update PhotoService, DI registrations, and unit tests to use new abstractions

## Testing
- dotnet test PhotoBank.Backend.sln *(fails: Docker daemon unavailable for integration tests)*
- dotnet test --no-build PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --logger "console;verbosity=minimal" *(fails: logger failure due to output limits)*
- dotnet test --no-build PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --filter FullyQualifiedName~PhotoServiceUploadTests *(pass)*

------
https://chatgpt.com/codex/tasks/task_e_68e227c973488328bca9ae2fa5a68f1e