### PR TITLE
docs: refresh enricher dependency diagram and update backend CLAUDE.md

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -119,9 +119,10 @@ The photo enrichment system is the core of PhotoBank's processing:
 **Key Enrichers:**
 - `MetadataEnricher` - Extracts EXIF data (date, GPS, camera info)
 - `PreviewEnricher` - Generates preview images
+- `DuplicateEnricher` - Computes image hash, initializes file metadata, detects duplicates
 - `ThumbnailEnricher` - Generates thumbnails
 - `UnifiedFaceEnricher` - Detects faces using configured provider (InsightFace/Azure/AWS)
-- `UnifiedObjectPropertyEnricher` - Detects objects using YOLO ONNX models
+- `UnifiedObjectPropertyEnricher` - Detects objects using Azure or YOLO ONNX providers
 - `AdultEnricher` - Detects adult/racy content using NudeNet ONNX
 - `CaptionEnricher` - Generates captions using image analysis (OpenRouter/Ollama)
 - `ColorEnricher` - Analyzes dominant colors
@@ -129,9 +130,11 @@ The photo enrichment system is the core of PhotoBank's processing:
 
 **Enricher Dependencies:**
 Enrichers declare dependencies to ensure proper execution order. For example:
-- Face/object detection depends on metadata extraction
-- Caption generation depends on face/object detection
-- All enrichers that need images depend on Preview/Thumbnail enrichers
+- `DuplicateEnricher` depends on `PreviewEnricher` (hash/preview-based prep)
+- `AdultEnricher`, `MetadataEnricher`, `ThumbnailEnricher`, `UnifiedFaceEnricher` depend on `DuplicateEnricher`
+- `AnalyzeEnricher` depends on `AdultEnricher`
+- `CaptionEnricher`, `ColorEnricher`, `CategoryEnricher`, `TagEnricher` depend on `AnalyzeEnricher`
+- `UnifiedObjectPropertyEnricher` depends on `AnalyzeEnricher` (Azure) or `DuplicateEnricher` (YOLO ONNX)
 
 **Re-enrichment:**
 The `IReEnrichmentService` allows re-running enrichers on already-processed photos:

--- a/docs/enricher-dependency-diagram.md
+++ b/docs/enricher-dependency-diagram.md
@@ -7,31 +7,27 @@ graph TD
     %% Корневой энричер
     Preview[PreviewEnricher<br/>🖼️ Создание превью]
 
-    %% Энричеры первого уровня
-    Preview --> Adult[AdultEnricher<br/>🔞 Adult контент ONNX]
-    Preview --> Metadata[MetadataEnricher<br/>📋 EXIF данные]
-    Preview --> Thumbnail[ThumbnailEnricher<br/>🔲 Миниатюра]
+    %% Подготовка и проверка дубликатов
+    Preview --> Duplicate[DuplicateEnricher<br/>🔁 Дубликаты + файлы]
 
-    %% Энричеры второго уровня (зависят от Adult)
-    Adult --> Analyze[AnalyzeEnricher<br/>🔍 Azure Vision API]
+    %% Энричеры базового уровня
+    Duplicate --> Adult[AdultEnricher<br/>🔞 Adult контент ONNX]
+    Duplicate --> Metadata[MetadataEnricher<br/>📋 EXIF данные]
+    Duplicate --> Thumbnail[ThumbnailEnricher<br/>🔲 Миниатюра]
+    Duplicate --> UnifiedFace[UnifiedFaceEnricher<br/>👤 Лица unified]
 
-    %% Энричеры третьего уровня (зависят от Analyze)
+    %% Энричеры анализа
+    Adult --> Analyze[AnalyzeEnricher<br/>🔍 Анализ изображения]
+
+    %% Энричеры детального анализа
     Analyze --> Color[ColorEnricher<br/>🎨 Цвета]
     Analyze --> Caption[CaptionEnricher<br/>💬 Описание]
     Analyze --> Tag[TagEnricher<br/>🏷️ Теги]
     Analyze --> Category[CategoryEnricher<br/>📁 Категории]
-    Analyze --> Object[ObjectPropertyEnricher<br/>📦 Объекты]
 
-    %% Энричер с двойной зависимостью
-    Preview --> UnifiedFace[UnifiedFaceEnricher<br/>👤 Лица unified]
-    Metadata --> UnifiedFace
-
-    %% Устаревшие энричеры
-    Preview -.-> FaceOld[FaceEnricher<br/>👤 Лица Azure<br/>⚠️ DEPRECATED]
-    Metadata -.-> FaceOld
-
-    Preview -.-> FaceAws[FaceEnricherAws<br/>👤 Лица AWS<br/>⚠️ DEPRECATED]
-    Metadata -.-> FaceAws
+    %% Унифицированный энричер объектов (зависимость зависит от провайдера)
+    Analyze -.-> UnifiedObject[UnifiedObjectPropertyEnricher<br/>📦 Объекты unified]
+    Duplicate -.-> UnifiedObject
 
     %% Стили
     classDef root fill:#4CAF50,stroke:#2E7D32,color:#fff
@@ -39,15 +35,17 @@ graph TD
     classDef level2 fill:#FF9800,stroke:#E65100,color:#fff
     classDef level3 fill:#FFB74D,stroke:#E65100,color:#fff
     classDef unified fill:#9C27B0,stroke:#6A1B9A,color:#fff
-    classDef deprecated fill:#757575,stroke:#424242,color:#fff,stroke-dasharray: 5 5
 
     class Preview root
-    class Metadata,Thumbnail,Adult level1
+    class Duplicate,Metadata,Thumbnail,Adult level1
     class Analyze level2
-    class Color,Caption,Tag,Category,Object level3
-    class UnifiedFace unified
-    class FaceOld,FaceAws deprecated
+    class Color,Caption,Tag,Category level3
+    class UnifiedFace,UnifiedObject unified
 ```
+
+> Примечание: `UnifiedObjectPropertyEnricher` зависит от провайдера —
+> - **Azure**: зависит от `AnalyzeEnricher` (использует ImageAnalysis)
+> - **YOLO ONNX**: зависит от `DuplicateEnricher` (использует PreviewImage)
 
 ## Уровни зависимостей
 
@@ -55,26 +53,37 @@ graph TD
 - **PreviewEnricher** - создает preview изображения из оригинального файла
   - Зависимостей: нет
   - Сервисы: `IImageService` (ImageMagick)
+  - Дополнительно: формирует letterbox 640x640 для ONNX моделей
 
-### 🔵 Уровень 1 - Базовая подготовка
-- **AdultEnricher** - проверяет на adult/racy контент с помощью ONNX модели
+### 🔵 Уровень 1 - Подготовка и базовая обработка
+- **DuplicateEnricher** - проверяет дубликаты и подготавливает базовые поля
   - Зависимости: `PreviewEnricher`
+  - Сервисы: `IRepository<Photo>`
+  - Данные: ImageHash, Name, RelativePath, Files, DuplicatePhotoId
+
+- **AdultEnricher** - проверяет на adult/racy контент с помощью ONNX модели
+  - Зависимости: `DuplicateEnricher`
   - Сервисы: `INudeNetDetector` (Local ONNX NudeNet YOLOv8)
   - Данные: AdultScore, RacyScore, IsAdultContent, IsRacyContent
 
 - **MetadataEnricher** - извлекает EXIF метаданные из файла
-  - Зависимости: `PreviewEnricher`
+  - Зависимости: `DuplicateEnricher`
   - Сервисы: `IImageMetadataReaderWrapper` (MetadataExtractor)
   - Извлекает: Дата съемки, GPS, Camera info
 
 - **ThumbnailEnricher** - генерирует миниатюру 50x50px
-  - Зависимости: `PreviewEnricher`
-  - Сервисы: `IComputerVisionClient` (Azure)
+  - Зависимости: `DuplicateEnricher`
+  - Сервисы: Smartcrop + ImageMagick
+
+- **UnifiedFaceEnricher** ✅ - универсальный детектор лиц
+  - Зависимости: `DuplicateEnricher`
+  - Сервисы: `IUnifiedFaceService` (Azure/AWS/Local провайдеры)
+  - Функции: Определение лиц, возраст, пол, эмоции, создание preview лиц
 
 ### 🟠 Уровень 2 - Анализ содержимого
-- **AnalyzeEnricher** - анализирует изображение через Azure Computer Vision API
+- **AnalyzeEnricher** - анализирует изображение через `IImageAnalyzer`
   - Зависимости: `AdultEnricher`
-  - Сервисы: `IComputerVisionClient` (Azure)
+  - Сервисы: `IImageAnalyzer` (Azure/OpenRouter/Ollama и др.)
   - Извлекает: Categories, Description, Tags, Objects, Colors, Adult content
 
 ### 🟠 Уровень 3 - Детализация анализа
@@ -94,24 +103,13 @@ graph TD
   - Базовый класс: `BaseLookupEnricher<Category, PhotoCategory>`
   - База данных: `IRepository<Category>`
 
-- **ObjectPropertyEnricher** - создает/связывает обнаруженные объекты
-  - Базовый класс: `BaseLookupEnricher<PropertyName, ObjectProperty>`
+### 🟣 Уровень 1/2 - Унифицированные объекты
+- **UnifiedObjectPropertyEnricher** - детекция объектов через провайдер
+  - Зависимости:
+    - Azure: `AnalyzeEnricher`
+    - YOLO ONNX: `DuplicateEnricher`
+  - Сервисы: `IObjectDetectionProvider`
   - База данных: `IRepository<PropertyName>`
-
-### 🟣 Уровень 1+2 - Комбинированные зависимости
-- **UnifiedFaceEnricher** ✅ - универсальный детектор лиц
-  - Зависимости: `PreviewEnricher` + `MetadataEnricher`
-  - Сервисы: `IUnifiedFaceService` (поддержка Azure/AWS/Local провайдеров)
-  - Функции: Определение лиц, возраст, пол, эмоции, создание preview лиц
-
-### ⚠️ Устаревшие энричеры (DEPRECATED)
-- **FaceEnricher** - только Azure Face API
-  - Зависимости: `PreviewEnricher` + `MetadataEnricher`
-  - Статус: `[Obsolete("Use UnifiedFaceEnricher instead")]`
-
-- **FaceEnricherAws** - только AWS Rekognition
-  - Зависимости: `PreviewEnricher` + `MetadataEnricher`
-  - Статус: `[Obsolete("Use UnifiedFaceEnricher instead")]`
 
 ## Базовые классы
 
@@ -142,7 +140,6 @@ classDiagram
 
     TagEnricher --|> BaseLookupEnricher
     CategoryEnricher --|> BaseLookupEnricher
-    ObjectPropertyEnricher --|> BaseLookupEnricher
 
     class TagEnricher {
         +EnricherType: Tag
@@ -151,10 +148,6 @@ classDiagram
     class CategoryEnricher {
         +EnricherType: Category
     }
-
-    class ObjectPropertyEnricher {
-        +EnricherType: ObjectProperty
-    }
 ```
 
 ## Порядок выполнения
@@ -162,27 +155,28 @@ classDiagram
 Enrichment Pipeline использует топологическую сортировку для определения порядка выполнения:
 
 1. **PreviewEnricher** (корневой)
-2. **Параллельно:**
+2. **DuplicateEnricher**
+3. **Параллельно (после DuplicateEnricher):**
    - AdultEnricher (ONNX)
    - MetadataEnricher
    - ThumbnailEnricher
-3. **После AdultEnricher:**
+   - UnifiedFaceEnricher
+   - UnifiedObjectPropertyEnricher (если провайдер YOLO ONNX)
+4. **После AdultEnricher:**
    - AnalyzeEnricher
-4. **После AnalyzeEnricher (параллельно):**
+5. **После AnalyzeEnricher (параллельно):**
    - ColorEnricher
    - CaptionEnricher
    - TagEnricher
    - CategoryEnricher
-   - ObjectPropertyEnricher
-5. **После PreviewEnricher + MetadataEnricher:**
-   - UnifiedFaceEnricher
+   - UnifiedObjectPropertyEnricher (если провайдер Azure)
 
 ## Статистика
 
-- **Всего энричеров:** 11 (9 активных + 2 устаревших)
-- **Уровней зависимостей:** 3
-- **Внешних сервисов:** 4 (Azure Vision, Azure Face, AWS Rekognition, MetadataExtractor)
-- **Репозиториев БД:** 3 (Tag, Category, PropertyName)
+- **Всего энричеров:** 12
+- **Уровней зависимостей:** 4
+- **Внешних сервисов:** 5 (ImageMagick, MetadataExtractor, Smartcrop, ONNX, ImageAnalyzer)
+- **Репозиториев БД:** 4 (Photo, Tag, Category, PropertyName)
 - **Поддержка параллелизма:** Да (`RunBatchAsync`)
 
 ## Компоненты оркестрации


### PR DESCRIPTION
### Motivation
- The enrichment pipeline documentation was out of sync with code changes around duplicate handling and object detection providers. 
- The `DuplicateEnricher` is now an explicit step that prepares file metadata and image hash, and docs should reflect its role. 
- `UnifiedObjectPropertyEnricher` behavior depends on provider (Azure vs YOLO ONNX) and needed clearer description. 
- Update counts and external service list to match current implementation.

### Description
- Updated `docs/enricher-dependency-diagram.md` to add `DuplicateEnricher`, adjust the mermaid graph, reorder levels, and reflect provider-dependent object enricher dependencies. 
- Updated `backend/CLAUDE.md` to mention `DuplicateEnricher`, clarify enricher dependency ordering, and note that `UnifiedObjectPropertyEnricher` can depend on Azure (`AnalyzeEnricher`) or YOLO ONNX (`DuplicateEnricher`). 
- Adjusted statistics in docs (enricher count, dependency levels, external services, DB repositories) to match current code. 
- This PR is docs-only and does not modify runtime code outside documentation files `docs/enricher-dependency-diagram.md` and `backend/CLAUDE.md`.

### Testing
- No automated tests were run because this is a documentation-only change. 
- To validate the codebase generally, run unit and integration tests with `dotnet test`. 
- Repository-level test commands are available as `pnpm -w test` for workspace and `dotnet test` for backend projects. 
- Manual review: mermaid diagram and CLAUDE guidance were updated to reflect the current enricher implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c03aaf6c832894997b7a38179cea)