### PR TITLE
refactor: introduce storage upload strategies

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -10,6 +10,7 @@ using PhotoBank.Services.Photos;
 using PhotoBank.Services.Photos.Admin;
 using PhotoBank.Services.Photos.Faces;
 using PhotoBank.Services.Photos.Queries;
+using PhotoBank.Services.Photos.Upload;
 using PhotoBank.Services.Search;
 using PhotoBank.Services.Translator;
 using Polly;
@@ -44,6 +45,9 @@ public static partial class ServiceCollectionExtensions
         services.AddScoped<IPersonGroupService, PersonGroupService>();
         services.AddScoped<IFaceCatalogService, FaceCatalogService>();
         services.AddScoped<IPhotoDuplicateFinder, PhotoDuplicateFinder>();
+        services.AddSingleton<UploadNameResolver>();
+        services.AddScoped<IStorageUploadStrategy, ObjectStorageUploadStrategy>();
+        services.AddScoped<IStorageUploadStrategy, FileSystemStorageUploadStrategy>();
         services.AddScoped<IPhotoIngestionService, PhotoIngestionService>();
         services.AddScoped<IPhotoAdminService, PhotoAdminService>();
         services.AddScoped<IPhotoService, PhotoService>();

--- a/backend/PhotoBank.Services/Photos/IPhotoIngestionService.cs
+++ b/backend/PhotoBank.Services/Photos/IPhotoIngestionService.cs
@@ -1,19 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Minio;
-using Minio.DataModel;
-using Minio.DataModel.Args;
 using PhotoBank.DbContext.Models;
 using PhotoBank.Repositories;
-using PhotoBank.Services.Internal;
-using System.IO.Abstractions;
+using PhotoBank.Services.Photos.Upload;
 
 namespace PhotoBank.Services.Photos;
 
@@ -25,22 +19,16 @@ public interface IPhotoIngestionService
 public class PhotoIngestionService : IPhotoIngestionService
 {
     private readonly IRepository<Storage> _storageRepository;
-    private readonly IMinioClient _minioClient;
-    private readonly S3Options _s3Options;
-    private readonly IFileSystem _fileSystem;
+    private readonly IEnumerable<IStorageUploadStrategy> _uploadStrategies;
     private readonly ILogger<PhotoIngestionService> _logger;
 
     public PhotoIngestionService(
         IRepository<Storage> storageRepository,
-        IMinioClient minioClient,
-        IOptions<S3Options> s3Options,
-        IFileSystem fileSystem,
+        IEnumerable<IStorageUploadStrategy> uploadStrategies,
         ILogger<PhotoIngestionService> logger)
     {
         _storageRepository = storageRepository;
-        _minioClient = minioClient;
-        _s3Options = s3Options?.Value ?? new S3Options();
-        _fileSystem = fileSystem;
+        _uploadStrategies = uploadStrategies;
         _logger = logger;
     }
 
@@ -58,210 +46,12 @@ public class PhotoIngestionService : IPhotoIngestionService
             throw new ArgumentException($"Storage {storageId} not found", nameof(storageId));
         }
 
-        if (IsObjectStorageLocation(storage.Folder, out var bucket, out var prefix))
+        var strategy = _uploadStrategies.FirstOrDefault(s => s.CanHandle(storage));
+        if (strategy == null)
         {
-            var resolvedBucket = string.IsNullOrWhiteSpace(bucket) ? _s3Options.Bucket : bucket;
-            await UploadToObjectStorageAsync(storageId, resolvedBucket, prefix, files, relativePath, cancellationToken);
-            return;
+            throw new InvalidOperationException($"No upload strategy registered for storage {storage.Id}.");
         }
 
-        await UploadToFileSystemAsync(storageId, storage.Folder, files, relativePath, cancellationToken);
-    }
-
-    private async Task UploadToFileSystemAsync(
-        int storageId,
-        string? root,
-        IEnumerable<IFormFile> files,
-        string? relativePath,
-        CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(root))
-        {
-            throw new InvalidOperationException($"Storage {storageId} does not have a folder configured.");
-        }
-
-        var targetPath = string.IsNullOrEmpty(relativePath)
-            ? root
-            : _fileSystem.Path.Combine(root, relativePath);
-
-        if (!_fileSystem.Directory.Exists(targetPath))
-        {
-            _fileSystem.Directory.CreateDirectory(targetPath);
-        }
-
-        foreach (var file in files)
-        {
-            var destination = _fileSystem.Path.Combine(targetPath, file.FileName);
-
-            if (_fileSystem.File.Exists(destination))
-            {
-                var existing = _fileSystem.FileInfo.New(destination);
-                if (existing.Length == file.Length)
-                {
-                    _logger.LogInformation(
-                        "Skipping upload for {FileName} - identical file already exists in storage {StorageId}",
-                        file.FileName,
-                        storageId);
-                    continue;
-                }
-
-                var baseName = _fileSystem.Path.GetFileNameWithoutExtension(file.FileName);
-                var extension = _fileSystem.Path.GetExtension(file.FileName);
-                var index = 1;
-                string candidate;
-                do
-                {
-                    candidate = _fileSystem.Path.Combine(targetPath, $"{baseName}_{index}{extension}");
-                    index++;
-                } while (_fileSystem.File.Exists(candidate));
-
-                destination = candidate;
-            }
-
-            await using var stream = _fileSystem.File.Create(destination);
-            await file.CopyToAsync(stream, cancellationToken);
-        }
-    }
-
-    private async Task UploadToObjectStorageAsync(
-        int storageId,
-        string bucket,
-        string? basePrefix,
-        IEnumerable<IFormFile> files,
-        string? relativePath,
-        CancellationToken cancellationToken)
-    {
-        var prefix = CombinePrefixes(basePrefix, relativePath);
-
-        foreach (var file in files)
-        {
-            var key = BuildObjectKey(prefix, file.FileName);
-            var candidateKey = key;
-            var index = 1;
-
-            while (true)
-            {
-                var stat = await TryStatObjectAsync(bucket, candidateKey, cancellationToken);
-                if (stat == null)
-                {
-                    break;
-                }
-
-                if (stat.Size == file.Length)
-                {
-                    _logger.LogInformation(
-                        "Skipping upload for {FileName} - identical object already exists in bucket {Bucket}",
-                        file.FileName,
-                        bucket);
-                    goto ContinueWithNextFile;
-                }
-
-                var baseName = Path.GetFileNameWithoutExtension(file.FileName);
-                var extension = Path.GetExtension(file.FileName);
-                candidateKey = BuildObjectKey(prefix, $"{baseName}_{index}{extension}");
-                index++;
-            }
-
-            await using (var stream = file.OpenReadStream())
-            {
-                await _minioClient.PutObjectAsync(new PutObjectArgs()
-                        .WithBucket(bucket)
-                        .WithObject(candidateKey)
-                        .WithStreamData(stream)
-                        .WithObjectSize(file.Length)
-                        .WithContentType(string.IsNullOrWhiteSpace(file.ContentType)
-                            ? "application/octet-stream"
-                            : file.ContentType),
-                    cancellationToken);
-            }
-
-            _logger.LogInformation(
-                "Uploaded {FileName} to bucket {Bucket} with key {ObjectKey} for storage {StorageId}",
-                file.FileName,
-                bucket,
-                candidateKey,
-                storageId);
-
-        ContinueWithNextFile: ;
-        }
-    }
-
-    private async Task<ObjectStat?> TryStatObjectAsync(string bucket, string objectKey, CancellationToken cancellationToken)
-    {
-        try
-        {
-            return await _minioClient.StatObjectAsync(new StatObjectArgs()
-                .WithBucket(bucket)
-                .WithObject(objectKey), cancellationToken);
-        }
-        catch (Exception ex) when (IsNotFound(ex))
-        {
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to inspect object {ObjectKey} in bucket {Bucket}", objectKey, bucket);
-            return null;
-        }
-    }
-
-    private bool IsObjectStorageLocation(string? folder, out string bucket, out string? prefix)
-    {
-        bucket = string.Empty;
-        prefix = null;
-        if (string.IsNullOrWhiteSpace(folder))
-        {
-            bucket = _s3Options.Bucket;
-            return false;
-        }
-
-        if (Uri.TryCreate(folder, UriKind.Absolute, out var uri) &&
-            (string.Equals(uri.Scheme, "s3", StringComparison.OrdinalIgnoreCase) ||
-             string.Equals(uri.Scheme, "minio", StringComparison.OrdinalIgnoreCase)))
-        {
-            bucket = string.IsNullOrWhiteSpace(uri.Host) ? string.Empty : uri.Host;
-            prefix = uri.AbsolutePath.Trim('/');
-            return true;
-        }
-
-        return false;
-    }
-
-    private bool IsNotFound(Exception ex)
-    {
-        if (ex.GetType().Name.Contains("NotFound", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private string CombinePrefixes(string? basePrefix, string? relativePath)
-    {
-        var segments = new List<string>();
-        if (!string.IsNullOrWhiteSpace(basePrefix))
-        {
-            segments.Add(basePrefix.Trim('/'));
-        }
-
-        if (!string.IsNullOrWhiteSpace(relativePath))
-        {
-            segments.Add(relativePath.Replace('\\', '/').Trim('/'));
-        }
-
-        var prefix = string.Join('/', segments.Where(s => !string.IsNullOrWhiteSpace(s)));
-        return prefix;
-    }
-
-    private string BuildObjectKey(string prefix, string fileName)
-    {
-        var normalized = fileName.Replace('\\', '/');
-        if (string.IsNullOrWhiteSpace(prefix))
-        {
-            return normalized;
-        }
-
-        return string.Join('/', new[] { prefix.TrimEnd('/'), normalized.TrimStart('/') });
+        await strategy.UploadAsync(storage, files, relativePath, cancellationToken);
     }
 }

--- a/backend/PhotoBank.Services/Photos/Upload/FileSystemStorageUploadStrategy.cs
+++ b/backend/PhotoBank.Services/Photos/Upload/FileSystemStorageUploadStrategy.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using PhotoBank.DbContext.Models;
+
+namespace PhotoBank.Services.Photos.Upload;
+
+public sealed class FileSystemStorageUploadStrategy : IStorageUploadStrategy
+{
+    private readonly IFileSystem _fileSystem;
+    private readonly UploadNameResolver _nameResolver;
+    private readonly ILogger<FileSystemStorageUploadStrategy> _logger;
+
+    public FileSystemStorageUploadStrategy(
+        IFileSystem fileSystem,
+        UploadNameResolver nameResolver,
+        ILogger<FileSystemStorageUploadStrategy> logger)
+    {
+        _fileSystem = fileSystem;
+        _nameResolver = nameResolver;
+        _logger = logger;
+    }
+
+    public bool CanHandle(Storage storage)
+    {
+        if (storage == null)
+        {
+            return false;
+        }
+
+        var folder = storage.Folder;
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            return true;
+        }
+
+        return !IsObjectStorageUri(folder);
+    }
+
+    public async Task UploadAsync(
+        Storage storage,
+        IEnumerable<IFormFile> files,
+        string? relativePath,
+        CancellationToken cancellationToken)
+    {
+        var root = storage.Folder;
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            throw new InvalidOperationException($"Storage {storage.Id} does not have a folder configured.");
+        }
+
+        var targetPath = string.IsNullOrWhiteSpace(relativePath)
+            ? root
+            : _fileSystem.Path.Combine(root, relativePath);
+
+        if (!_fileSystem.Directory.Exists(targetPath))
+        {
+            _fileSystem.Directory.CreateDirectory(targetPath);
+        }
+
+        foreach (var file in files)
+        {
+            var resolution = await _nameResolver.ResolveAsync(
+                file.FileName,
+                file.Length,
+                candidate => Task.FromResult<UploadNameResolver.StoredObjectInfo?>(GetExistingFile(targetPath, candidate)),
+                cancellationToken).ConfigureAwait(false);
+
+            if (!resolution.ShouldUpload)
+            {
+                _logger.LogInformation(
+                    "Skipping upload for {FileName} - identical file already exists in storage {StorageId}",
+                    file.FileName,
+                    storage.Id);
+                continue;
+            }
+
+            var destination = _fileSystem.Path.Combine(targetPath, resolution.TargetName);
+            await using var stream = _fileSystem.File.Create(destination);
+            await file.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private UploadNameResolver.StoredObjectInfo? GetExistingFile(string targetPath, string candidate)
+    {
+        var destination = _fileSystem.Path.Combine(targetPath, candidate);
+        if (!_fileSystem.File.Exists(destination))
+        {
+            return null;
+        }
+
+        var existing = _fileSystem.FileInfo.New(destination);
+        return new UploadNameResolver.StoredObjectInfo(existing.Length);
+    }
+
+    private static bool IsObjectStorageUri(string folder)
+    {
+        if (!Uri.TryCreate(folder, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        return string.Equals(uri.Scheme, "s3", StringComparison.OrdinalIgnoreCase)
+               || string.Equals(uri.Scheme, "minio", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/backend/PhotoBank.Services/Photos/Upload/IStorageUploadStrategy.cs
+++ b/backend/PhotoBank.Services/Photos/Upload/IStorageUploadStrategy.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using PhotoBank.DbContext.Models;
+
+namespace PhotoBank.Services.Photos.Upload;
+
+public interface IStorageUploadStrategy
+{
+    bool CanHandle(Storage storage);
+
+    Task UploadAsync(
+        Storage storage,
+        IEnumerable<IFormFile> files,
+        string? relativePath,
+        CancellationToken cancellationToken);
+}

--- a/backend/PhotoBank.Services/Photos/Upload/ObjectStorageUploadStrategy.cs
+++ b/backend/PhotoBank.Services/Photos/Upload/ObjectStorageUploadStrategy.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Minio;
+using Minio.DataModel;
+using Minio.DataModel.Args;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Internal;
+
+namespace PhotoBank.Services.Photos.Upload;
+
+public sealed class ObjectStorageUploadStrategy : IStorageUploadStrategy
+{
+    private readonly IMinioClient _minioClient;
+    private readonly S3Options _options;
+    private readonly UploadNameResolver _nameResolver;
+    private readonly ILogger<ObjectStorageUploadStrategy> _logger;
+
+    public ObjectStorageUploadStrategy(
+        IMinioClient minioClient,
+        IOptions<S3Options> options,
+        UploadNameResolver nameResolver,
+        ILogger<ObjectStorageUploadStrategy> logger)
+    {
+        _minioClient = minioClient;
+        _options = options?.Value ?? new S3Options();
+        _nameResolver = nameResolver;
+        _logger = logger;
+    }
+
+    public bool CanHandle(Storage storage)
+    {
+        if (storage == null)
+        {
+            return false;
+        }
+
+        return TryParseLocation(storage.Folder, out _);
+    }
+
+    public async Task UploadAsync(
+        Storage storage,
+        IEnumerable<IFormFile> files,
+        string? relativePath,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseLocation(storage.Folder, out var location))
+        {
+            throw new InvalidOperationException($"Storage {storage.Id} is not configured for object storage uploads.");
+        }
+
+        var prefix = CombinePrefixes(location.Prefix, relativePath);
+
+        foreach (var file in files)
+        {
+            var resolution = await _nameResolver.ResolveAsync(
+                file.FileName,
+                file.Length,
+                candidate => TryStatAsync(location.Bucket, BuildObjectKey(prefix, candidate), cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+
+            if (!resolution.ShouldUpload)
+            {
+                _logger.LogInformation(
+                    "Skipping upload for {FileName} - identical object already exists in bucket {Bucket}",
+                    file.FileName,
+                    location.Bucket);
+                continue;
+            }
+
+            var key = BuildObjectKey(prefix, resolution.TargetName);
+
+            await using var stream = file.OpenReadStream();
+            await _minioClient.PutObjectAsync(new PutObjectArgs()
+                    .WithBucket(location.Bucket)
+                    .WithObject(key)
+                    .WithStreamData(stream)
+                    .WithObjectSize(file.Length)
+                    .WithContentType(string.IsNullOrWhiteSpace(file.ContentType)
+                        ? "application/octet-stream"
+                        : file.ContentType),
+                cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Uploaded {FileName} to bucket {Bucket} with key {ObjectKey} for storage {StorageId}",
+                file.FileName,
+                location.Bucket,
+                key,
+                storage.Id);
+        }
+    }
+
+    private async Task<UploadNameResolver.StoredObjectInfo?> TryStatAsync(
+        string bucket,
+        string objectKey,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var stat = await _minioClient.StatObjectAsync(new StatObjectArgs()
+                    .WithBucket(bucket)
+                    .WithObject(objectKey),
+                cancellationToken).ConfigureAwait(false);
+
+            return new UploadNameResolver.StoredObjectInfo(stat.Size);
+        }
+        catch (Exception ex) when (IsNotFound(ex))
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to inspect object {ObjectKey} in bucket {Bucket}", objectKey, bucket);
+            return null;
+        }
+    }
+
+    private bool TryParseLocation(string? folder, out ObjectStorageLocation location)
+    {
+        location = default;
+
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(folder, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        if (!string.Equals(uri.Scheme, "s3", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(uri.Scheme, "minio", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var bucket = string.IsNullOrWhiteSpace(uri.Host) ? _options.Bucket : uri.Host;
+        if (string.IsNullOrWhiteSpace(bucket))
+        {
+            bucket = _options.Bucket;
+        }
+        var prefix = uri.AbsolutePath.Trim('/');
+
+        location = new ObjectStorageLocation(bucket, string.IsNullOrWhiteSpace(prefix) ? null : prefix);
+        return true;
+    }
+
+    private bool IsNotFound(Exception ex)
+    {
+        if (ex.GetType().Name.Contains("NotFound", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string CombinePrefixes(string? basePrefix, string? relativePath)
+    {
+        var segments = new List<string>();
+        if (!string.IsNullOrWhiteSpace(basePrefix))
+        {
+            segments.Add(basePrefix.Trim('/'));
+        }
+
+        if (!string.IsNullOrWhiteSpace(relativePath))
+        {
+            segments.Add(relativePath.Replace('\\', '/').Trim('/'));
+        }
+
+        return string.Join('/', segments.Where(s => !string.IsNullOrWhiteSpace(s)));
+    }
+
+    private static string BuildObjectKey(string prefix, string fileName)
+    {
+        var normalized = fileName.Replace('\\', '/');
+        if (string.IsNullOrWhiteSpace(prefix))
+        {
+            return normalized;
+        }
+
+        return string.Join('/', new[] { prefix.TrimEnd('/'), normalized.TrimStart('/') });
+    }
+
+    private readonly struct ObjectStorageLocation
+    {
+        public ObjectStorageLocation(string bucket, string? prefix)
+        {
+            Bucket = bucket;
+            Prefix = prefix;
+        }
+
+        public string Bucket { get; }
+
+        public string? Prefix { get; }
+    }
+}

--- a/backend/PhotoBank.Services/Photos/Upload/UploadNameResolver.cs
+++ b/backend/PhotoBank.Services/Photos/Upload/UploadNameResolver.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PhotoBank.Services.Photos.Upload;
+
+public sealed class UploadNameResolver
+{
+    public async Task<UploadResolution> ResolveAsync(
+        string fileName,
+        long fileLength,
+        Func<string, Task<StoredObjectInfo?>> tryGetExistingAsync,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentNullException.ThrowIfNull(tryGetExistingAsync);
+
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var extension = Path.GetExtension(fileName);
+
+        var index = 1;
+        var candidate = fileName;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var existing = await tryGetExistingAsync(candidate).ConfigureAwait(false);
+            if (existing == null)
+            {
+                return UploadResolution.Create(candidate);
+            }
+
+            if (existing.Length == fileLength)
+            {
+                return UploadResolution.Skip(candidate);
+            }
+
+            candidate = string.IsNullOrEmpty(extension)
+                ? $"{baseName}_{index}"
+                : $"{baseName}_{index}{extension}";
+            index++;
+        }
+    }
+
+    public sealed record StoredObjectInfo(long Length);
+
+    public sealed record UploadResolution(bool ShouldUpload, string TargetName)
+    {
+        public static UploadResolution Skip(string name) => new(false, name);
+
+        public static UploadResolution Create(string name) => new(true, name);
+    }
+}

--- a/backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj
+++ b/backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="nunit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="20.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/PhotoBank.UnitTests/Services/Photos/Upload/FileSystemStorageUploadStrategyTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/Photos/Upload/FileSystemStorageUploadStrategyTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Photos.Upload;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace PhotoBank.UnitTests.Services.Photos.Upload;
+
+[TestFixture]
+public class FileSystemStorageUploadStrategyTests
+{
+    private static IFormFile CreateFormFile(byte[] content, string fileName)
+    {
+        var stream = new MemoryStream(content);
+        return new FormFile(stream, 0, content.Length, "file", fileName);
+    }
+
+    [Test]
+    public void CanHandle_ReturnsFalse_ForObjectStorage()
+    {
+        var strategy = new FileSystemStorageUploadStrategy(
+            new MockFileSystem(),
+            new UploadNameResolver(),
+            NullLogger<FileSystemStorageUploadStrategy>.Instance);
+
+        var storage = new Storage { Folder = "s3://bucket/path" };
+
+        strategy.CanHandle(storage).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task UploadAsync_WritesFileToTargetDirectory()
+    {
+        var fileSystem = new MockFileSystem();
+        var strategy = new FileSystemStorageUploadStrategy(
+            fileSystem,
+            new UploadNameResolver(),
+            NullLogger<FileSystemStorageUploadStrategy>.Instance);
+
+        var storage = new Storage { Id = 1, Folder = "/storage" };
+        var file = CreateFormFile(new byte[] { 1, 2, 3 }, "photo.jpg");
+
+        await strategy.UploadAsync(storage, new[] { file }, "sub", CancellationToken.None);
+
+        fileSystem.FileExists("/storage/sub/photo.jpg").Should().BeTrue();
+    }
+
+    [Test]
+    public async Task UploadAsync_SkipsDuplicateWithSameLength()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { "/storage/photo.jpg", new MockFileData(new byte[] { 1, 2, 3 }) }
+        });
+
+        var strategy = new FileSystemStorageUploadStrategy(
+            fileSystem,
+            new UploadNameResolver(),
+            NullLogger<FileSystemStorageUploadStrategy>.Instance);
+
+        var storage = new Storage { Id = 2, Folder = "/storage" };
+        var file = CreateFormFile(new byte[] { 1, 2, 3 }, "photo.jpg");
+
+        await strategy.UploadAsync(storage, new[] { file }, null, CancellationToken.None);
+
+        fileSystem.AllFiles.Should().ContainSingle().Which.Should().Be("/storage/photo.jpg");
+    }
+
+    [Test]
+    public async Task UploadAsync_RenamesFileWhenSizeDiffers()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { "/storage/photo.jpg", new MockFileData(new byte[] { 1, 2, 3 }) }
+        });
+
+        var strategy = new FileSystemStorageUploadStrategy(
+            fileSystem,
+            new UploadNameResolver(),
+            NullLogger<FileSystemStorageUploadStrategy>.Instance);
+
+        var storage = new Storage { Id = 3, Folder = "/storage" };
+        var file = CreateFormFile(new byte[] { 4, 5 }, "photo.jpg");
+
+        await strategy.UploadAsync(storage, new[] { file }, null, CancellationToken.None);
+
+        fileSystem.FileExists("/storage/photo_1.jpg").Should().BeTrue();
+        var newFile = fileSystem.GetFile("/storage/photo_1.jpg");
+        newFile.Contents.Length.Should().Be(2);
+    }
+}

--- a/backend/PhotoBank.UnitTests/Services/Photos/Upload/ObjectStorageUploadStrategyTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/Photos/Upload/ObjectStorageUploadStrategyTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Minio;
+using Minio.DataModel;
+using Minio.DataModel.Args;
+using Minio.DataModel.Response;
+using Moq;
+using NUnit.Framework;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Services.Photos.Upload;
+using PhotoBank.Services.Internal;
+
+namespace PhotoBank.UnitTests.Services.Photos.Upload;
+
+[TestFixture]
+public class ObjectStorageUploadStrategyTests
+{
+    private static IFormFile CreateFormFile(byte[] content, string fileName, string? contentType = null)
+    {
+        var stream = new MemoryStream(content);
+        return new FormFile(stream, 0, content.Length, "file", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = contentType
+        };
+    }
+
+    private static ObjectStat CreateObjectStat(long size)
+    {
+        var stat = (ObjectStat)FormatterServices.GetUninitializedObject(typeof(ObjectStat));
+        typeof(ObjectStat).GetProperty("Size")!.SetValue(stat, size);
+        return stat;
+    }
+
+    [Test]
+    public void CanHandle_ReturnsTrue_ForS3Uri()
+    {
+        var strategy = CreateStrategy();
+        var storage = new Storage { Folder = "s3://bucket/root" };
+
+        strategy.CanHandle(storage).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task UploadAsync_UploadsObjectWithResolvedKey()
+    {
+        var minio = new Mock<IMinioClient>();
+        minio
+            .Setup(m => m.StatObjectAsync(It.IsAny<StatObjectArgs>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("not found"));
+
+        string? capturedBucket = null;
+        string? capturedKey = null;
+
+        minio
+            .Setup(m => m.PutObjectAsync(It.IsAny<PutObjectArgs>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectArgs, CancellationToken>((args, _) =>
+            {
+                capturedBucket = ReadStringProperty(args, "BucketName");
+                capturedKey = ReadStringProperty(args, "ObjectName");
+            })
+            .Returns(Task.FromResult(CreatePutObjectResponse()));
+
+        var strategy = CreateStrategy(minioClient: minio.Object);
+        var storage = new Storage { Id = 5, Folder = "s3://photos/base" };
+        var file = CreateFormFile(new byte[] { 1, 2, 3 }, "image.jpg", "image/jpeg");
+
+        await strategy.UploadAsync(storage, new[] { file }, "nested", CancellationToken.None);
+
+        capturedBucket.Should().Be("photos");
+        capturedKey.Should().Be("base/nested/image.jpg");
+    }
+
+    [Test]
+    public async Task UploadAsync_SkipsDuplicateWhenSameSize()
+    {
+        var minio = new Mock<IMinioClient>();
+        minio
+            .Setup(m => m.StatObjectAsync(It.IsAny<StatObjectArgs>(), It.IsAny<CancellationToken>()))
+            .Returns<StatObjectArgs, CancellationToken>((_, _) =>
+                Task.FromResult(CreateObjectStat(3)));
+
+        var strategy = CreateStrategy(minioClient: minio.Object);
+        var storage = new Storage { Id = 6, Folder = "s3://bucket/root" };
+        var file = CreateFormFile(new byte[] { 1, 2, 3 }, "image.jpg");
+
+        await strategy.UploadAsync(storage, new[] { file }, null, CancellationToken.None);
+
+        minio.Verify(m => m.PutObjectAsync(It.IsAny<PutObjectArgs>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task UploadAsync_AppendsSuffixWhenDifferentSize()
+    {
+        var minio = new Mock<IMinioClient>();
+        minio
+            .Setup(m => m.StatObjectAsync(It.IsAny<StatObjectArgs>(), It.IsAny<CancellationToken>()))
+            .Returns<StatObjectArgs, CancellationToken>((args, _) =>
+            {
+                var objectName = ReadStringProperty(args, "ObjectName");
+                if (objectName?.EndsWith("image.jpg", StringComparison.Ordinal) == true)
+                {
+                    return Task.FromResult(CreateObjectStat(5));
+                }
+
+                return Task.FromException<ObjectStat>(new Exception("not found"));
+            });
+
+        string? capturedKey = null;
+        minio
+            .Setup(m => m.PutObjectAsync(It.IsAny<PutObjectArgs>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectArgs, CancellationToken>((args, _) =>
+            {
+                capturedKey = ReadStringProperty(args, "ObjectName");
+            })
+            .Returns(Task.FromResult(CreatePutObjectResponse()));
+
+        var strategy = CreateStrategy(minioClient: minio.Object);
+        var storage = new Storage { Id = 7, Folder = "s3://bucket/root" };
+        var file = CreateFormFile(new byte[] { 1, 2, 3 }, "image.jpg");
+
+        await strategy.UploadAsync(storage, new[] { file }, null, CancellationToken.None);
+
+        capturedKey.Should().Be("root/image_1.jpg");
+    }
+
+    private static ObjectStorageUploadStrategy CreateStrategy(IMinioClient? minioClient = null)
+    {
+        var client = minioClient ?? Mock.Of<IMinioClient>();
+        var options = Options.Create(new S3Options { Bucket = "default" });
+        return new ObjectStorageUploadStrategy(
+            client,
+            options,
+            new UploadNameResolver(),
+            NullLogger<ObjectStorageUploadStrategy>.Instance);
+    }
+
+    private static string? ReadStringProperty(object instance, string propertyName)
+    {
+        var property = instance.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        return property?.GetValue(instance) as string;
+    }
+
+    private static PutObjectResponse CreatePutObjectResponse()
+        => (PutObjectResponse)FormatterServices.GetUninitializedObject(typeof(PutObjectResponse));
+}


### PR DESCRIPTION
## Summary
- extract file-system and object storage upload strategies behind IStorageUploadStrategy
- add an UploadNameResolver helper to centralize duplicate detection and name generation
- refactor PhotoIngestionService to resolve the appropriate strategy via DI and add focused unit tests for each strategy

## Testing
- `dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build --filter "FullyQualifiedName~StorageUploadStrategy"`


------
https://chatgpt.com/codex/tasks/task_e_68e25e3a9634832887fff763b5c8c958