### PR TITLE
fix: register enrichment pipeline with catalog service

### DIFF
--- a/backend/PhotoBank.DependencyInjection/AddPhotobankConsoleExtensions.cs
+++ b/backend/PhotoBank.DependencyInjection/AddPhotobankConsoleExtensions.cs
@@ -84,12 +84,8 @@ public static partial class ServiceCollectionExtensions
             .Distinct()
             .ToArray();
 
-        services.AddSingleton<IEnrichmentPipeline>(provider =>
-        {
-            var options = provider.GetRequiredService<IOptions<EnrichmentPipelineOptions>>();
-            var logger = provider.GetRequiredService<ILogger<EnrichmentPipeline>>();
-            return new EnrichmentPipeline(provider, enricherTypes, options, logger);
-        });
+        services.AddSingleton(_ => new EnricherTypeCatalog(enricherTypes));
+        services.AddSingleton<IEnrichmentPipeline, EnrichmentPipeline>();
         services.AddSingleton<EnricherResolver>(provider =>
         {
             var activeEnricherProvider = provider.GetRequiredService<IActiveEnricherProvider>();

--- a/backend/PhotoBank.Services/Enrichment/EnricherTypeCatalog.cs
+++ b/backend/PhotoBank.Services/Enrichment/EnricherTypeCatalog.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PhotoBank.Services.Enrichment;
+
+public sealed class EnricherTypeCatalog
+{
+    public EnricherTypeCatalog(IEnumerable<Type> types)
+    {
+        ArgumentNullException.ThrowIfNull(types);
+        Types = types.Distinct().ToArray();
+    }
+
+    public IReadOnlyList<Type> Types { get; }
+}

--- a/backend/PhotoBank.Services/Enrichment/EnrichmentPipeline.cs
+++ b/backend/PhotoBank.Services/Enrichment/EnrichmentPipeline.cs
@@ -21,12 +21,12 @@ public sealed class EnrichmentPipeline : IEnrichmentPipeline
     private readonly ILogger<EnrichmentPipeline> _log;
 
     public EnrichmentPipeline(IServiceProvider root,
-                              IEnumerable<Type> enricherTypes,
+                              EnricherTypeCatalog enricherCatalog,
                               IOptions<EnrichmentPipelineOptions> opts,
                               ILogger<EnrichmentPipeline> log)
     {
         _root = root;
-        _enricherTypes = enricherTypes.ToArray();
+        _enricherTypes = enricherCatalog.Types.ToArray();
         _opts = opts.Value;
         _log = log;
     }

--- a/backend/PhotoBank.Services/Enrichment/EnrichmentPipelineServiceCollectionExtensions.cs
+++ b/backend/PhotoBank.Services/Enrichment/EnrichmentPipelineServiceCollectionExtensions.cs
@@ -40,12 +40,8 @@ public static class EnrichmentPipelineServiceCollectionExtensions
         else
             services.Configure<EnrichmentPipelineOptions>(_ => { });
 
-        services.AddSingleton<IEnrichmentPipeline>(sp =>
-        {
-            var opts = sp.GetRequiredService<IOptions<EnrichmentPipelineOptions>>();
-            var logger = sp.GetRequiredService<ILogger<EnrichmentPipeline>>();
-            return new EnrichmentPipeline(sp, enricherTypes, opts, logger);
-        });
+        services.AddSingleton(_ => new EnricherTypeCatalog(enricherTypes));
+        services.AddSingleton<IEnrichmentPipeline, EnrichmentPipeline>();
 
         return services;
     }

--- a/backend/PhotoBank.UnitTests/Enrichment/EnrichmentPipelineTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichment/EnrichmentPipelineTests.cs
@@ -26,9 +26,10 @@ public class EnrichmentPipelineTests
         services.AddScoped<CharlieEnricher>();
 
         var provider = services.BuildServiceProvider();
+        var catalog = new EnricherTypeCatalog(new[] { typeof(AlphaEnricher), typeof(BravoEnricher), typeof(CharlieEnricher) });
         var pipeline = new EnrichmentPipeline(
             provider,
-            new[] { typeof(AlphaEnricher), typeof(BravoEnricher), typeof(CharlieEnricher) },
+            catalog,
             Options.Create(new EnrichmentPipelineOptions { LogTimings = false }),
             NullLogger<EnrichmentPipeline>.Instance);
 
@@ -116,9 +117,10 @@ public class EnrichmentPipelineTests
         services.AddScoped<CycleBravoEnricher>();
 
         var provider = services.BuildServiceProvider();
+        var catalog = new EnricherTypeCatalog(new[] { typeof(CycleAlphaEnricher), typeof(CycleBravoEnricher) });
         var pipeline = new EnrichmentPipeline(
             provider,
-            new[] { typeof(CycleAlphaEnricher), typeof(CycleBravoEnricher) },
+            catalog,
             Options.Create(new EnrichmentPipelineOptions { LogTimings = false }),
             NullLogger<EnrichmentPipeline>.Instance);
 
@@ -148,9 +150,10 @@ public class EnrichmentPipelineTests
         services.AddScoped<BlockingEnricher>();
 
         var provider = services.BuildServiceProvider();
+        var catalog = new EnricherTypeCatalog(new[] { typeof(BlockingEnricher) });
         var pipeline = new EnrichmentPipeline(
             provider,
-            new[] { typeof(BlockingEnricher) },
+            catalog,
             Options.Create(new EnrichmentPipelineOptions
             {
                 LogTimings = false,

--- a/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/backend/PhotoBank.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -276,7 +276,8 @@ public class ServiceCollectionExtensionsTests
         AssertScopedRegistration<UnifiedFaceService, UnifiedFaceService>(services);
         AssertScopedRegistration<IFaceService, FaceService>(services);
         AssertSingletonRegistration<IInsightFaceApiClient, InsightFaceClient>(services);
-        AssertFactoryRegistration<IEnrichmentPipeline>(services, "Singleton");
+        AssertSingletonRegistration<IEnrichmentPipeline, EnrichmentPipeline>(services);
+        AssertFactoryRegistration<EnricherTypeCatalog>(services, "Singleton");
         AssertFactoryRegistration<EnricherResolver>(services, "Singleton");
         AssertSingletonRegistration<IActiveEnricherProvider, ActiveEnricherProvider>(services);
 


### PR DESCRIPTION
## Summary
- introduce an EnricherTypeCatalog singleton so the pipeline can obtain discovered enricher types through DI
- register the enrichment pipeline via its implementation type in both console and shared DI helpers
- adjust unit tests to work with the catalog-based pipeline construction and verify the new registration pattern

## Testing
- MSBUILDTERMINALLOGGER=off dotnet test backend/PhotoBank.UnitTests/PhotoBank.UnitTests.csproj --nologo


------
https://chatgpt.com/codex/tasks/task_e_68e2c883bc4083289a455def15a747aa