### PR TITLE
feat: centralize reference data caching

### DIFF
--- a/backend/PhotoBank.Services/Photos/Admin/IPersonDirectoryService.cs
+++ b/backend/PhotoBank.Services/Photos/Admin/IPersonDirectoryService.cs
@@ -66,6 +66,6 @@ public class PersonDirectoryService : IPersonDirectoryService
     private void InvalidatePersonsCache()
     {
         _logger.LogDebug("Invalidating persons cache");
-        _searchReferenceDataService.InvalidatePersonsCache();
+        _searchReferenceDataService.InvalidatePersons();
     }
 }

--- a/backend/PhotoBank.Services/Search/ISearchReferenceDataService.cs
+++ b/backend/PhotoBank.Services/Search/ISearchReferenceDataService.cs
@@ -9,5 +9,10 @@ public interface ISearchReferenceDataService
 {
     Task<IReadOnlyList<PersonDto>> GetPersonsAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<TagDto>> GetTagsAsync(CancellationToken cancellationToken = default);
-    void InvalidatePersonsCache();
+    Task<IReadOnlyList<PathDto>> GetPathsAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<StorageDto>> GetStoragesAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<PersonGroupDto>> GetPersonGroupsAsync(CancellationToken cancellationToken = default);
+    void InvalidatePersons();
+    void InvalidatePersonGroups();
+    void InvalidateStorages();
 }

--- a/backend/PhotoBank.Services/Search/SearchReferenceDataService.cs
+++ b/backend/PhotoBank.Services/Search/SearchReferenceDataService.cs
@@ -19,50 +19,43 @@ public sealed class SearchReferenceDataService : ISearchReferenceDataService
 {
     private readonly IRepository<Person> _personRepository;
     private readonly IRepository<Tag> _tagRepository;
+    private readonly IRepository<Photo> _photoRepository;
+    private readonly IRepository<Storage> _storageRepository;
+    private readonly IRepository<PersonGroup> _personGroupRepository;
     private readonly ICurrentUser _currentUser;
     private readonly IMemoryCache _cache;
     private readonly IMapper _mapper;
 
-    private readonly Lazy<Task<IReadOnlyList<PersonDto>>> _persons;
+    private Lazy<Task<IReadOnlyList<PersonDto>>> _persons;
     private readonly Lazy<Task<IReadOnlyList<TagDto>>> _tags;
+    private Lazy<Task<IReadOnlyList<PathDto>>> _paths;
+    private Lazy<Task<IReadOnlyList<StorageDto>>> _storages;
+    private Lazy<Task<IReadOnlyList<PersonGroupDto>>> _personGroups;
 
     public SearchReferenceDataService(
         IRepository<Person> personRepository,
         IRepository<Tag> tagRepository,
+        IRepository<Photo> photoRepository,
+        IRepository<Storage> storageRepository,
+        IRepository<PersonGroup> personGroupRepository,
         ICurrentUser currentUser,
         IMemoryCache cache,
         IMapper mapper)
     {
         _personRepository = personRepository;
         _tagRepository = tagRepository;
+        _photoRepository = photoRepository;
+        _storageRepository = storageRepository;
+        _personGroupRepository = personGroupRepository;
         _currentUser = currentUser;
         _cache = cache;
         _mapper = mapper;
 
-        _persons = new Lazy<Task<IReadOnlyList<PersonDto>>>(() =>
-            _cache.GetOrCreateAsync(CacheKeys.Persons(_currentUser), async () =>
-            {
-                var query = _personRepository.GetAll()
-                    .AsNoTracking()
-                    .MaybeApplyAcl(_currentUser);
-
-                var items = await query
-                    .OrderBy(p => p.Name).ThenBy(p => p.Id)
-                    .ProjectTo<PersonDto>(_mapper.ConfigurationProvider)
-                    .ToListAsync();
-                return (IReadOnlyList<PersonDto>)items;
-            }));
-
-        _tags = new Lazy<Task<IReadOnlyList<TagDto>>>(() =>
-            _cache.GetOrCreateAsync(CacheKeys.Tags, async () =>
-            {
-                var items = await _tagRepository.GetAll()
-                    .AsNoTracking()
-                    .OrderBy(t => t.Name).ThenBy(t => t.Id)
-                    .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
-                    .ToListAsync();
-                return (IReadOnlyList<TagDto>)items;
-            }));
+        _persons = CreatePersonsLazy();
+        _tags = CreateTagsLazy();
+        _paths = CreatePathsLazy();
+        _storages = CreateStoragesLazy();
+        _personGroups = CreatePersonGroupsLazy();
     }
 
     public Task<IReadOnlyList<PersonDto>> GetPersonsAsync(CancellationToken cancellationToken = default)
@@ -85,9 +78,143 @@ public sealed class SearchReferenceDataService : ISearchReferenceDataService
         return _tags.Value;
     }
 
-    public void InvalidatePersonsCache()
+    public Task<IReadOnlyList<PathDto>> GetPathsAsync(CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<PathDto>>(cancellationToken);
+        }
+
+        return _paths.Value;
+    }
+
+    public Task<IReadOnlyList<StorageDto>> GetStoragesAsync(CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<StorageDto>>(cancellationToken);
+        }
+
+        return _storages.Value;
+    }
+
+    public Task<IReadOnlyList<PersonGroupDto>> GetPersonGroupsAsync(CancellationToken cancellationToken = default)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<PersonGroupDto>>(cancellationToken);
+        }
+
+        return _personGroups.Value;
+    }
+
+    public void InvalidatePersons()
     {
         _cache.Remove(CacheKeys.PersonsAll);
         _cache.Remove(CacheKeys.PersonsOf(_currentUser.UserId));
+        _persons = CreatePersonsLazy();
     }
+
+    public void InvalidatePersonGroups()
+    {
+        _cache.Remove(CacheKeys.PersonGroups);
+        _personGroups = CreatePersonGroupsLazy();
+    }
+
+    public void InvalidateStorages()
+    {
+        _cache.Remove(CacheKeys.StoragesAll);
+        _cache.Remove(CacheKeys.StoragesOf(_currentUser.UserId));
+        _cache.Remove(CacheKeys.PathsAll);
+        _cache.Remove(CacheKeys.PathsOf(_currentUser.UserId));
+        _storages = CreateStoragesLazy();
+        _paths = CreatePathsLazy();
+    }
+
+    private Lazy<Task<IReadOnlyList<PersonDto>>> CreatePersonsLazy() => new(() =>
+        _cache.GetOrCreateAsync(CacheKeys.Persons(_currentUser), async _ =>
+        {
+            var query = _personRepository.GetAll()
+                .AsNoTracking()
+                .MaybeApplyAcl(_currentUser);
+
+            var items = await query
+                .OrderBy(p => p.Name)
+                .ThenBy(p => p.Id)
+                .ProjectTo<PersonDto>(_mapper.ConfigurationProvider)
+                .ToListAsync();
+
+            return (IReadOnlyList<PersonDto>)items;
+        })!);
+
+    private Lazy<Task<IReadOnlyList<TagDto>>> CreateTagsLazy() => new(() =>
+        _cache.GetOrCreateAsync(CacheKeys.Tags, async _ =>
+        {
+            var items = await _tagRepository.GetAll()
+                .AsNoTracking()
+                .OrderBy(t => t.Name)
+                .ThenBy(t => t.Id)
+                .ProjectTo<TagDto>(_mapper.ConfigurationProvider)
+                .ToListAsync();
+
+            return (IReadOnlyList<TagDto>)items;
+        })!);
+
+    private Lazy<Task<IReadOnlyList<PathDto>>> CreatePathsLazy() => new(() =>
+        _cache.GetOrCreateAsync(CacheKeys.Paths(_currentUser), async _ =>
+        {
+            var query = _photoRepository.GetAll()
+                .AsNoTracking()
+                .MaybeApplyAcl(_currentUser)
+                .Where(p => p.RelativePath != null);
+
+            var paths = await query
+                .Select(p => new { p.StorageId, p.RelativePath })
+                .Distinct()
+                .OrderBy(p => p.StorageId)
+                .ThenBy(p => p.RelativePath)
+                .ToListAsync();
+
+            return (IReadOnlyList<PathDto>)paths
+                .Select(p => new PathDto
+                {
+                    StorageId = p.StorageId,
+                    Path = p.RelativePath!
+                })
+                .ToList();
+        })!);
+
+    private Lazy<Task<IReadOnlyList<StorageDto>>> CreateStoragesLazy() => new(() =>
+        _cache.GetOrCreateAsync(CacheKeys.Storages(_currentUser), async _ =>
+        {
+            var query = _storageRepository.GetAll()
+                .AsNoTracking()
+                .MaybeApplyAcl(_currentUser);
+
+            var items = await query
+                .OrderBy(p => p.Name)
+                .ThenBy(p => p.Id)
+                .ProjectTo<StorageDto>(_mapper.ConfigurationProvider)
+                .ToListAsync();
+
+            return (IReadOnlyList<StorageDto>)items;
+        })!);
+
+    private Lazy<Task<IReadOnlyList<PersonGroupDto>>> CreatePersonGroupsLazy() => new(() =>
+        _cache.GetOrCreateAsync(CacheKeys.PersonGroups, async _ =>
+        {
+            var items = await _personGroupRepository.GetAll()
+                .AsNoTracking()
+                .OrderBy(pg => pg.Name)
+                .ThenBy(pg => pg.Id)
+                .ProjectTo<PersonGroupDto>(_mapper.ConfigurationProvider)
+                .ToListAsync();
+
+            foreach (var group in items)
+            {
+                group.Persons ??= [];
+            }
+
+            return (IReadOnlyList<PersonGroupDto>)items;
+        })!);
 }

--- a/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/PersonGroupServiceTests.cs
@@ -56,14 +56,12 @@ public class PersonGroupServiceTests
             .Setup(n => n.NormalizeAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((FilterDto f, CancellationToken _) => f);
 
-        var memoryCache = _provider.GetRequiredService<IMemoryCache>();
         var mapper = _provider.GetRequiredService<IMapper>();
         var currentUser = _provider.GetRequiredService<ICurrentUser>();
         var referenceDataService = _provider.GetRequiredService<ISearchReferenceDataService>();
         var photoRepository = _provider.GetRequiredService<IRepository<Photo>>();
         var personRepository = _provider.GetRequiredService<IRepository<Person>>();
         var faceRepository = _provider.GetRequiredService<IRepository<Face>>();
-        var storageRepository = _provider.GetRequiredService<IRepository<Storage>>();
         var personGroupRepository = _provider.GetRequiredService<IRepository<PersonGroup>>();
         var minioClient = new Mock<IMinioClient>();
         var s3Options = Options.Create(new S3Options());
@@ -73,9 +71,7 @@ public class PersonGroupServiceTests
         var photoQueryService = new PhotoQueryService(
             db,
             photoRepository,
-            storageRepository,
             mapper,
-            memoryCache,
             NullLogger<PhotoQueryService>.Instance,
             currentUser,
             referenceDataService,
@@ -94,7 +90,7 @@ public class PersonGroupServiceTests
             db,
             personGroupRepository,
             mapper,
-            memoryCache,
+            referenceDataService,
             NullLogger<PersonGroupService>.Instance);
 
         var faceCatalogService = new FaceCatalogService(

--- a/backend/PhotoBank.UnitTests/SearchReferenceDataServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/SearchReferenceDataServiceTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using PhotoBank.AccessControl;
+using PhotoBank.DbContext.DbContext;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+using PhotoBank.Services;
+using PhotoBank.Services.Internal;
+using PhotoBank.Services.Search;
+using PhotoBank.ViewModel.Dto;
+
+namespace PhotoBank.UnitTests;
+
+[TestFixture]
+public class SearchReferenceDataServiceTests
+{
+    [Test]
+    public async Task InvalidateStorages_ShouldRefreshStoragesAndPathsWithAclAndOrdering()
+    {
+        using var fixture = new ReferenceServiceFixture(isAdmin: false, allowedStorages: new[] { 1 });
+        var context = fixture.Context;
+        var service = fixture.Service;
+        var user = fixture.User;
+
+        var storage1 = new Storage { Id = 1, Name = "B Storage", Folder = "root1" };
+        context.Storages.Add(storage1);
+        context.Photos.AddRange(
+            CreatePhoto(1, storage1, "photo-1", "folder/b"),
+            CreatePhoto(2, storage1, "photo-2", "folder/a"));
+        await context.SaveChangesAsync();
+
+        var storagesInitial = await service.GetStoragesAsync();
+        storagesInitial.Select(s => s.Id).Should().Equal(1);
+        storagesInitial.Select(s => s.Name).Should().Equal("B Storage");
+
+        var pathsInitial = await service.GetPathsAsync();
+        pathsInitial.Select(p => (p.StorageId, p.Path)).Should().Equal((1, "folder/a"), (1, "folder/b"));
+
+        var storage2 = new Storage { Id = 2, Name = "A Storage", Folder = "root2" };
+        context.Storages.Add(storage2);
+        context.Photos.AddRange(
+            CreatePhoto(3, storage1, "photo-3", "folder/c"),
+            CreatePhoto(4, storage2, "photo-4", "alpha/path"));
+        await context.SaveChangesAsync();
+        user.AllowStorage(2);
+
+        var storagesCached = await service.GetStoragesAsync();
+        storagesCached.Select(s => s.Id).Should().Equal(1);
+
+        var pathsCached = await service.GetPathsAsync();
+        pathsCached.Select(p => p.Path).Should().Equal("folder/a", "folder/b");
+
+        service.InvalidateStorages();
+
+        var storagesUpdated = await service.GetStoragesAsync();
+        storagesUpdated.Select(s => (s.Id, s.Name))
+            .Should()
+            .Equal((2, "A Storage"), (1, "B Storage"));
+
+        var pathsUpdated = await service.GetPathsAsync();
+        pathsUpdated.Select(p => (p.StorageId, p.Path))
+            .Should()
+            .Equal((1, "folder/a"), (1, "folder/b"), (1, "folder/c"), (2, "alpha/path"));
+    }
+
+    [Test]
+    public async Task GetPersonGroupsAsync_ShouldReturnSortedAndRefreshOnInvalidation()
+    {
+        using var fixture = new ReferenceServiceFixture(isAdmin: true, allowedStorages: Array.Empty<int>());
+        var context = fixture.Context;
+        var service = fixture.Service;
+
+        context.PersonGroups.AddRange(
+            new PersonGroup { Id = 1, Name = "Zeta" },
+            new PersonGroup { Id = 2, Name = "Alpha" });
+        await context.SaveChangesAsync();
+
+        var groups = await service.GetPersonGroupsAsync();
+        groups.Select(g => g.Name).Should().Equal("Alpha", "Zeta");
+
+        context.PersonGroups.Add(new PersonGroup { Id = 3, Name = "Beta" });
+        await context.SaveChangesAsync();
+
+        var cached = await service.GetPersonGroupsAsync();
+        cached.Select(g => g.Name).Should().Equal("Alpha", "Zeta");
+
+        service.InvalidatePersonGroups();
+
+        var refreshed = await service.GetPersonGroupsAsync();
+        refreshed.Select(g => g.Name).Should().Equal("Alpha", "Beta", "Zeta");
+    }
+
+    private static Photo CreatePhoto(int id, Storage storage, string name, string relativePath) => new()
+    {
+        Id = id,
+        StorageId = storage.Id,
+        Storage = storage,
+        Name = name,
+        RelativePath = relativePath,
+        AccentColor = string.Empty,
+        DominantColorBackground = string.Empty,
+        DominantColorForeground = string.Empty,
+        DominantColors = string.Empty,
+        S3Key_Preview = string.Empty,
+        S3ETag_Preview = string.Empty,
+        Sha256_Preview = string.Empty,
+        S3Key_Thumbnail = string.Empty,
+        S3ETag_Thumbnail = string.Empty,
+        Sha256_Thumbnail = string.Empty,
+        ImageHash = string.Empty,
+        Captions = new List<Caption>(),
+        PhotoTags = new List<PhotoTag>(),
+        PhotoCategories = new List<PhotoCategory>(),
+        ObjectProperties = new List<ObjectProperty>(),
+        Faces = new List<Face>(),
+        Files = new List<File>()
+    };
+
+    private sealed class ReferenceServiceFixture : IDisposable
+    {
+        private readonly ServiceProvider _provider;
+        private readonly IServiceScope _scope;
+
+        public ReferenceServiceFixture(bool isAdmin, IEnumerable<int> allowedStorages)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddDbContext<PhotoBankDbContext>(o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+            services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
+            services.AddAutoMapper(cfg => cfg.AddProfile<MappingProfile>());
+            services.AddMemoryCache();
+
+            _provider = services.BuildServiceProvider();
+            _scope = _provider.CreateScope();
+
+            Context = _scope.ServiceProvider.GetRequiredService<PhotoBankDbContext>();
+            Cache = _scope.ServiceProvider.GetRequiredService<IMemoryCache>();
+            var mapper = _scope.ServiceProvider.GetRequiredService<IMapper>();
+            var personRepository = _scope.ServiceProvider.GetRequiredService<IRepository<Person>>();
+            var tagRepository = _scope.ServiceProvider.GetRequiredService<IRepository<Tag>>();
+            var photoRepository = _scope.ServiceProvider.GetRequiredService<IRepository<Photo>>();
+            var storageRepository = _scope.ServiceProvider.GetRequiredService<IRepository<Storage>>();
+            var personGroupRepository = _scope.ServiceProvider.GetRequiredService<IRepository<PersonGroup>>();
+
+            User = new TestCurrentUser(isAdmin ? "admin" : "user", isAdmin, allowedStorages);
+            Service = new SearchReferenceDataService(
+                personRepository,
+                tagRepository,
+                photoRepository,
+                storageRepository,
+                personGroupRepository,
+                User,
+                Cache,
+                mapper);
+        }
+
+        public SearchReferenceDataService Service { get; }
+        public PhotoBankDbContext Context { get; }
+        public TestCurrentUser User { get; }
+        public IMemoryCache Cache { get; }
+
+        public void Dispose()
+        {
+            _scope.Dispose();
+            _provider.Dispose();
+        }
+    }
+
+    private sealed class TestCurrentUser : ICurrentUser
+    {
+        private readonly HashSet<int> _allowedStorageIds;
+        private readonly HashSet<int> _allowedPersonGroupIds = [];
+
+        public TestCurrentUser(string userId, bool isAdmin, IEnumerable<int> allowedStorages)
+        {
+            UserId = userId;
+            IsAdmin = isAdmin;
+            _allowedStorageIds = new HashSet<int>(allowedStorages);
+        }
+
+        public string UserId { get; }
+        public bool IsAdmin { get; }
+        public IReadOnlySet<int> AllowedStorageIds => _allowedStorageIds;
+        public IReadOnlySet<int> AllowedPersonGroupIds => _allowedPersonGroupIds;
+        public IReadOnlyList<(DateOnly From, DateOnly To)> AllowedDateRanges { get; } = new List<(DateOnly, DateOnly)>();
+        public bool CanSeeNsfw => true;
+
+        public void AllowStorage(int storageId) => _allowedStorageIds.Add(storageId);
+    }
+}

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
@@ -1,7 +1,6 @@
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -150,17 +149,24 @@ public class PhotoServiceGetFacesPageAsyncTests
         referenceDataService
             .Setup(s => s.GetTagsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(Array.Empty<TagDto>());
+        referenceDataService
+            .Setup(s => s.GetStoragesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<StorageDto>());
+        referenceDataService
+            .Setup(s => s.GetPathsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PathDto>());
+        referenceDataService
+            .Setup(s => s.GetPersonGroupsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PersonGroupDto>());
 
         var normalizer = new Mock<ISearchFilterNormalizer>();
         normalizer
             .Setup(n => n.NormalizeAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((FilterDto f, CancellationToken _) => f);
 
-        var memoryCache = new MemoryCache(new MemoryCacheOptions());
         var photoRepository = new Repository<Photo>(provider);
         var personRepository = new Repository<Person>(provider);
         var faceRepository = new Repository<Face>(provider);
-        var storageRepository = new Repository<Storage>(provider);
         var personGroupRepository = new Repository<PersonGroup>(provider);
         var s3Options = Options.Create(new S3Options { Bucket = "bucket", UrlExpirySeconds = 60 });
 
@@ -169,9 +175,7 @@ public class PhotoServiceGetFacesPageAsyncTests
         var photoQueryService = new PhotoQueryService(
             context,
             photoRepository,
-            storageRepository,
             _mapper,
-            memoryCache,
             NullLogger<PhotoQueryService>.Instance,
             new DummyCurrentUser(),
             referenceDataService.Object,
@@ -190,7 +194,7 @@ public class PhotoServiceGetFacesPageAsyncTests
             context,
             personGroupRepository,
             _mapper,
-            memoryCache,
+            referenceDataService.Object,
             NullLogger<PersonGroupService>.Instance);
 
         var faceCatalogService = new FaceCatalogService(

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
@@ -1,7 +1,6 @@
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -103,6 +102,15 @@ namespace PhotoBank.UnitTests.Services
             referenceDataService
                 .Setup(s => s.GetTagsAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Array.Empty<TagDto>());
+            referenceDataService
+                .Setup(s => s.GetStoragesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<StorageDto>());
+            referenceDataService
+                .Setup(s => s.GetPathsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<PathDto>());
+            referenceDataService
+                .Setup(s => s.GetPersonGroupsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<PersonGroupDto>());
 
             var minioClient = new Mock<IMinioClient>();
             minioClient
@@ -111,11 +119,9 @@ namespace PhotoBank.UnitTests.Services
 
             var filterNormalizer = new Mock<ISearchFilterNormalizer>();
 
-            var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var photoRepository = new Repository<Photo>(provider);
             var personRepository = new Repository<Person>(provider);
             var faceRepository = new Repository<Face>(provider);
-            var storageRepository = new Repository<Storage>(provider);
             var personGroupRepository = new Repository<PersonGroup>(provider);
             var s3Options = Options.Create(new S3Options());
 
@@ -124,9 +130,7 @@ namespace PhotoBank.UnitTests.Services
             var photoQueryService = new PhotoQueryService(
                 context,
                 photoRepository,
-                storageRepository,
                 _mapper,
-                memoryCache,
                 NullLogger<PhotoQueryService>.Instance,
                 currentUser,
                 referenceDataService.Object,
@@ -145,7 +149,7 @@ namespace PhotoBank.UnitTests.Services
                 context,
                 personGroupRepository,
                 _mapper,
-                memoryCache,
+                referenceDataService.Object,
                 NullLogger<PersonGroupService>.Instance);
 
             var faceCatalogService = new FaceCatalogService(

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -2,7 +2,6 @@ using AutoMapper;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -54,13 +53,21 @@ namespace PhotoBank.UnitTests.Services
             referenceDataService
                 .Setup(s => s.GetTagsAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Array.Empty<TagDto>());
+            referenceDataService
+                .Setup(s => s.GetStoragesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<StorageDto>());
+            referenceDataService
+                .Setup(s => s.GetPathsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<PathDto>());
+            referenceDataService
+                .Setup(s => s.GetPersonGroupsAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<PersonGroupDto>());
 
             var normalizer = new Mock<ISearchFilterNormalizer>();
             normalizer
                 .Setup(n => n.NormalizeAsync(It.IsAny<FilterDto>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync((FilterDto f, CancellationToken _) => f);
 
-            var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var minioClient = new Mock<IMinioClient>();
             var s3Options = new Mock<IOptions<S3Options>>();
             s3Options.Setup(o => o.Value).Returns(new S3Options());
@@ -76,9 +83,7 @@ namespace PhotoBank.UnitTests.Services
             var photoQueryService = new PhotoQueryService(
                 context,
                 photoRepository,
-                storageRepository,
                 _mapper,
-                memoryCache,
                 NullLogger<PhotoQueryService>.Instance,
                 new DummyCurrentUser(),
                 referenceDataService.Object,
@@ -97,7 +102,7 @@ namespace PhotoBank.UnitTests.Services
                 context,
                 personGroupRepository,
                 _mapper,
-                memoryCache,
+                referenceDataService.Object,
                 NullLogger<PersonGroupService>.Instance);
 
             var faceCatalogService = new FaceCatalogService(


### PR DESCRIPTION
## Summary
- extend `SearchReferenceDataService` to serve storages, paths, and person groups with centralized invalidation hooks
- wire `PhotoQueryService`, `PersonDirectoryService`, and `PersonGroupService` through the refreshed cache provider
- refresh and add unit tests covering cache invalidation behaviour for storages, paths, and person groups

## Testing
- dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --filter SearchReferenceDataServiceTests --logger:"console;verbosity=minimal"


------
https://chatgpt.com/codex/tasks/task_e_68e22e854b448328b3e57926709c5024