### PR TITLE
refactor: unify date formatting utilities

### DIFF
--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import { formatDate, getOrientation, getPlaceByGeoPoint, useIsAdmin } from '@photobank/shared';
+import { getOrientation, getPlaceByGeoPoint, useIsAdmin } from '@photobank/shared';
+import { formatDate } from '@photobank/shared/format';
 import { logger } from '@photobank/shared/utils/logger';
 import type { FaceBoxDto, FaceDto } from '@photobank/shared/api/photobank';
 import * as PhotosApi from '@photobank/shared/api/photobank';

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
@@ -1,5 +1,6 @@
 import { Calendar, User, Tag } from 'lucide-react';
-import { formatDate, firstNWords } from '@photobank/shared';
+import { firstNWords } from '@photobank/shared';
+import { formatDate } from '@photobank/shared/format';
 import type { PhotoItemDto } from '@photobank/shared/api/photobank';
 import {
   MAX_VISIBLE_PERSONS_SM,

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -1,27 +1,5 @@
 // packages/shared/src/index.ts
 
-import { format } from 'date-fns';
-
-import {
-  DEFAULT_DATE_FORMAT,
-  toDate,
-  type FlexibleDateInput,
-} from './utils/parseDate';
-
-export const formatDate = (dateInput?: FlexibleDateInput) => {
-  if (dateInput === null || dateInput === undefined) return 'не указана дата';
-  if (typeof dateInput === 'string' && dateInput.trim().length === 0) {
-    return 'не указана дата';
-  }
-
-  const parsedDate = toDate(dateInput);
-  if (!parsedDate) {
-    return 'неверный формат даты';
-  }
-
-  return format(parsedDate, DEFAULT_DATE_FORMAT);
-};
-
 export const getGenderText = (gender?: boolean | null) => {
   if (gender === undefined || gender === null) return 'не указан пол';
   return gender ? 'Муж' : 'Жен';

--- a/frontend/packages/shared/test/formatDate.test.ts
+++ b/frontend/packages/shared/test/formatDate.test.ts
@@ -2,10 +2,11 @@ import { format, fromUnixTime } from 'date-fns';
 import { describe, expect, it } from 'vitest';
 
 import { formatDate } from '../src/index';
+import { formatDate as formatDateFromFormatModule } from '../src/format';
 
 const DATE_FORMAT = 'dd.MM.yyyy';
 
-describe('formatDate (legacy export)', () => {
+describe('formatDate re-export', () => {
   it('formats ISO strings through date-fns', () => {
     const value = '2024-01-02T03:04:05Z';
     expect(formatDate(value)).toBe(format(new Date(value), DATE_FORMAT));
@@ -28,12 +29,32 @@ describe('formatDate (legacy export)', () => {
     expect(formatDate(value)).toBe(format(value, DATE_FORMAT));
   });
 
-  it('keeps legacy fallback messages', () => {
-    expect(formatDate(undefined)).toBe('не указана дата');
-    expect(formatDate(null)).toBe('не указана дата');
-    expect(formatDate('')).toBe('не указана дата');
-    expect(formatDate('   ')).toBe('не указана дата');
-    expect(formatDate(Number.NaN)).toBe('неверный формат даты');
-    expect(formatDate('definitely-not-a-date')).toBe('неверный формат даты');
+  it('returns an empty string for invalid inputs', () => {
+    expect(formatDate(undefined)).toBe('');
+    expect(formatDate(null)).toBe('');
+    expect(formatDate('')).toBe('');
+    expect(formatDate('   ')).toBe('');
+    expect(formatDate(Number.NaN)).toBe('');
+    expect(formatDate('definitely-not-a-date')).toBe('');
+  });
+
+  it('matches the implementation exported from src/format', () => {
+    const samples = [
+      '2024-01-02T03:04:05Z',
+      '07.06.2024',
+      1_700_000_000,
+      1_700_000_000_000,
+      new Date('2024-05-06T07:08:09Z'),
+      undefined,
+      null,
+      '',
+      '  ',
+      Number.NaN,
+      'definitely-not-a-date',
+    ];
+
+    for (const sample of samples) {
+      expect(formatDate(sample)).toBe(formatDateFromFormatModule(sample));
+    }
   });
 });


### PR DESCRIPTION
## Summary
- remove the duplicate `formatDate` implementation from `@photobank/shared` root exports
- align the legacy `formatDate` tests with the canonical formatter behaviour and ensure parity with `src/format`
- update frontend imports to pull formatting helpers from `@photobank/shared/format`

## Testing
- pnpm --filter @photobank/shared test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e40f07277483289532e93224a93c4c