### PR TITLE
feat: add shared HTTP context module

### DIFF
--- a/frontend/packages/frontend/src/shared/lib/api.ts
+++ b/frontend/packages/frontend/src/shared/lib/api.ts
@@ -1,10 +1,12 @@
-import {
-  configureApi as setBaseUrl,
-  configureApiAuth,
-} from '@photobank/shared/api/photobank';
+import { configureApi as setBaseUrl } from '@photobank/shared/api/photobank';
+import { applyHttpContext } from '@photobank/shared/api/photobank/httpContext';
 import { getAuthToken } from '@photobank/shared/auth';
 
 export function configureApi(baseUrl: string) {
   setBaseUrl(baseUrl);
-  configureApiAuth(() => getAuthToken() ?? undefined);
+  applyHttpContext({
+    auth: {
+      getToken: () => getAuthToken() ?? undefined,
+    },
+  });
 }

--- a/frontend/packages/shared/src/api/photobank/httpContext.ts
+++ b/frontend/packages/shared/src/api/photobank/httpContext.ts
@@ -1,0 +1,124 @@
+import type { HttpError } from '../../types/problem';
+
+export type TokenProvider = (
+  context: unknown | undefined,
+  options?: { forceRefresh?: boolean },
+) => string | undefined | Promise<string | undefined>;
+
+export type TokenManager = {
+  getToken: TokenProvider;
+  onAuthError?: (context: unknown | undefined, error: unknown) => void | Promise<void>;
+};
+
+export type MaybeTokenManager = TokenManager | TokenProvider | undefined;
+
+export interface RetryAttemptContext {
+  attempt: number;
+  error?: unknown;
+  response?: Response;
+}
+
+export interface HttpRetryPolicy {
+  attempts: number;
+  shouldRetry: (context: RetryAttemptContext) => boolean;
+  getDelayMs: (context: RetryAttemptContext) => number;
+}
+
+export interface HttpContextConfig {
+  auth?: MaybeTokenManager | null;
+  impersonateUser?: string | null;
+  retry?: Partial<HttpRetryPolicy> | null;
+}
+
+const DEFAULT_RETRY_POLICY: HttpRetryPolicy = {
+  attempts: 3,
+  shouldRetry: ({ response, error }) => {
+    if (response) return response.status >= 500;
+
+    if (error instanceof TypeError) return true;
+
+    const status = (error as HttpError | { status?: number } | undefined)?.status;
+    if (typeof status === 'number') {
+      return status >= 500;
+    }
+
+    return false;
+  },
+  getDelayMs: ({ attempt }) => 2 ** attempt * 100 + Math.random() * 100,
+};
+
+let tokenManager: TokenManager | undefined;
+let impersonatedUser: string | null = null;
+let retryPolicy: HttpRetryPolicy = { ...DEFAULT_RETRY_POLICY };
+
+function normalizeManager(manager: MaybeTokenManager): TokenManager | undefined {
+  if (!manager) return undefined;
+  return typeof manager === 'function' ? { getToken: manager } : manager;
+}
+
+export function setTokenManager(manager?: MaybeTokenManager) {
+  tokenManager = normalizeManager(manager);
+}
+
+export function getTokenManager() {
+  return tokenManager;
+}
+
+export async function resolveAuthToken(
+  context: unknown | undefined,
+  options: { forceRefresh: boolean },
+) {
+  if (!tokenManager) return undefined;
+  return tokenManager.getToken(context, { forceRefresh: options.forceRefresh });
+}
+
+export async function notifyAuthError(context: unknown | undefined, error: unknown) {
+  await tokenManager?.onAuthError?.(context, error);
+}
+
+export function setImpersonateUser(username: string | null | undefined) {
+  impersonatedUser = username ?? null;
+}
+
+export function getImpersonateUser() {
+  return impersonatedUser;
+}
+
+export function resetRetryPolicy() {
+  retryPolicy = { ...DEFAULT_RETRY_POLICY };
+}
+
+export function setRetryPolicy(policy?: Partial<HttpRetryPolicy> | null) {
+  if (!policy) {
+    resetRetryPolicy();
+    return;
+  }
+
+  retryPolicy = {
+    attempts: Math.max(1, policy.attempts ?? retryPolicy.attempts),
+    shouldRetry: policy.shouldRetry ?? retryPolicy.shouldRetry,
+    getDelayMs: policy.getDelayMs ?? retryPolicy.getDelayMs,
+  };
+}
+
+export function getRetryPolicy(): HttpRetryPolicy {
+  return retryPolicy;
+}
+
+export function applyHttpContext(config: HttpContextConfig) {
+  if ('auth' in config) {
+    setTokenManager(config.auth ?? undefined);
+  }
+
+  if ('impersonateUser' in config) {
+    setImpersonateUser(config.impersonateUser ?? null);
+  }
+
+  if ('retry' in config) {
+    setRetryPolicy(config.retry ?? undefined);
+  }
+}
+
+export function getDefaultRetryPolicy() {
+  return { ...DEFAULT_RETRY_POLICY };
+}

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -67,3 +67,16 @@ export {
   getRequestContext,
 } from './api/photobank/fetcher';
 export { configureApi as setBaseUrl } from './api/photobank/fetcher';
+export {
+  applyHttpContext,
+  getDefaultRetryPolicy,
+  getRetryPolicy,
+  resetRetryPolicy,
+  setRetryPolicy,
+  type HttpContextConfig,
+  type HttpRetryPolicy,
+  type MaybeTokenManager,
+  type RetryAttemptContext,
+  type TokenManager,
+  type TokenProvider,
+} from './api/photobank/httpContext';

--- a/frontend/packages/telegram-bot/src/api/client.ts
+++ b/frontend/packages/telegram-bot/src/api/client.ts
@@ -1,11 +1,7 @@
 import type { Context } from 'grammy';
 
-import {
-  configureApi,
-  configureApiAuth,
-  getRequestContext,
-  runWithRequestContext,
-} from '@photobank/shared/api/photobank';
+import { configureApi, getRequestContext, runWithRequestContext } from '@photobank/shared/api/photobank';
+import { applyHttpContext } from '@photobank/shared/api/photobank/httpContext';
 
 import { ensureUserAccessToken, invalidateUserToken } from '@/auth';
 
@@ -13,15 +9,17 @@ const API_BASE_URL = process.env.API_BASE_URL ?? '';
 
 configureApi(API_BASE_URL);
 
-configureApiAuth({
-  getToken: async (ctx, options) => {
-    const context = (ctx ?? getRequestContext<Context>()) as Context | undefined;
-    if (!context) return undefined;
-    return ensureUserAccessToken(context, options?.forceRefresh ?? false);
-  },
-  onAuthError: async (ctx) => {
-    const context = (ctx ?? getRequestContext<Context>()) as Context | undefined;
-    if (context) invalidateUserToken(context);
+applyHttpContext({
+  auth: {
+    getToken: async (ctx, options) => {
+      const context = (ctx ?? getRequestContext<Context>()) as Context | undefined;
+      if (!context) return undefined;
+      return ensureUserAccessToken(context, options?.forceRefresh ?? false);
+    },
+    onAuthError: async (ctx) => {
+      const context = (ctx ?? getRequestContext<Context>()) as Context | undefined;
+      if (context) invalidateUserToken(context);
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- add a shared HTTP context module that centralizes token handling and retry policy configuration
- refactor the photobank fetcher to delegate auth header and retry behavior to the shared context utilities
- update the frontend and telegram bot clients/tests to consume the new context helper instead of local API auth wiring

## Testing
- pnpm --filter @photobank/shared test
- pnpm --filter @photobank/frontend exec vitest run *(fails: missing @/features/viewer/prefetch import in existing test)*
- pnpm --filter @photobank/telegram-bot test


------
https://chatgpt.com/codex/tasks/task_e_68e569d3cb30832898adbdeae9df41b7