### PR TITLE
feat: add active enricher provider

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankCoreExtensions.cs
@@ -6,6 +6,7 @@ using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Enrichment;
 using PhotoBank.Services.Photos;
 using PhotoBank.Services.Photos.Admin;
 using PhotoBank.Services.Photos.Faces;
@@ -52,6 +53,7 @@ public static partial class ServiceCollectionExtensions
         services.AddScoped<IPhotoAdminService, PhotoAdminService>();
         services.AddScoped<IPhotoService, PhotoService>();
         services.AddScoped<ISearchReferenceDataService, SearchReferenceDataService>();
+        services.AddSingleton<IActiveEnricherProvider, ActiveEnricherProvider>();
         services.AddPhotoEvents();
         if (configuration != null)
         {

--- a/backend/PhotoBank.Services/Enrichment/ActiveEnricherProvider.cs
+++ b/backend/PhotoBank.Services/Enrichment/ActiveEnricherProvider.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+using PhotoBank.Services.Enrichers;
+
+namespace PhotoBank.Services.Enrichment;
+
+public sealed class ActiveEnricherProvider : IActiveEnricherProvider
+{
+    private static readonly Lazy<IReadOnlyDictionary<string, Type>> EnricherTypes =
+        new(BuildEnricherTypeMap, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    public IReadOnlyCollection<Type> GetActiveEnricherTypes(IRepository<Enricher> repository)
+    {
+        if (repository is null)
+        {
+            throw new ArgumentNullException(nameof(repository));
+        }
+
+        var activeNames = repository.GetAll()
+            .Where(e => e.IsActive)
+            .Select(e => e.Name)
+            .ToArray();
+
+        var result = new List<Type>(activeNames.Length);
+        foreach (var name in activeNames)
+        {
+            if (!EnricherTypes.Value.TryGetValue(name, out var type))
+            {
+                throw new NotSupportedException($"Enricher '{name}' not found in loaded assemblies.");
+            }
+
+            result.Add(type);
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyDictionary<string, Type> BuildEnricherTypeMap()
+    {
+        return typeof(IEnricher).Assembly
+            .GetTypes()
+            .Where(t => !t.IsAbstract && typeof(IEnricher).IsAssignableFrom(t))
+            .ToDictionary(t => t.Name, t => t, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/backend/PhotoBank.Services/Enrichment/IActiveEnricherProvider.cs
+++ b/backend/PhotoBank.Services/Enrichment/IActiveEnricherProvider.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+
+namespace PhotoBank.Services.Enrichment;
+
+public interface IActiveEnricherProvider
+{
+    IReadOnlyCollection<Type> GetActiveEnricherTypes(IRepository<Enricher> repository);
+}

--- a/backend/PhotoBank.UnitTests/Enrichment/ActiveEnricherProviderTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichment/ActiveEnricherProviderTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using PhotoBank.DbContext.Models;
+using PhotoBank.Repositories;
+using PhotoBank.Services.Enrichment;
+using PhotoBank.Services.Enrichers;
+
+namespace PhotoBank.UnitTests.Enrichment;
+
+[TestFixture]
+public class ActiveEnricherProviderTests
+{
+    [Test]
+    public void GetActiveEnricherTypes_ReturnsOnlyActiveEnrichers()
+    {
+        var repository = new FakeEnricherRepository(new[]
+        {
+            new Enricher { Name = nameof(MetadataEnricher), IsActive = true },
+            new Enricher { Name = nameof(TagEnricher), IsActive = false }
+        });
+        var provider = new ActiveEnricherProvider();
+
+        var types = provider.GetActiveEnricherTypes(repository);
+
+        types.Should().Contain(typeof(MetadataEnricher));
+        types.Should().NotContain(typeof(TagEnricher));
+    }
+
+    [Test]
+    public void GetActiveEnricherTypes_ThrowsForUnknownEnricher()
+    {
+        var repository = new FakeEnricherRepository(new[]
+        {
+            new Enricher { Name = "UnknownEnricher", IsActive = true }
+        });
+        var provider = new ActiveEnricherProvider();
+
+        Action act = () => provider.GetActiveEnricherTypes(repository);
+
+        act.Should().Throw<NotSupportedException>()
+            .WithMessage("*UnknownEnricher*");
+    }
+
+    private sealed class FakeEnricherRepository : IRepository<Enricher>
+    {
+        private readonly IQueryable<Enricher> _items;
+
+        public FakeEnricherRepository(IEnumerable<Enricher> items)
+        {
+            _items = items.AsQueryable();
+        }
+
+        public IQueryable<Enricher> GetAll() => _items;
+        public IQueryable<Enricher> GetByCondition(Expression<Func<Enricher, bool>> predicate) => _items.Where(predicate);
+        public Task<Enricher> GetAsync(int id, Func<IQueryable<Enricher>, IQueryable<Enricher>> queryable) => throw new NotSupportedException();
+        public Enricher Get(int id, Func<IQueryable<Enricher>, IQueryable<Enricher>> queryable) => throw new NotSupportedException();
+        public Task<Enricher> GetAsync(int id) => throw new NotSupportedException();
+        public Enricher Get(int id) => throw new NotSupportedException();
+        public Task<Enricher> InsertAsync(Enricher entity) => throw new NotSupportedException();
+        public Task InsertRangeAsync(List<Enricher> entities) => throw new NotSupportedException();
+        public Task<Enricher> UpdateAsync(Enricher entity) => throw new NotSupportedException();
+        public Task<int> UpdateAsync(Enricher entity, params Expression<Func<Enricher, object>>[] properties) => throw new NotSupportedException();
+        public Task<int> DeleteAsync(int id) => throw new NotSupportedException();
+    }
+}

--- a/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -46,6 +46,7 @@ using PhotoBank.Services.FaceRecognition.Local;
 using PhotoBank.Services.FaceRecognition.Abstractions;
 using PhotoBank.Services.Photos;
 using PhotoBank.Services.Internal;
+using PhotoBank.Services.Enrichment;
 using PhotoBank.Services.Recognition;
 using PhotoBank.Services.Search;
 using PhotoBank.Services.Translator;
@@ -208,6 +209,7 @@ public class ServiceCollectionExtensionsTests
         AssertScopedRegistration<IPhotoIngestionService, PhotoIngestionService>(services);
         AssertScopedRegistration<IPhotoService, PhotoService>(services);
         AssertScopedRegistration<ISearchReferenceDataService, SearchReferenceDataService>(services);
+        AssertSingletonRegistration<IActiveEnricherProvider, ActiveEnricherProvider>(services);
         AssertHttpClientRegistration<ITranslatorService, TranslatorService>(services);
 
         services.Should().Contain(d =>
@@ -275,6 +277,7 @@ public class ServiceCollectionExtensionsTests
         AssertScopedRegistration<IFaceService, FaceService>(services);
         AssertSingletonRegistration<IInsightFaceApiClient, InsightFaceClient>(services);
         AssertFactoryRegistration<EnricherResolver>(services, "Singleton");
+        AssertSingletonRegistration<IActiveEnricherProvider, ActiveEnricherProvider>(services);
 
         AssertEnricherRegistration(services);
 
@@ -308,7 +311,8 @@ public class ServiceCollectionExtensionsTests
         using var provider = services.BuildServiceProvider();
         var resolver = provider.GetRequiredService<EnricherResolver>();
         var resolved = resolver(provider.GetRequiredService<IRepository<Enricher>>()).ToList();
-        resolved.Should().NotBeEmpty();
+        resolved.Should().ContainSingle(e => e is MetadataEnricher);
+        resolved.Should().NotContain(e => e is TagEnricher);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- add an active enricher provider abstraction and implementation that resolves enricher types based on active records
- wire the provider into core and console dependency injection to reuse type resolution logic
- add unit tests covering inactive enricher filtering and provider registration expectations

## Testing
- dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bf718970832891f9fb7b81f22acf