### PR TITLE
feat: route gender formatting through client i18n

### DIFF
--- a/frontend/packages/frontend/src/app/ErrorBoundary.tsx
+++ b/frontend/packages/frontend/src/app/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { withTranslation, type WithTranslation } from 'react-i18next';
 
 import { Button } from '@/shared/ui/button';
 
@@ -10,7 +11,7 @@ interface State {
   hasError: boolean;
 }
 
-export default class ErrorBoundary extends Component<Props, State> {
+class ErrorBoundary extends Component<Props & WithTranslation, State> {
   public state: State = { hasError: false };
 
   static getDerivedStateFromError(): State {
@@ -27,10 +28,11 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
+      const { t } = this.props;
       return (
         <div className="p-6 space-y-4">
-          <p className="text-muted-foreground">Произошла ошибка.</p>
-          <Button onClick={this.handleRetry}>Повторить</Button>
+          <p className="text-muted-foreground">{t('genericErrorMessage')}</p>
+          <Button onClick={this.handleRetry}>{t('retryButtonLabel')}</Button>
         </div>
       );
     }
@@ -38,4 +40,6 @@ export default class ErrorBoundary extends Component<Props, State> {
     return this.props.children;
   }
 }
+
+export default withTranslation()(ErrorBoundary);
 

--- a/frontend/packages/frontend/src/components/FaceOverlay.tsx
+++ b/frontend/packages/frontend/src/components/FaceOverlay.tsx
@@ -1,4 +1,4 @@
-import { getGenderText } from '@photobank/shared';
+import { resolveGender } from '@photobank/shared';
 import type { FaceDto } from '@photobank/shared/api/photobank';
 import { useTranslation } from 'react-i18next';
 
@@ -39,7 +39,7 @@ export const FaceOverlay = ({
                     </div>
                     <div>
                         <Label className="text-muted-foreground">{t('genderLabel')}</Label>
-                        <p className="font-medium">{getGenderText(face.gender)}</p>
+                        <p className="font-medium">{t(`gender.${resolveGender(face.gender)}`)}</p>
                     </div>
                     {face.personId && (
                         <div className="col-span-2">

--- a/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
+++ b/frontend/packages/frontend/src/pages/detail/PhotoDetailsPage.tsx
@@ -156,7 +156,7 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
 
     useEffect(() => {
         if (error) {
-            logger.error('Ошибка загрузки фото:', error);
+            logger.error('Failed to load photo:', error);
         }
     }, [error]);
 
@@ -198,7 +198,7 @@ const PhotoDetailsPage = ({ photoId: propPhotoId }: PhotoDetailsPageProps) => {
     };
 
     if (!photoData) {
-        return <div className="p-4">Загрузка...</div>;
+        return <div className="p-4">{t('loadingText')}</div>;
     }
 
     return (

--- a/frontend/packages/frontend/src/shared/config/locales/en.json
+++ b/frontend/packages/frontend/src/shared/config/locales/en.json
@@ -23,6 +23,8 @@
   "applyFiltersButton": "Apply Filters",
   "loadingText": "Loading...",
   "metadataErrorText": "Failed to load metadata.",
+  "genericErrorMessage": "Something went wrong.",
+  "retryButtonLabel": "Try again",
   "openAiPageTitle": "OpenAI Chat",
   "openAiSendButton": "Send",
   "openAiPromptPlaceholder": "Enter your request...",
@@ -57,6 +59,11 @@
   "faceDetailsTitle": "Face Details",
   "ageLabel": "Age",
   "genderLabel": "Gender",
+  "gender": {
+    "male": "Male",
+    "female": "Female",
+    "unknown": "Unknown"
+  },
   "personIdLabel": "Person ID",
   "attributesLabel": "Attributes",
   "unknownLabel": "Unknown",

--- a/frontend/packages/frontend/src/shared/config/locales/ru.json
+++ b/frontend/packages/frontend/src/shared/config/locales/ru.json
@@ -23,6 +23,8 @@
   "applyFiltersButton": "Применить фильтры",
   "loadingText": "Загрузка...",
   "metadataErrorText": "Не удалось загрузить метаданные.",
+  "genericErrorMessage": "Произошла ошибка.",
+  "retryButtonLabel": "Повторить",
   "openAiPageTitle": "Чат OpenAI",
   "openAiSendButton": "Отправить",
   "openAiPromptPlaceholder": "Введите запрос...",
@@ -57,6 +59,11 @@
   "faceDetailsTitle": "Детали лица",
   "ageLabel": "Возраст",
   "genderLabel": "Пол",
+  "gender": {
+    "male": "Муж", 
+    "female": "Жен",
+    "unknown": "Неизвестно"
+  },
   "personIdLabel": "ID человека",
   "attributesLabel": "Атрибуты",
   "unknownLabel": "Неизвестно",

--- a/frontend/packages/frontend/test-setup.ts
+++ b/frontend/packages/frontend/test-setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom/vitest';
+import './src/shared/config/i18n';
 
 class ResizeObserver {
   observe() {}

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -1,8 +1,24 @@
 // packages/shared/src/index.ts
 
-export const getGenderText = (gender?: boolean | null) => {
-  if (gender === undefined || gender === null) return 'не указан пол';
-  return gender ? 'Муж' : 'Жен';
+export type GenderCategory = 'male' | 'female' | 'unknown';
+
+export const resolveGender = (gender?: boolean | null): GenderCategory => {
+  if (gender === undefined || gender === null) return 'unknown';
+  return gender ? 'male' : 'female';
+};
+
+export interface GenderLabels {
+  male: string;
+  female: string;
+  unknown: string;
+}
+
+export const formatGender = (
+  gender: boolean | null | undefined,
+  labels: GenderLabels,
+): string => {
+  const key = resolveGender(gender);
+  return labels[key];
 };
 
 export { getFilterHash } from './utils/getFilterHash';

--- a/frontend/packages/shared/test/index.test.skip.ts
+++ b/frontend/packages/shared/test/index.test.skip.ts
@@ -1,7 +1,7 @@
 import { format, parseISO } from 'date-fns';
 import { describe, expect, it } from 'vitest';
 
-import { formatDate, getGenderText } from '../src';
+import { formatDate, formatGender, resolveGender } from '../src';
 
 // FormatDate tests
 
@@ -13,25 +13,31 @@ describe('formatDate', () => {
     expect(result).toBe(expected);
   });
 
-  it('returns fallback for undefined input', () => {
-    expect(formatDate()).toBe('не указана дата');
+  it('returns empty string for undefined input', () => {
+    expect(formatDate()).toBe('');
   });
 
-  it('returns fallback for invalid input', () => {
-    expect(formatDate('not-a-date')).toBe('неверный формат даты');
+  it('returns empty string for invalid input', () => {
+    expect(formatDate('not-a-date')).toBe('');
   });
 });
 
-describe('getGenderText', () => {
-  it('returns text for male', () => {
-    expect(getGenderText(true)).toBe('Муж');
+describe('gender helpers', () => {
+  const labels = {
+    male: 'Male',
+    female: 'Female',
+    unknown: 'Unknown',
+  } as const;
+
+  it('resolves keys correctly', () => {
+    expect(resolveGender(true)).toBe('male');
+    expect(resolveGender(false)).toBe('female');
+    expect(resolveGender(undefined)).toBe('unknown');
   });
 
-  it('returns text for female', () => {
-    expect(getGenderText(false)).toBe('Жен');
-  });
-
-  it('returns fallback for undefined', () => {
-    expect(getGenderText(undefined)).toBe('не указан пол');
+  it('formats using provided labels', () => {
+    expect(formatGender(true, labels)).toBe('Male');
+    expect(formatGender(false, labels)).toBe('Female');
+    expect(formatGender(undefined, labels)).toBe('Unknown');
   });
 });


### PR DESCRIPTION
## Summary
- expose gender helpers from @photobank/shared without hard-coded Russian labels
- localize face overlay and error boundary strings through the frontend i18n resources
- initialize i18n in vitest setup so translated components work in tests

## Testing
- pnpm --filter @photobank/frontend exec vitest run *(fails: missing module @/features/viewer/prefetch in existing test)*

------
https://chatgpt.com/codex/tasks/task_e_68e410ca6aa88328903a5ec6dfb2ccc9