### PR TITLE
refactor: reuse shared metadata builders

### DIFF
--- a/frontend/packages/frontend/src/features/metadata/selectors.ts
+++ b/frontend/packages/frontend/src/features/metadata/selectors.ts
@@ -1,4 +1,10 @@
 import { createSelector } from '@reduxjs/toolkit';
+import {
+  buildPersonMap,
+  buildTagMap,
+  type PersonMap,
+  type TagMap,
+} from '@photobank/shared/metadata';
 
 import type { RootState } from '@/app/store';
 
@@ -6,10 +12,10 @@ export const selectMetadataLoaded = (state: RootState) => state.metadata.loaded;
 
 export const selectPersonsMap = createSelector(
   (state: RootState) => state.metadata.persons,
-  (persons) => new Map(persons.map((p) => [p.id, p.name])),
+  (persons): PersonMap => buildPersonMap(persons),
 );
 
 export const selectTagsMap = createSelector(
   (state: RootState) => state.metadata.tags,
-  (tags) => new Map(tags.map((t) => [t.id, t.name])),
+  (tags): TagMap => buildTagMap(tags),
 );

--- a/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
+++ b/frontend/packages/frontend/src/pages/admin/FacesPage.tsx
@@ -6,8 +6,8 @@ import {
   usePersonsGetAll,
   type FaceDto,
   type IdentityStatusDto as IdentityStatusType,
-  type PersonDto,
 } from '@photobank/shared/api/photobank';
+import { buildPersonMap } from '@photobank/shared/metadata';
 
 import { Button } from '@/shared/ui/button';
 import { Input } from '@/shared/ui/input';
@@ -72,18 +72,6 @@ type FaceRow = {
   personName: string | null;
 };
 
-const buildPersonLookup = (persons?: PersonDto[] | null) => {
-  const map = new Map<number, string>();
-
-  for (const person of persons ?? []) {
-    if (typeof person?.id === 'number') {
-      map.set(person.id, person.name);
-    }
-  }
-
-  return map;
-};
-
 export default function FacesPage() {
   const [searchTerm, setSearchTerm] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
@@ -100,10 +88,11 @@ export default function FacesPage() {
 
   const { data, isLoading, isError, isFetching, refetch } = useFacesGetFacesPage(paginationParams);
   const { data: personsResponse } = usePersonsGetAll();
+  const persons = personsResponse?.data;
 
   const personLookup = useMemo(
-    () => buildPersonLookup(personsResponse?.data ?? null),
-    [personsResponse]
+    () => buildPersonMap(persons ?? null),
+    [persons]
   );
 
   const facesResponse = data?.data;
@@ -130,7 +119,8 @@ export default function FacesPage() {
         face: normalizedFace,
         id,
         status,
-        personName: personId != null ? personLookup.get(personId) ?? null : null,
+        personName:
+          personId != null ? personLookup.get(personId)?.name ?? null : null,
       };
     });
   }, [personLookup, rawFaces]);

--- a/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListItemMobile.tsx
@@ -2,6 +2,7 @@ import { Calendar, User, Tag } from 'lucide-react';
 import { firstNWords } from '@photobank/shared';
 import { formatDate } from '@photobank/shared/format';
 import type { PhotoItemDto } from '@photobank/shared/api/photobank';
+import type { PersonMap, TagMap } from '@photobank/shared/metadata';
 import {
   MAX_VISIBLE_PERSONS_SM,
   MAX_VISIBLE_TAGS_SM,
@@ -16,8 +17,8 @@ import PhotoPreview from './PhotoPreview';
 
 export type PhotoListItemMobileProps = {
   photo: PhotoItemDto;
-  personsMap: Record<number, string>;
-  tagsMap: Record<number, string>;
+  personsMap: PersonMap;
+  tagsMap: TagMap;
   onClick: () => void;
 };
 

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/shared/ui/button';
 import { ScrollArea } from '@/shared/ui/scroll-area';
 import { deserializeFilter } from '@/shared/lib/filter-url';
 import { PhotoTable } from '@/features/photos/components/PhotoTable';
+import { selectPersonsMap, selectTagsMap } from '@/features/metadata/selectors';
 
 import PhotoListItemMobile from './PhotoListItemMobile';
 
@@ -24,18 +25,9 @@ const PhotoListPage = () => {
   const dispatch = useAppDispatch();
   const filter = useAppSelector((state) => state.photo.filter);
   const { t } = useTranslation();
-  const persons = useAppSelector((state) => state.metadata.persons);
-  const tags = useAppSelector((state) => state.metadata.tags);
+  const personsMap = useAppSelector(selectPersonsMap);
+  const tagsMap = useAppSelector(selectTagsMap);
   const [searchParams] = useSearchParams();
-
-  const personsMap = useMemo(
-    () => Object.fromEntries(persons.map((p) => [p.id, p.name])),
-    [persons]
-  );
-  const tagsMap = useMemo(
-    () => Object.fromEntries(tags.map((t) => [t.id, t.name])),
-    [tags]
-  );
 
   const {
     items: photos,


### PR DESCRIPTION
## Summary
- build metadata selectors on top of the shared map builders so consumers receive memoized maps
- update photo list flows (table columns, mobile list) to use the centralized selectors instead of local dictionaries
- reuse the shared person map on the faces admin page and extend MetadataBadgeList to handle DTO-backed maps

## Testing
- pnpm --filter frontend exec vitest run src/features/photos/components/photoColumns.test.tsx src/pages/list/PhotoTable.integration.test.tsx src/pages/admin/FacesPage.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e681ad3bd883289eab60d858401618