### PR TITLE
feat: add photo list adapter with derived counters

### DIFF
--- a/frontend/packages/frontend/src/features/photo/usePhotoListAdapter.test.ts
+++ b/frontend/packages/frontend/src/features/photo/usePhotoListAdapter.test.ts
@@ -1,0 +1,66 @@
+import { renderHook } from '@testing-library/react';
+import { vi, beforeEach, describe, expect, test, type Mock } from 'vitest';
+import type {
+  FilterDto,
+  PhotoItemDto,
+} from '@photobank/shared/api/photobank';
+
+import { usePhotoListAdapter } from './usePhotoListAdapter';
+import { useInfinitePhotos } from './useInfinitePhotos';
+
+vi.mock('./useInfinitePhotos');
+
+describe('usePhotoListAdapter', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test('exposes photos and derived counters', () => {
+    const photos: PhotoItemDto[] = [
+      {
+        id: 1,
+        name: 'first',
+        storageName: 's',
+        relativePath: 'a',
+        isBW: true,
+        isAdultContent: true,
+      },
+      {
+        id: 2,
+        name: 'second',
+        storageName: 's',
+        relativePath: 'b',
+        isRacyContent: true,
+      },
+      {
+        id: 3,
+        name: 'third',
+        storageName: 's',
+        relativePath: 'c',
+      },
+    ];
+
+    const fetchNextPage = vi.fn();
+
+    (useInfinitePhotos as unknown as Mock).mockReturnValue({
+      items: photos,
+      total: 10,
+      fetchNextPage,
+      hasNextPage: true,
+      isLoading: false,
+      isFetchingNextPage: false,
+    });
+
+    const { result } = renderHook(() =>
+      usePhotoListAdapter({} as FilterDto)
+    );
+
+    expect(result.current.photos).toEqual(photos);
+    expect(result.current.counters).toEqual({
+      total: 10,
+      loaded: photos.length,
+      flags: { bw: 1, adult: 1, racy: 1 },
+    });
+    expect(result.current.fetchNextPage).toBe(fetchNextPage);
+  });
+});

--- a/frontend/packages/frontend/src/features/photo/usePhotoListAdapter.ts
+++ b/frontend/packages/frontend/src/features/photo/usePhotoListAdapter.ts
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+import type {
+  FilterDto,
+  PhotoItemDto,
+} from '@photobank/shared/api/photobank';
+
+import {
+  useInfinitePhotos,
+  type UseInfinitePhotosResult,
+} from './useInfinitePhotos';
+
+export type PhotoFlagCounters = {
+  bw: number;
+  adult: number;
+  racy: number;
+};
+
+export type PhotoListCounters = {
+  total: number;
+  loaded: number;
+  flags: PhotoFlagCounters;
+};
+
+export type UsePhotoListAdapterResult = Omit<UseInfinitePhotosResult, 'items'> & {
+  photos: PhotoItemDto[];
+  counters: PhotoListCounters;
+};
+
+const initialFlagCounters: PhotoFlagCounters = Object.freeze({
+  bw: 0,
+  adult: 0,
+  racy: 0,
+});
+
+function countFlags(photos: PhotoItemDto[]): PhotoFlagCounters {
+  return photos.reduce<PhotoFlagCounters>((acc, photo) => {
+    if (photo.isBW) acc.bw += 1;
+    if (photo.isAdultContent) acc.adult += 1;
+    if (photo.isRacyContent) acc.racy += 1;
+    return acc;
+  }, { ...initialFlagCounters });
+}
+
+export const usePhotoListAdapter = (
+  filter: FilterDto
+): UsePhotoListAdapterResult => {
+  const { items, total, ...query } = useInfinitePhotos(filter);
+
+  const counters = useMemo<PhotoListCounters>(() => {
+    const flags = countFlags(items);
+
+    return {
+      total,
+      loaded: items.length,
+      flags,
+    };
+  }, [items, total]);
+
+  return {
+    ...query,
+    total,
+    photos: items,
+    counters,
+  };
+};

--- a/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoListPage.tsx
@@ -4,9 +4,9 @@ import type { FilterDto, PhotoItemDto } from '@photobank/shared/api/photobank';
 import { useTranslation } from 'react-i18next';
 
 import {
-  useInfinitePhotos,
-  type UseInfinitePhotosResult,
-} from '@/features/photo/useInfinitePhotos';
+  usePhotoListAdapter,
+  type UsePhotoListAdapterResult,
+} from '@/features/photo/usePhotoListAdapter';
 import { useAppDispatch, useAppSelector } from '@/app/hook';
 import { setFilter } from '@/features/photo/model/photoSlice';
 import { open } from '@/features/viewer/viewerSlice';
@@ -30,13 +30,19 @@ const PhotoListPage = () => {
   const [searchParams] = useSearchParams();
 
   const {
-    items: photos,
+    photos,
+    counters,
     total,
     fetchNextPage,
     hasNextPage,
     isLoading,
     isFetchingNextPage,
-  }: UseInfinitePhotosResult = useInfinitePhotos(filter);
+  }: UsePhotoListAdapterResult = usePhotoListAdapter(filter);
+
+  const {
+    loaded: loadedCount,
+    flags: { bw: bwCount, adult: adultCount, racy: racyCount },
+  } = counters;
   const navigate = useNavigate();
   const location = useLocation();
   const scrollAreaRef = useRef<HTMLDivElement>(null);
@@ -143,8 +149,16 @@ const PhotoListPage = () => {
       <div className="p-6 border-b flex items-center justify-between">
         <div>
           <h1 className="text-3xl font-bold">{t('photoGalleryTitle')}</h1>
-          <p className="text-muted-foreground mt-2">
-            {photos.length} of {total} photos
+          <p className="text-muted-foreground mt-2 space-x-2 text-sm">
+            <span>
+              {loadedCount} of {total} photos
+            </span>
+            <span aria-hidden="true">•</span>
+            <span>B/W: {bwCount}</span>
+            <span aria-hidden="true">•</span>
+            <span>NSFW: {adultCount}</span>
+            <span aria-hidden="true">•</span>
+            <span>Racy: {racyCount}</span>
           </p>
         </div>
         <Button variant="outline" onClick={handleFilterOpen}>

--- a/frontend/packages/frontend/src/pages/list/PhotoTable.integration.test.tsx
+++ b/frontend/packages/frontend/src/pages/list/PhotoTable.integration.test.tsx
@@ -11,11 +11,11 @@ import metaReducer from '@/features/meta/model/metaSlice';
 import photoReducer from '@/features/photo/model/photoSlice';
 import viewerReducer from '@/features/viewer/viewerSlice';
 import PhotoListPage from './PhotoListPage';
-import { useInfinitePhotos } from '@/features/photo/useInfinitePhotos';
+import { usePhotoListAdapter } from '@/features/photo/usePhotoListAdapter';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { I18nProvider } from '@/app/providers/I18nProvider';
 
-vi.mock('@/features/photo/useInfinitePhotos');
+vi.mock('@/features/photo/usePhotoListAdapter');
 vi.mock('@tanstack/react-virtual', () => ({
   useVirtualizer: vi.fn(),
 }));
@@ -54,8 +54,13 @@ test('renders PhotoTable and fetches next page when scrolled', async () => {
   const photos = createPhotos(10);
   const fetchNextPage = vi.fn();
 
-  (useInfinitePhotos as unknown as Mock).mockReturnValue({
-    items: photos,
+  (usePhotoListAdapter as unknown as Mock).mockReturnValue({
+    photos,
+    counters: {
+      total: 20,
+      loaded: photos.length,
+      flags: { bw: 0, adult: 0, racy: 0 },
+    },
     total: 20,
     fetchNextPage,
     hasNextPage: true,


### PR DESCRIPTION
## Summary
- introduce a `usePhotoListAdapter` hook that wraps `useInfinitePhotos` and derives flag counters alongside the photo list
- switch the photo list page to the adapter and expose the counters in the header UI
- cover the new adapter with a focused unit test and update the existing integration test mocks

## Testing
- pnpm --filter @photobank/frontend exec vitest run usePhotoListAdapter

------
https://chatgpt.com/codex/tasks/task_e_68e69095cee883289a815358a9bd774b