### PR TITLE
refactor: run photo enrichment via pipeline

### DIFF
--- a/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -36,6 +36,7 @@ using PhotoBank.InsightFaceApiClient;
 using PhotoBank.Repositories;
 using PhotoBank.Services;
 using PhotoBank.Services.Api;
+using PhotoBank.Services.Enrichment;
 using PhotoBank.Services.Enrichers;
 using PhotoBank.Services.Enrichers.Services;
 using PhotoBank.Services.Events;
@@ -276,6 +277,7 @@ public class ServiceCollectionExtensionsTests
         AssertScopedRegistration<UnifiedFaceService, UnifiedFaceService>(services);
         AssertScopedRegistration<IFaceService, FaceService>(services);
         AssertSingletonRegistration<IInsightFaceApiClient, InsightFaceClient>(services);
+        AssertSingletonRegistration<IEnrichmentPipeline, EnrichmentPipeline>(services);
         AssertFactoryRegistration<EnricherResolver>(services, "Singleton");
         AssertSingletonRegistration<IActiveEnricherProvider, ActiveEnricherProvider>(services);
 
@@ -294,6 +296,7 @@ public class ServiceCollectionExtensionsTests
             typeof(IImageMetadataReaderWrapper),
             typeof(IRecognitionService),
             typeof(IInsightFaceApiClient),
+            typeof(IEnrichmentPipeline),
             typeof(UnifiedFaceService));
 
         var activeEnrichers = new[]
@@ -307,6 +310,8 @@ public class ServiceCollectionExtensionsTests
         {
             services.AddTransient(descriptor.ImplementationType!);
         }
+
+        services.TryAddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
 
         using var provider = services.BuildServiceProvider();
         var resolver = provider.GetRequiredService<EnricherResolver>();


### PR DESCRIPTION
## Summary
- switch `PhotoProcessor` to run the enrichment pipeline with the active enricher set when adding or updating photos
- register the enrichment pipeline in the console service collection so the processor can resolve it
- extend the service collection unit test to cover the new pipeline registration

## Testing
- dotnet test PhotoBank.UnitTests/PhotoBank.UnitTests.csproj -v:minimal *(fails: Microsoft.Build logging issue in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c13e14b08328b5ecd4450532d95e