### PR TITLE
feat(shared): add metadata builders

### DIFF
--- a/frontend/packages/shared/package.json
+++ b/frontend/packages/shared/package.json
@@ -20,6 +20,10 @@
       "types": "./dist/format/index.d.ts",
       "default": "./dist/format/index.js"
     },
+    "./metadata": {
+      "types": "./dist/metadata/index.d.ts",
+      "default": "./dist/metadata/index.js"
+    },
     "./ai/openai": {
       "types": "./dist/ai/openai.d.ts",
       "default": "./dist/ai/openai.js"
@@ -62,6 +66,7 @@
     "date-fns": "^4.1.0",
     "dexie": "^4.2.0",
     "eventemitter3": "^5.0.1",
+    "fuse.js": "^7.1.0",
     "lru-cache": "^11.2.1",
     "object-hash": "^3.0.0",
     "openai": "^5.20.1",

--- a/frontend/packages/shared/src/index.ts
+++ b/frontend/packages/shared/src/index.ts
@@ -53,6 +53,7 @@ export * from './format';
 export * from './auth';
 export * from './safeStorage';
 export * from './constants';
+export * from './metadata';
 export * as logger from './utils/logger';
 
 // важно: пробрасываем наружу весь автосгенерённый API под @photobank/shared/api/photobank

--- a/frontend/packages/shared/src/metadata/index.ts
+++ b/frontend/packages/shared/src/metadata/index.ts
@@ -1,0 +1,70 @@
+import Fuse from 'fuse.js';
+
+import type { PersonDto, StorageDto, TagDto } from '../api/photobank/photoBankApi.schemas';
+
+type EntityWithId = { id: number };
+type EntityWithName = { name: string };
+
+type MaybeEntities<TEntity> = readonly TEntity[] | null | undefined;
+
+const createMemoizedBuilder = <TEntity, TResult>(
+  factory: (entities: readonly TEntity[]) => TResult,
+) => {
+  const cache = new WeakMap<object, TResult>();
+  let emptyCache: TResult | undefined;
+
+  return (entities?: MaybeEntities<TEntity>): TResult => {
+    if (!entities || entities.length === 0) {
+      if (!emptyCache) {
+        emptyCache = factory([]);
+      }
+
+      return emptyCache;
+    }
+
+    const key = entities as unknown as object;
+
+    if (cache.has(key)) {
+      return cache.get(key)!;
+    }
+
+    const result = factory(entities);
+    cache.set(key, result);
+
+    return result;
+  };
+};
+
+const createMapBuilder = <TEntity extends EntityWithId>() =>
+  createMemoizedBuilder<TEntity, ReadonlyMap<number, TEntity>>((entities) =>
+    new Map(entities.map((entity) => [entity.id, entity] as const)),
+  );
+
+const createFuzzyIndexBuilder = <TEntity extends EntityWithName>() => {
+  const options: Fuse.IFuseOptions<TEntity> = {
+    keys: ['name'],
+    threshold: 0.3,
+    ignoreLocation: true,
+  };
+
+  return createMemoizedBuilder<TEntity, Fuse<TEntity>>(
+    (entities) => new Fuse(Array.from(entities), options),
+  );
+};
+
+export type TagMap = ReadonlyMap<number, TagDto>;
+export type PersonMap = ReadonlyMap<number, PersonDto>;
+export type StorageMap = ReadonlyMap<number, StorageDto>;
+
+export const buildTagMap = createMapBuilder<TagDto>();
+export const buildPersonMap = createMapBuilder<PersonDto>();
+export const buildStorageMap = createMapBuilder<StorageDto>();
+
+export type TagSearchIndex = Fuse<TagDto>;
+export type PersonSearchIndex = Fuse<PersonDto>;
+export type StorageSearchIndex = Fuse<StorageDto>;
+
+export const buildTagSearchIndex = createFuzzyIndexBuilder<TagDto>();
+export const buildPersonSearchIndex = createFuzzyIndexBuilder<PersonDto>();
+export const buildStorageSearchIndex = createFuzzyIndexBuilder<StorageDto>();
+

--- a/frontend/packages/shared/test/metadata.test.ts
+++ b/frontend/packages/shared/test/metadata.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PersonDto, StorageDto, TagDto } from '../src/api/photobank/photoBankApi.schemas';
+import {
+  buildPersonMap,
+  buildPersonSearchIndex,
+  buildStorageMap,
+  buildStorageSearchIndex,
+  buildTagMap,
+  buildTagSearchIndex,
+} from '../src/metadata';
+
+describe('metadata builders', () => {
+  const tags: TagDto[] = [
+    { id: 1, name: 'Beach' },
+    { id: 2, name: 'Mountains' },
+  ];
+
+  const persons: PersonDto[] = [
+    { id: 1, name: 'Anna' },
+    { id: 2, name: 'Ben' },
+  ];
+
+  const storages: StorageDto[] = [
+    { id: 4, name: 'Archive' },
+    { id: 9, name: 'Family Library' },
+  ];
+
+  it('builds memoised tag maps', () => {
+    const map = buildTagMap(tags);
+
+    expect(map.get(1)?.name).toBe('Beach');
+    expect(buildTagMap(tags)).toBe(map);
+
+    const otherReference = buildTagMap(tags.slice());
+
+    expect(otherReference).not.toBe(map);
+    expect(otherReference.get(2)?.name).toBe('Mountains');
+  });
+
+  it('builds memoised person maps', () => {
+    const map = buildPersonMap(persons);
+
+    expect(map.get(2)?.name).toBe('Ben');
+    expect(buildPersonMap(persons)).toBe(map);
+
+    expect(buildPersonMap(undefined).size).toBe(0);
+  });
+
+  it('builds memoised storage maps', () => {
+    const map = buildStorageMap(storages);
+
+    expect(map.get(9)?.name).toBe('Family Library');
+    expect(buildStorageMap(storages)).toBe(map);
+  });
+
+  it('creates fuzzy indexes for tags', () => {
+    const index = buildTagSearchIndex(tags);
+
+    expect(buildTagSearchIndex(tags)).toBe(index);
+    expect(index.search('beach')[0]?.item).toMatchObject({ id: 1 });
+  });
+
+  it('creates fuzzy indexes for persons', () => {
+    const index = buildPersonSearchIndex(persons);
+
+    const [match] = index.search('anna');
+
+    expect(match?.item.id).toBe(1);
+  });
+
+  it('creates fuzzy indexes for storages', () => {
+    const index = buildStorageSearchIndex(storages);
+
+    expect(index.search('Family')[0]?.item.id).toBe(9);
+    expect(buildStorageSearchIndex(undefined).search('anything')).toHaveLength(0);
+  });
+});
+

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -496,6 +496,9 @@ importers:
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.1
+      fuse.js:
+        specifier: ^7.1.0
+        version: 7.1.0
       lru-cache:
         specifier: ^11.2.1
         version: 11.2.1
@@ -3317,6 +3320,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuse.js@7.1.0:
+    resolution: {integrity: sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==}
+    engines: {node: '>=10'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -8405,6 +8412,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  fuse.js@7.1.0: {}
 
   gensync@1.0.0-beta.2: {}
 


### PR DESCRIPTION
## Summary
- add memoized builders for tag, person, and storage maps
- provide fuzzy search index builders via a new metadata module and export it publicly
- cover the new builders with unit tests and add the fuse.js dependency

## Testing
- pnpm -C frontend --filter @photobank/shared test

------
https://chatgpt.com/codex/tasks/task_e_68e67f26abc88328a4e7ca0f89652160