### PR TITLE
refactor: adopt shared fetcher configuration in frontend

### DIFF
--- a/frontend/packages/frontend/src/shared/lib/api.ts
+++ b/frontend/packages/frontend/src/shared/lib/api.ts
@@ -1,12 +1,12 @@
-import { configureApi as setBaseUrl } from '@photobank/shared/api/photobank';
-import { applyHttpContext } from '@photobank/shared/api/photobank/httpContext';
+import {
+  configureApi as setBaseUrl,
+  configureApiAuth,
+} from '@photobank/shared/api/photobank';
 import { getAuthToken } from '@photobank/shared/auth';
 
 export function configureApi(baseUrl: string) {
   setBaseUrl(baseUrl);
-  applyHttpContext({
-    auth: {
-      getToken: () => getAuthToken() ?? undefined,
-    },
+  configureApiAuth({
+    getToken: () => getAuthToken() ?? undefined,
   });
 }


### PR DESCRIPTION
## Summary
- configure the frontend API bootstrap to register the shared fetcher auth handler

## Testing
- pnpm --filter @photobank/frontend build

------
https://chatgpt.com/codex/tasks/task_e_68e56cdd914083288eb49abc79aea81d