### PR TITLE
fix: clamp enrichment pipeline parallelism

### DIFF
--- a/backend/PhotoBank.Services/Enrichment/EnrichmentPipeline.cs
+++ b/backend/PhotoBank.Services/Enrichment/EnrichmentPipeline.cs
@@ -68,7 +68,10 @@ public sealed class EnrichmentPipeline : IEnrichmentPipeline
     public async Task RunBatchAsync(IEnumerable<(Photo photo, SourceDataDto source)> items, CancellationToken ct = default)
     {
         var arr = items.ToArray();
-        var dop = _opts.MaxDegreeOfParallelism.GetValueOrDefault(Environment.ProcessorCount);
+        var configuredDop = _opts.MaxDegreeOfParallelism;
+        var dop = configuredDop.HasValue && configuredDop.Value > 0
+            ? configuredDop.Value
+            : Math.Max(1, Environment.ProcessorCount);
         _log.LogInformation("Batch enrichment: {Count} items, DOP={Dop}", arr.Length, dop);
 
         await Parallel.ForEachAsync(arr, new ParallelOptions { MaxDegreeOfParallelism = dop, CancellationToken = ct },


### PR DESCRIPTION
## Summary
- ensure the enrichment pipeline falls back to Environment.ProcessorCount when MaxDegreeOfParallelism is null or <= 0
- cover the fallback behavior with a new unit test that waits for concurrent execution

## Testing
- dotnet test PhotoBank.Backend.sln *(fails: integration tests require Docker in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cb08bb8c8328b2951ede362494db