### PR TITLE
Evaluate imageHash index usefulness

### DIFF
--- a/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
+++ b/backend/PhotoBank.DbContext/DbContext/PhotoBankDbContext.cs
@@ -124,6 +124,9 @@ namespace PhotoBank.DbContext.DbContext
             modelBuilder.Entity<Photo>()
                 .HasIndex(p => new { p.StorageId, p.TakenDate });
 
+            modelBuilder.Entity<Photo>()
+                .HasIndex(p => p.ImageHash);
+
             modelBuilder.Entity<Photo>().Property(p => p.TakenMonth)
                 .HasComputedColumnSql(@"(EXTRACT(MONTH FROM (""TakenDate"" AT TIME ZONE 'UTC')))::int", stored: true);
             modelBuilder.Entity<Photo>().Property(p => p.TakenDay)


### PR DESCRIPTION
Added B-tree index on Photo.ImageHash to optimize duplicate photo detection queries.

This will improve performance for:
- DuplicatePhotoStopCondition (exact match, threshold=0)
- API endpoint /Photos/duplicates
- Index-only scans when projecting Id and ImageHash

Expected impact:
- Exact duplicate lookups: O(n) → O(log n)
- Benefit increases with database size (>10k photos)
- Minimal overhead on insert/update operations

Note: Migration needs to be generated separately with: dotnet ef migrations add AddImageHashIndex