### PR TITLE
Refactor search reference data caching helper

### DIFF
--- a/backend/PhotoBank.Services/Internal/CachedAsyncValue.cs
+++ b/backend/PhotoBank.Services/Internal/CachedAsyncValue.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace PhotoBank.Services.Internal;
+
+internal sealed class CachedAsyncValue<T>
+{
+    private readonly IMemoryCache _cache;
+    private readonly Func<object> _keyFactory;
+    private readonly Func<ICacheEntry, Task<T>> _valueFactory;
+    private readonly Func<IEnumerable<object>> _invalidationKeysFactory;
+    private readonly object _syncRoot = new();
+    private Lazy<Task<T>> _lazy;
+
+    public CachedAsyncValue(
+        IMemoryCache cache,
+        Func<object> keyFactory,
+        Func<ICacheEntry, Task<T>> valueFactory,
+        Func<IEnumerable<object>>? invalidationKeysFactory = null)
+    {
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _keyFactory = keyFactory ?? throw new ArgumentNullException(nameof(keyFactory));
+        _valueFactory = valueFactory ?? throw new ArgumentNullException(nameof(valueFactory));
+        _invalidationKeysFactory = invalidationKeysFactory ?? (() => Array.Empty<object>());
+
+        _lazy = CreateLazy();
+    }
+
+    public Task<T> GetValueAsync()
+    {
+        var lazy = _lazy;
+        return lazy.Value;
+    }
+
+    public void Reset()
+    {
+        lock (_syncRoot)
+        {
+            foreach (var key in _invalidationKeysFactory())
+            {
+                if (key is not null)
+                {
+                    _cache.Remove(key);
+                }
+            }
+
+            _lazy = CreateLazy();
+        }
+    }
+
+    private Lazy<Task<T>> CreateLazy()
+        => new(() => _cache.GetOrCreateAsync(_keyFactory(), entry =>
+        {
+            entry.PostEvictionCallbacks.Add(new PostEvictionCallbackRegistration
+            {
+                State = this,
+                EvictionCallback = static (_, _, _, state) =>
+                {
+                    if (state is CachedAsyncValue<T> cached)
+                    {
+                        cached.HandleEvicted();
+                    }
+                }
+            });
+
+            return _valueFactory(entry);
+        })!, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private void HandleEvicted()
+    {
+        if (!Monitor.TryEnter(_syncRoot))
+        {
+            return;
+        }
+
+        try
+        {
+            _lazy = CreateLazy();
+        }
+        finally
+        {
+            Monitor.Exit(_syncRoot);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a CachedAsyncValue helper that wires IMemoryCache eviction callbacks and reset support
- refactor SearchReferenceDataService to use CachedAsyncValue for people, paths, storages, tags, and person groups
- extend SearchReferenceDataService tests to cover cache invalidation and ACL filtering for people

## Testing
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj -v q

------
https://chatgpt.com/codex/tasks/task_e_68e252ab1d3c8328ba183af0aa4ec32a