### PR TITLE
feat: centralize media URL generation via resolver

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -36,6 +36,7 @@ public static partial class ServiceCollectionExtensions
         services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
         services.AddScoped<IFaceStorageService, FaceStorageService>();
         services.AddScoped<MinioObjectService>();
+        services.AddScoped<IMediaUrlResolver, MediaUrlResolver>();
         services.AddScoped<ISearchFilterNormalizer, SearchFilterNormalizer>();
         services.AddScoped<PhotoFilterSpecification>();
         services.AddScoped<IPhotoQueryService, PhotoQueryService>();

--- a/backend/PhotoBank.Services/Internal/MediaUrlResolver.cs
+++ b/backend/PhotoBank.Services/Internal/MediaUrlResolver.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Minio;
+using Minio.DataModel.Args;
+
+namespace PhotoBank.Services.Internal;
+
+public readonly record struct MediaUrlContext(int? PhotoId, int? FaceId)
+{
+    public static MediaUrlContext ForPhoto(int? photoId) => new(photoId, null);
+
+    public static MediaUrlContext ForFace(int? photoId, int? faceId) => new(photoId, faceId);
+}
+
+public interface IMediaUrlResolver
+{
+    Task<string?> ResolveAsync(string? key, int ttlSeconds, MediaUrlContext context, CancellationToken cancellationToken = default);
+}
+
+public sealed class MediaUrlResolver : IMediaUrlResolver
+{
+    private readonly IMinioClient _minioClient;
+    private readonly IOptions<S3Options> _s3Options;
+    private readonly ILogger<MediaUrlResolver> _logger;
+
+    public MediaUrlResolver(
+        IMinioClient minioClient,
+        IOptions<S3Options> s3Options,
+        ILogger<MediaUrlResolver> logger)
+    {
+        _minioClient = minioClient ?? throw new ArgumentNullException(nameof(minioClient));
+        _s3Options = s3Options ?? throw new ArgumentNullException(nameof(s3Options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string?> ResolveAsync(string? key, int ttlSeconds, MediaUrlContext context, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return null;
+        }
+
+        if (ttlSeconds <= 0)
+        {
+            _logger.LogWarning(
+                "TTL must be positive when resolving media URL. PhotoId: {PhotoId}; FaceId: {FaceId}; Key: {S3Key}.",
+                context.PhotoId,
+                context.FaceId,
+                key);
+            return null;
+        }
+
+        var s3 = _s3Options.Value ?? new S3Options();
+
+        try
+        {
+            return await _minioClient.PresignedGetObjectAsync(new PresignedGetObjectArgs()
+                .WithBucket(s3.Bucket)
+                .WithObject(key)
+                .WithExpiry(ttlSeconds)).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Failed to generate presigned URL. PhotoId: {PhotoId}; FaceId: {FaceId}; Key: {S3Key}.",
+                context.PhotoId,
+                context.FaceId,
+                key);
+            return null;
+        }
+    }
+}

--- a/backend/PhotoBank.UnitTests/Internal/MediaUrlResolverTests.cs
+++ b/backend/PhotoBank.UnitTests/Internal/MediaUrlResolverTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Minio;
+using Minio.DataModel.Args;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.Services.Internal;
+using PhotoBank.UnitTests.Infrastructure.Logging;
+
+namespace PhotoBank.UnitTests.Internal;
+
+[TestFixture]
+public sealed class MediaUrlResolverTests
+{
+    [Test]
+    public async Task ResolveAsync_ReturnsNull_WhenKeyIsMissing()
+    {
+        var minioClient = new Mock<IMinioClient>(MockBehavior.Strict);
+        var logger = new TestLogger<MediaUrlResolver>();
+        var resolver = new MediaUrlResolver(minioClient.Object, Options.Create(new S3Options { Bucket = "bucket" }), logger);
+
+        var result = await resolver.ResolveAsync(null, 60, MediaUrlContext.ForPhoto(42));
+
+        result.Should().BeNull();
+        minioClient.VerifyNoOtherCalls();
+        logger.Entries.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ResolveAsync_ReturnsUrl_WhenPresignedSuccessfully()
+    {
+        const string expectedUrl = "https://example.com/object";
+        var minioClient = new Mock<IMinioClient>();
+        minioClient
+            .Setup(c => c.PresignedGetObjectAsync(It.IsAny<PresignedGetObjectArgs>()))
+            .ReturnsAsync(expectedUrl);
+        var logger = new TestLogger<MediaUrlResolver>();
+        var resolver = new MediaUrlResolver(minioClient.Object, Options.Create(new S3Options { Bucket = "bucket" }), logger);
+
+        var result = await resolver.ResolveAsync("object-key", 120, MediaUrlContext.ForPhoto(10));
+
+        result.Should().Be(expectedUrl);
+        logger.Entries.Should().BeEmpty();
+        minioClient.Verify(c => c.PresignedGetObjectAsync(It.IsAny<PresignedGetObjectArgs>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ResolveAsync_LogsWarningAndReturnsNull_WhenPresignedFails()
+    {
+        var minioClient = new Mock<IMinioClient>();
+        minioClient
+            .Setup(c => c.PresignedGetObjectAsync(It.IsAny<PresignedGetObjectArgs>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        var logger = new TestLogger<MediaUrlResolver>();
+        var resolver = new MediaUrlResolver(minioClient.Object, Options.Create(new S3Options { Bucket = "bucket" }), logger);
+
+        var result = await resolver.ResolveAsync("object-key", 120, MediaUrlContext.ForFace(99, 5));
+
+        result.Should().BeNull();
+        logger.Entries.Should().ContainSingle();
+        logger.Entries[0].Level.Should().Be(LogLevel.Warning);
+        logger.Entries[0].Message.Should().Contain("Failed to generate presigned URL");
+        logger.Entries[0].Exception.Should().BeOfType<InvalidOperationException>();
+    }
+}

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceUploadTests.cs
@@ -69,6 +69,15 @@ namespace PhotoBank.UnitTests.Services
                 .ReturnsAsync((FilterDto f, CancellationToken _) => f);
 
             var minioClient = new Mock<IMinioClient>();
+            var mediaUrlResolver = new Mock<IMediaUrlResolver>();
+            mediaUrlResolver
+                .Setup(r => r.ResolveAsync(
+                    It.IsAny<string?>(),
+                    It.IsAny<int>(),
+                    It.IsAny<MediaUrlContext>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string? key, int _, MediaUrlContext _, CancellationToken _) =>
+                    string.IsNullOrEmpty(key) ? null : $"resolved-{key}");
             var s3Options = new Mock<IOptions<S3Options>>();
             s3Options.Setup(o => o.Value).Returns(new S3Options());
 
@@ -84,12 +93,11 @@ namespace PhotoBank.UnitTests.Services
                 context,
                 photoRepository,
                 _mapper,
-                NullLogger<PhotoQueryService>.Instance,
                 new DummyCurrentUser(),
                 referenceDataService.Object,
                 normalizer.Object,
                 photoFilterSpecification,
-                minioClient.Object,
+                mediaUrlResolver.Object,
                 s3Options.Object);
 
             var personDirectoryService = new PersonDirectoryService(
@@ -108,8 +116,7 @@ namespace PhotoBank.UnitTests.Services
             var faceCatalogService = new FaceCatalogService(
                 faceRepository,
                 _mapper,
-                minioClient.Object,
-                NullLogger<FaceCatalogService>.Instance,
+                mediaUrlResolver.Object,
                 s3Options.Object);
 
             var duplicateFinder = new Mock<IPhotoDuplicateFinder>();


### PR DESCRIPTION
## Summary
- add IMediaUrlResolver to encapsulate presigned URL generation with unified logging
- refactor photo and face services to consume the resolver and register it in DI
- update unit tests and add MediaUrlResolver tests covering success and failure cases

## Testing
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build --filter FullyQualifiedName~MediaUrlResolverTests --logger "console;verbosity=minimal"
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build --filter FullyQualifiedName~PhotoServiceGetAllPhotosAsyncTests --logger "console;verbosity=minimal"
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build --filter FullyQualifiedName~PhotoServiceGetPhotoAsyncTests --logger "console;verbosity=minimal"
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build --filter FullyQualifiedName~PhotoServiceGetFacesPageAsyncTests --logger "console;verbosity=minimal"
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build --filter FullyQualifiedName~PhotoServiceUploadTests --logger "console;verbosity=minimal"
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build --filter FullyQualifiedName~PersonGroupServiceTests --logger "console;verbosity=minimal"

------
https://chatgpt.com/codex/tasks/task_e_68e242e8cb5883288b7c1d360973aab2