### PR TITLE
refactor: use shared fetcher context in telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/src/api/client.ts
+++ b/frontend/packages/telegram-bot/src/api/client.ts
@@ -1,7 +1,11 @@
 import type { Context } from 'grammy';
 
-import { configureApi, getRequestContext, runWithRequestContext } from '@photobank/shared/api/photobank';
-import { applyHttpContext } from '@photobank/shared/api/photobank/httpContext';
+import {
+  configureApi,
+  configureApiAuth,
+  getRequestContext,
+  runWithRequestContext,
+} from '@photobank/shared/api/photobank';
 
 import { ensureUserAccessToken, invalidateUserToken } from '@/auth';
 
@@ -9,17 +13,15 @@ const API_BASE_URL = process.env.API_BASE_URL ?? '';
 
 configureApi(API_BASE_URL);
 
-applyHttpContext({
-  auth: {
-    getToken: async (ctx, options) => {
-      const context = (ctx ?? getRequestContext<Context>()) as Context | undefined;
-      if (!context) return undefined;
-      return ensureUserAccessToken(context, options?.forceRefresh ?? false);
-    },
-    onAuthError: async (ctx) => {
-      const context = (ctx ?? getRequestContext<Context>()) as Context | undefined;
-      if (context) invalidateUserToken(context);
-    },
+configureApiAuth({
+  getToken: async (ctx, options) => {
+    const context = (ctx ?? getRequestContext<Context>()) as Context | undefined;
+    if (!context) return undefined;
+    return ensureUserAccessToken(context, options?.forceRefresh ?? false);
+  },
+  onAuthError: async (ctx) => {
+    const context = (ctx ?? getRequestContext<Context>()) as Context | undefined;
+    if (context) invalidateUserToken(context);
   },
 });
 


### PR DESCRIPTION
## Summary
- switch the bot API client to use the shared fetcher auth configuration
- update the client unit test doubles to reflect the shared configureApiAuth entry point

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e56f048db48328869ee899705ea55a