### PR TITLE
refactor: replace lookup enrichers reflection with expressions

### DIFF
--- a/backend/PhotoBank.Services/Enrichers/CategoryEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/CategoryEnricher.cs
@@ -14,6 +14,7 @@ namespace PhotoBank.Services.Enrichers
             : base(
                 categoryRepository,
                 src => src.ImageAnalysis.Categories.Select(c => c.Name),
+                model => model.Name,
                 name => new Category { Name = name },
                 (photo, name, categoryModel, src) =>
                 {

--- a/backend/PhotoBank.Services/Enrichers/ObjectPropertyEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/ObjectPropertyEnricher.cs
@@ -14,6 +14,7 @@ namespace PhotoBank.Services.Enrichers
             : base(
                 propertyNameRepository,
                 src => src.ImageAnalysis.Objects.Select(o => o.ObjectProperty),
+                model => model.Name,
                 name => new PropertyName { Name = name },
                 (photo, name, propertyName, src) =>
                 {

--- a/backend/PhotoBank.Services/Enrichers/TagEnricher.cs
+++ b/backend/PhotoBank.Services/Enrichers/TagEnricher.cs
@@ -13,6 +13,7 @@ namespace PhotoBank.Services.Enrichers
             : base(
                 repo,
                 src => src.ImageAnalysis.Tags.Select(t => t.Name),
+                model => model.Name,
                 name => new Tag { Name = name },
                 (photo, name, tagModel, src) =>
                 {


### PR DESCRIPTION
## Summary
- extend `BaseLookupEnricher` to accept a strongly-typed name selector and reuse it for lookups
- update tag, category, and object property enrichers to pass `m => m.Name`

## Testing
- dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --no-build

------
https://chatgpt.com/codex/tasks/task_e_68e2b8391cf48328adf02cc4f1eb465d