### PR TITLE
Align photo storage references with File entity

### DIFF
--- a/backend/PhotoBank.IntegrationTests/ReEnrichmentIntegrationTests.cs
+++ b/backend/PhotoBank.IntegrationTests/ReEnrichmentIntegrationTests.cs
@@ -368,15 +368,13 @@ public class ReEnrichmentIntegrationTests
             var photo = new Photo
             {
                 Name = $"test{i}",
-                RelativePath = "photos",
                 AccentColor = "00000",
                 DominantColorBackground = "black",
                 DominantColorForeground = "black",
                 DominantColors = "black",
                 ImageHash = $"hash-{i}",
-                StorageId = storage.Id,
-                Storage = storage,
-                EnrichedWithEnricherType = EnricherType.None
+                EnrichedWithEnricherType = EnricherType.None,
+                Files = new List<DbContext.Models.File>()
             };
 
             _context.Photos.Add(photo);
@@ -386,8 +384,11 @@ public class ReEnrichmentIntegrationTests
                 Name = "test.jpg",
                 Photo = photo,
                 Storage = storage,
+                StorageId = storage.Id,
                 RelativePath = "photos"
             };
+
+            photo.Files.Add(file);
 
             _context.Files.Add(file);
         }

--- a/backend/PhotoBank.Services/MappingProfile.cs
+++ b/backend/PhotoBank.Services/MappingProfile.cs
@@ -37,12 +37,24 @@ namespace PhotoBank.Services
                 .ForMember(dest => dest.Tags, opt => opt.MapFrom(src => src.PhotoTags))
                 .ForMember(dest => dest.Persons, opt => opt.MapFrom(src => src.Faces))
                 .ForMember(dest => dest.Captions, opt => opt.MapFrom(src => src.Captions))
-                .ForMember(dest => dest.StorageName, opt => opt.MapFrom(src => src.Storage.Name))
+                .ForMember(dest => dest.StorageName,
+                    opt => opt.MapFrom(src => src.Files
+                        .OrderBy(f => f.Id)
+                        .Select(f => f.Storage.Name)
+                        .FirstOrDefault() ?? string.Empty))
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
             CreateMap<Photo, PathDto>()
-                .ForMember(dest => dest.StorageId, opt => opt.MapFrom(src => src.Files.FirstOrDefault().StorageId ?? 0))
-                .ForMember(dest => dest.Path, opt => opt.MapFrom(src => src.Files.FirstOrDefault().RelativePath ?? string.Empty))
+                .ForMember(dest => dest.StorageId,
+                    opt => opt.MapFrom(src => src.Files
+                        .OrderBy(f => f.Id)
+                        .Select(f => f.StorageId)
+                        .FirstOrDefault()))
+                .ForMember(dest => dest.Path,
+                    opt => opt.MapFrom(src => src.Files
+                        .OrderBy(f => f.Id)
+                        .Select(f => f.RelativePath)
+                        .FirstOrDefault() ?? string.Empty))
                 .IgnoreAllPropertiesWithAnInaccessibleSetter();
 
             CreateMap<Person, PersonDto>()

--- a/backend/PhotoBank.Services/PhotoDeletionService.cs
+++ b/backend/PhotoBank.Services/PhotoDeletionService.cs
@@ -139,7 +139,6 @@ public class PhotoDeletionService : IPhotoDeletionService
     {
         return await _context.Photos
             .AsTracking()
-            .Include(p => p.Storage)
             .Include(p => p.Files)
                 .ThenInclude(f => f.Storage)  // Load Storage for each File (cross-storage support)
             .Include(p => p.Captions)

--- a/backend/PhotoBank.Services/Search/PhotoFilterSpecification.cs
+++ b/backend/PhotoBank.Services/Search/PhotoFilterSpecification.cs
@@ -62,7 +62,7 @@ public class PhotoFilterSpecification
         {
             var storages = filter.Storages.ToList();
             // Filter by Files.StorageId for cross-storage duplicate support
-            query = query.Where(p => p.Files.Any(f => storages.Contains(f.StorageId ?? 0)));
+            query = query.Where(p => p.Files.Any(f => storages.Contains(f.StorageId)));
 
             if (!string.IsNullOrEmpty(filter.RelativePath))
             {

--- a/backend/PhotoBank.Services/Search/SearchReferenceDataService.cs
+++ b/backend/PhotoBank.Services/Search/SearchReferenceDataService.cs
@@ -239,7 +239,7 @@ public sealed class SearchReferenceDataService : ISearchReferenceDataService
                 return (IReadOnlyList<PathDto>)paths
                     .Select(f => new PathDto
                     {
-                        StorageId = f.StorageId ?? 0,
+                        StorageId = f.StorageId,
                         Path = f.RelativePath!,
                     })
                     .ToList();

--- a/backend/PhotoBank.UnitTests/Enrichers/DuplicateEnricherTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichers/DuplicateEnricherTests.cs
@@ -88,11 +88,12 @@ public class DuplicateEnricherTests
         _dbContext.Storages.Add(storage);
         await _dbContext.SaveChangesAsync();
 
-        var photo = new Photo { Storage = storage };
+        var photo = new Photo();
         var sourceData = new SourceDataDto
         {
             AbsolutePath = _tempImagePath,
-            PreviewImage = new MagickImage(MagickColors.Blue, 50, 50)
+            PreviewImage = new MagickImage(MagickColors.Blue, 50, 50),
+            Storage = storage
         };
 
         // Act
@@ -119,11 +120,12 @@ public class DuplicateEnricherTests
         _dbContext.Storages.Add(storage);
         await _dbContext.SaveChangesAsync();
 
-        var photo = new Photo { Storage = storage };
+        var photo = new Photo();
         var sourceData = new SourceDataDto
         {
             AbsolutePath = testFile,
-            PreviewImage = new MagickImage(MagickColors.Blue, 50, 50)
+            PreviewImage = new MagickImage(MagickColors.Blue, 50, 50),
+            Storage = storage
         };
 
         try
@@ -159,11 +161,12 @@ public class DuplicateEnricherTests
         _dbContext.Storages.Add(storage);
         await _dbContext.SaveChangesAsync();
 
-        var photo = new Photo { Storage = storage };
+        var photo = new Photo();
         var sourceData = new SourceDataDto
         {
             AbsolutePath = _tempImagePath,
-            PreviewImage = new MagickImage(MagickColors.Blue, 50, 50)
+            PreviewImage = new MagickImage(MagickColors.Blue, 50, 50),
+            Storage = storage
         };
 
         // Act
@@ -186,11 +189,12 @@ public class DuplicateEnricherTests
         _dbContext.Storages.Add(storage);
         await _dbContext.SaveChangesAsync();
 
-        var photo = new Photo { Storage = storage };
+        var photo = new Photo();
         var sourceData = new SourceDataDto
         {
             AbsolutePath = _tempImagePath,
-            PreviewImage = new MagickImage(MagickColors.Blue, 50, 50)
+            PreviewImage = new MagickImage(MagickColors.Blue, 50, 50),
+            Storage = storage
         };
 
         // Act
@@ -214,23 +218,23 @@ public class DuplicateEnricherTests
         var existingPhoto = new Photo
         {
             ImageHash = "abc123",
-            Storage = existingStorage,
             Files = new List<File>
             {
-                new File { StorageId = existingStorage.Id, RelativePath = "photos/2024", Name = "existing.jpg" }
+                new File { StorageId = existingStorage.Id, Storage = existingStorage, RelativePath = "photos/2024", Name = "existing.jpg" }
             }
         };
         _dbContext.Photos.Add(existingPhoto);
         await _dbContext.SaveChangesAsync();
 
-        var photo = new Photo { Storage = storage };
+        var photo = new Photo();
 
         // Create image that will produce the same hash
         using var previewImage = new MagickImage(MagickColors.Blue, 50, 50);
         var sourceData = new SourceDataDto
         {
             AbsolutePath = _tempImagePath,
-            PreviewImage = previewImage
+            PreviewImage = previewImage,
+            Storage = storage
         };
 
         // Compute hash and update existing photo to match
@@ -256,11 +260,12 @@ public class DuplicateEnricherTests
         _dbContext.Storages.Add(storage);
         await _dbContext.SaveChangesAsync();
 
-        var photo = new Photo { Storage = storage };
+        var photo = new Photo();
         var sourceData = new SourceDataDto
         {
             AbsolutePath = _tempImagePath,
-            PreviewImage = null  // No preview image
+            PreviewImage = null,  // No preview image
+            Storage = storage
         };
 
         // Act

--- a/backend/PhotoBank.UnitTests/Enrichers/MetadataEnricherTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichers/MetadataEnricherTests.cs
@@ -28,8 +28,25 @@ namespace PhotoBank.UnitTests.Enrichers
             _mockImageMetadataReaderWrapper = new Mock<IImageMetadataReaderWrapper>();
             _metadataEnricher = new MetadataEnricher(_mockImageMetadataReaderWrapper.Object);
 
-            _photo = new Photo { Storage = new Storage { Folder = "c:\\storageFolder" } };
-            _sourceData = new SourceDataDto { AbsolutePath = "c:\\storageFolder\\folder\\photo.jpg" };
+            var storage = new Storage { Folder = "c:\\storageFolder" };
+            _photo = new Photo
+            {
+                Files = new List<File>
+                {
+                    new()
+                    {
+                        Storage = storage,
+                        StorageId = storage.Id,
+                        RelativePath = "folder",
+                        Name = "photo.jpg"
+                    }
+                }
+            };
+            _sourceData = new SourceDataDto
+            {
+                AbsolutePath = "c:\\storageFolder\\folder\\photo.jpg",
+                Storage = storage
+            };
         }
 
         [Test]

--- a/backend/PhotoBank.UnitTests/Enrichment/ReEnrichmentServiceTests.cs
+++ b/backend/PhotoBank.UnitTests/Enrichment/ReEnrichmentServiceTests.cs
@@ -741,9 +741,6 @@ public class ReEnrichmentServiceTests
         {
             Id = id,
             Name = "test",
-            RelativePath = "photos",
-            StorageId = storage.Id,
-            Storage = storage,
             Files = new List<DbContext.Models.File>
             {
                 new()

--- a/backend/PhotoBank.UnitTests/FaceServiceAwsTests.cs
+++ b/backend/PhotoBank.UnitTests/FaceServiceAwsTests.cs
@@ -313,8 +313,6 @@ public class FaceServiceAwsTests
         var photo = new DbPhoto
         {
             Id = 2000 + faceId,
-            StorageId = storage.Id,
-            Storage = storage,
             Name = $"photo-{faceId}",
             AccentColor = "ffffff",
             DominantColorBackground = "bg",
@@ -331,9 +329,17 @@ public class FaceServiceAwsTests
             PhotoCategories = new List<DbPhotoCategory>(),
             ObjectProperties = new List<DbObjectProperty>(),
             Faces = new List<DbFace>(),
-            Files = new List<DbFile>(),
-            ImageHash = $"hash-{faceId}",
-            RelativePath = $"path-{faceId}"
+            Files = new List<DbFile>
+            {
+                new()
+                {
+                    StorageId = storage.Id,
+                    Storage = storage,
+                    RelativePath = $"path-{faceId}",
+                    Name = $"photo-{faceId}.jpg"
+                }
+            },
+            ImageHash = $"hash-{faceId}"
         };
 
         storage.Photos = new List<DbPhoto> { photo };

--- a/backend/PhotoBank.UnitTests/FaceServiceIdentifyTests.cs
+++ b/backend/PhotoBank.UnitTests/FaceServiceIdentifyTests.cs
@@ -22,6 +22,7 @@ using PhotoBank.Services;
 using DbFace = PhotoBank.DbContext.Models.Face;
 using DbPerson = PhotoBank.DbContext.Models.Person;
 using DbPhoto = PhotoBank.DbContext.Models.Photo;
+using DbFile = PhotoBank.DbContext.Models.File;
 using DbStorage = PhotoBank.DbContext.Models.Storage;
 using IdentityStatus = PhotoBank.DbContext.Models.IdentityStatus;
 using PhotoBank.UnitTests.Infrastructure.Minio;
@@ -175,8 +176,6 @@ public class FaceServiceIdentifyTests
         {
             Id = photoId,
             Name = $"photo-{photoId}",
-            StorageId = storageId,
-            Storage = storage,
             TakenDate = takenDate,
             AccentColor = string.Empty,
             DominantColorBackground = string.Empty,
@@ -189,7 +188,16 @@ public class FaceServiceIdentifyTests
             S3ETag_Thumbnail = string.Empty,
             Sha256_Thumbnail = string.Empty,
             ImageHash = string.Empty,
-            RelativePath = string.Empty
+            Files = new List<DbFile>
+            {
+                new()
+                {
+                    StorageId = storage.Id,
+                    Storage = storage,
+                    RelativePath = string.Empty,
+                    Name = $"photo-{photoId}.jpg"
+                }
+            }
         };
 
         var face = new DbFace

--- a/backend/PhotoBank.UnitTests/Handlers/PhotoCreatedHandlerTests.cs
+++ b/backend/PhotoBank.UnitTests/Handlers/PhotoCreatedHandlerTests.cs
@@ -200,9 +200,6 @@ public class PhotoCreatedHandlerTests
         var photo = new Photo
         {
             Id = PhotoId,
-            StorageId = storage.Id,
-            Storage = storage,
-            RelativePath = "album",
             Name = "photo",
             AccentColor = string.Empty,
             DominantColorBackground = string.Empty,
@@ -220,7 +217,16 @@ public class PhotoCreatedHandlerTests
             PhotoCategories = new List<PhotoCategory>(),
             ObjectProperties = new List<ObjectProperty>(),
             Faces = new List<Face>(),
-            Files = new List<PhotoBank.DbContext.Models.File>()
+            Files = new List<PhotoBank.DbContext.Models.File>
+            {
+                new()
+                {
+                    StorageId = storage.Id,
+                    Storage = storage,
+                    RelativePath = "album",
+                    Name = "photo.jpg"
+                }
+            }
         };
         storage.Photos.Add(photo);
 

--- a/backend/PhotoBank.UnitTests/Search/PhotoFilterSpecificationTests.cs
+++ b/backend/PhotoBank.UnitTests/Search/PhotoFilterSpecificationTests.cs
@@ -289,8 +289,6 @@ public class PhotoFilterSpecificationTests
         var photo = new Photo
         {
             Id = id,
-            Storage = storage,
-            StorageId = storage.Id,
             Name = name,
             TakenDate = takenDate,
             AccentColor = string.Empty,
@@ -298,7 +296,6 @@ public class PhotoFilterSpecificationTests
             DominantColorForeground = string.Empty,
             DominantColors = string.Empty,
             ImageHash = string.Empty,
-            RelativePath = string.Empty,
             S3Key_Preview = string.Empty,
             S3ETag_Preview = string.Empty,
             Sha256_Preview = string.Empty,

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetFacesPageAsyncTests.cs
@@ -65,8 +65,6 @@ public class PhotoServiceGetFacesPageAsyncTests
         var photo = new Photo
         {
             Name = "photo.jpg",
-            Storage = storage,
-            StorageId = storage.Id,
             AccentColor = "000000",
             DominantColorBackground = "000000",
             DominantColorForeground = "000000",
@@ -78,12 +76,21 @@ public class PhotoServiceGetFacesPageAsyncTests
             S3ETag_Thumbnail = "etag-thumbnail",
             Sha256_Thumbnail = "sha-thumbnail",
             ImageHash = "hash",
-            RelativePath = "faces",
             Captions = new List<Caption>(),
             PhotoTags = new List<PhotoTag>(),
             PhotoCategories = new List<PhotoCategory>(),
             ObjectProperties = new List<ObjectProperty>(),
-            Faces = new List<Face>()
+            Faces = new List<Face>(),
+            Files = new List<File>
+            {
+                new()
+                {
+                    StorageId = storage.Id,
+                    Storage = storage,
+                    RelativePath = "faces",
+                    Name = "photo.jpg"
+                }
+            }
         };
         context.Photos.Add(photo);
         await context.SaveChangesAsync();

--- a/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
+++ b/backend/PhotoBank.UnitTests/Services/PhotoServiceGetPhotoAsyncTests.cs
@@ -64,8 +64,6 @@ namespace PhotoBank.UnitTests.Services
             var photo = new Photo
             {
                 Name = "photo",
-                Storage = storage,
-                StorageId = storage.Id,
                 S3Key_Preview = "preview",
                 S3ETag_Preview = "preview-etag",
                 Sha256_Preview = "preview-hash",
@@ -81,11 +79,19 @@ namespace PhotoBank.UnitTests.Services
                 PhotoTags = new List<PhotoTag>(),
                 PhotoCategories = new List<PhotoCategory>(),
                 ObjectProperties = new List<ObjectProperty>(),
-                Files = new List<File>(),
+                Files = new List<File>
+                {
+                    new()
+                    {
+                        StorageId = storage.Id,
+                        Storage = storage,
+                        RelativePath = "path",
+                        Name = "photo.jpg"
+                    }
+                },
                 TakenDate = DateTime.UtcNow,
                 IsAdultContent = false,
                 IsRacyContent = false,
-                RelativePath = "path",
                 ImageHash = "hash"
             };
             context.Photos.Add(photo);


### PR DESCRIPTION
## Summary
- update services to derive storage data from photo files after moving storage info to File
- adjust mapping and queries to use file-level storage and relative paths
- refresh unit and integration tests to construct photos with file-backed storage paths

## Testing
- dotnet build /consoleloggerparameters:DisableConsoleColor

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693096eefb4083288c5528eb12b3788d)