### PR TITLE
refactor: use shared metadata builders in telegram bot

### DIFF
--- a/frontend/packages/telegram-bot/src/api/photobank/photos/photos.ts
+++ b/frontend/packages/telegram-bot/src/api/photobank/photos/photos.ts
@@ -1,0 +1,1 @@
+export * from '@photobank/shared/api/photobank/photos/photos';

--- a/frontend/packages/telegram-bot/src/dictionaries.ts
+++ b/frontend/packages/telegram-bot/src/dictionaries.ts
@@ -3,6 +3,18 @@ import type {
   StorageDto,
   TagDto,
 } from '@photobank/shared/api/photobank';
+import {
+  buildPersonMap,
+  buildPersonSearchIndex,
+  buildStorageMap,
+  buildTagMap,
+  buildTagSearchIndex,
+  type PersonMap,
+  type PersonSearchIndex,
+  type StorageMap,
+  type TagMap,
+  type TagSearchIndex,
+} from '@photobank/shared/metadata';
 
 import { i18n } from './i18n';
 import type { MyContext } from './i18n';
@@ -14,12 +26,14 @@ import {
 } from './services/dictionary';
 
 type DictData = {
-  tagMap: Map<number, string>;
-  personMap: Map<number, string>;
+  tagMap: TagMap;
+  personMap: PersonMap;
+  storageMap: StorageMap;
+  tagIndex: TagSearchIndex;
+  personIndex: PersonSearchIndex;
   tagList: TagDto[];
   personList: PersonDto[];
   storageList: StorageDto[];
-  storageMap: Map<number, string>;
   pathsMap: Map<number, string[]>;
 };
 
@@ -36,18 +50,24 @@ export function getCurrentLocale(): string {
   return currentLocale;
 }
 
-function getDict(): DictData {
-  const existing = cache.get(currentUser);
-  if (existing) return existing;
+function createEmptyDict(): DictData {
   return {
-    tagMap: new Map<number, string>(),
-    personMap: new Map<number, string>(),
+    tagMap: buildTagMap(undefined),
+    personMap: buildPersonMap(undefined),
+    storageMap: buildStorageMap(undefined),
+    tagIndex: buildTagSearchIndex(undefined),
+    personIndex: buildPersonSearchIndex(undefined),
     tagList: [],
     personList: [],
     storageList: [],
-    storageMap: new Map<number, string>(),
     pathsMap: new Map<number, string[]>(),
   };
+}
+
+function getDict(): DictData {
+  const existing = cache.get(currentUser);
+  if (existing) return existing;
+  return createEmptyDict();
 }
 
 export async function loadDictionaries(ctx: MyContext) {
@@ -56,9 +76,11 @@ export async function loadDictionaries(ctx: MyContext) {
   const personList = await fetchPersons(ctx);
   const storageList = await fetchStorages(ctx);
   const pathList = await fetchPaths(ctx);
-  const tagMap = new Map<number, string>(tagList.map((t) => [t.id, t.name]));
-  const personMap = new Map<number, string>(personList.map((p) => [p.id, p.name]));
-  const storageMap = new Map<number, string>(storageList.map((s) => [s.id, s.name]));
+  const tagMap = buildTagMap(tagList);
+  const personMap = buildPersonMap(personList);
+  const storageMap = buildStorageMap(storageList);
+  const tagIndex = buildTagSearchIndex(tagList);
+  const personIndex = buildPersonSearchIndex(personList);
   const pathsMap = new Map<number, string[]>();
   for (const p of pathList) {
     const arr = pathsMap.get(p.storageId) ?? [];
@@ -68,6 +90,8 @@ export async function loadDictionaries(ctx: MyContext) {
   cache.set(currentUser, {
     tagMap,
     personMap,
+    tagIndex,
+    personIndex,
     tagList,
     personList,
     storageList,
@@ -77,7 +101,7 @@ export async function loadDictionaries(ctx: MyContext) {
 }
 
 export function getTagName(id: number): string {
-  return getDict().tagMap.get(id) ?? `#${String(id)}`;
+  return getDict().tagMap.get(id)?.name ?? `#${String(id)}`;
 }
 
 export function getAllTags(): TagDto[] {
@@ -86,7 +110,7 @@ export function getAllTags(): TagDto[] {
 
 export function getPersonName(id: number | null | undefined): string {
   if (id === null || id === undefined) return i18n.t(currentLocale, 'unknown-person');
-  return getDict().personMap.get(id) ?? `ID ${String(id)}`;
+  return getDict().personMap.get(id)?.name ?? `ID ${String(id)}`;
 }
 
 export function getAllPersons(): PersonDto[] {
@@ -94,19 +118,17 @@ export function getAllPersons(): PersonDto[] {
 }
 
 export function getStorageName(id: number): string {
-  return getDict().storageMap.get(id) ?? `ID ${String(id)}`;
+  return getDict().storageMap.get(id)?.name ?? `ID ${String(id)}`;
 }
 
 export function getStorageId(name: string): number {
-  const storage = Array.from(getDict().storageMap.entries()).find(
-    ([, value]) => value === name
-  );
+  const storage = getDict().storageList.find((value) => value.name === name);
 
   if (!storage) {
     throw new Error(`Storage with name "${name}" not found`);
   }
 
-  return storage[0];
+  return storage.id;
 }
 
 export function getAllStoragesWithPaths(): Array<StorageDto & { paths: string[] }> {
@@ -114,44 +136,12 @@ export function getAllStoragesWithPaths(): Array<StorageDto & { paths: string[] 
   return dict.storageList.map((s) => ({ ...s, paths: dict.pathsMap.get(s.id) ?? [] }));
 }
 
-function similarity(a: string, b: string): number {
-  const dp: number[][] = Array.from({ length: a.length + 1 }, () =>
-    Array<number>(b.length + 1).fill(0)
-  );
-  for (let i = 0; i <= a.length; i++) dp[i]![0] = i;
-  for (let j = 0; j <= b.length; j++) dp[0]![j] = j;
-  for (let i = 1; i <= a.length; i++) {
-    for (let j = 1; j <= b.length; j++) {
-      dp[i]![j] = Math.min(
-        dp[i - 1]![j]! + 1,
-        dp[i]![j - 1]! + 1,
-        dp[i - 1]![j - 1]! + (a[i - 1] === b[j - 1] ? 0 : 1)
-      );
-    }
-  }
-  const dist = dp[a.length]![b.length]!;
-  const maxLen = Math.max(a.length, b.length) || 1;
-  return (maxLen - dist) / maxLen;
-}
-
-function findBestId(map: Map<number, string>, name: string): number | undefined {
-  const lower = name.toLowerCase();
-  let bestId: number | undefined;
-  let bestScore = 0;
-  for (const [id, value] of map.entries()) {
-    const score = similarity(lower, value.toLowerCase());
-    if (score > bestScore) {
-      bestScore = score;
-      bestId = id;
-    }
-  }
-  return bestScore >= 0.5 ? bestId : undefined;
-}
-
 export function findBestPersonId(name: string): number | undefined {
-  return findBestId(getDict().personMap, name);
+  const [match] = getDict().personIndex.search(name);
+  return match?.item.id;
 }
 
 export function findBestTagId(name: string): number | undefined {
-  return findBestId(getDict().tagMap, name);
+  const [match] = getDict().tagIndex.search(name);
+  return match?.item.id;
 }

--- a/frontend/packages/telegram-bot/src/services/photo.ts
+++ b/frontend/packages/telegram-bot/src/services/photo.ts
@@ -1,10 +1,10 @@
 import type { Context } from 'grammy';
+import { type UploadFile } from '@photobank/shared';
 import {
   photosGetPhoto,
   photosSearchPhotos,
   photosUpload,
-  type UploadFile,
-} from '@photobank/shared';
+} from '../api/photobank/photos/photos';
 import { ProblemDetailsError } from '@photobank/shared/types/problem';
 import type {
   FilterDto,


### PR DESCRIPTION
## Summary
- build dictionary caches with the shared metadata map and search builders to keep lookups consistent with the rest of the app
- expose the photobank photo endpoints through a local re-export so tests can mock them while continuing to import from the shared API

## Testing
- pnpm --filter @photobank/telegram-bot test

------
https://chatgpt.com/codex/tasks/task_e_68e685755a908328bc7797d12d7d50b2